### PR TITLE
feat: update schema for possibly null data from ballchasing

### DIFF
--- a/common/src/celery/celery.service.ts
+++ b/common/src/celery/celery.service.ts
@@ -102,14 +102,7 @@ export class CeleryService {
     }
 
     parseResult<T extends Task>(task: T, result: unknown): TaskResult<T> {
-        const parseResult = TaskSchemas[task].result.safeParse(result);
-        if (parseResult.success) {
-            return parseResult.data;
-        }
-        this.logger.warn(`Task ${task} result failed schema validation, ${parseResult.error}`);
-        // TODO have better error handling on results that don't match the schema
-        return result as TaskResult<T>;
-
+        return TaskSchemas[task].result.parse(result);
     }
 
     /**

--- a/common/src/celery/types/schemas/stats/ballchasing/ballchasing.schema.ts
+++ b/common/src/celery/types/schemas/stats/ballchasing/ballchasing.schema.ts
@@ -27,7 +27,7 @@ export const BallchasingResponseSchema = z.object({
     match_guid: z.string(),
 
     // Uploader
-    recorder: z.string(),
+    recorder: z.string().optional(),
     uploader: BallchasingUploaderSchema,
     
     // Match
@@ -39,7 +39,7 @@ export const BallchasingResponseSchema = z.object({
     
     // Map
     map_code: z.string(), // TODO enum for maps
-    map_name: z.string(),
+    map_name: z.string().default("UNKNOWN"),
     
     // Duration
     duration: z.number(),


### PR DESCRIPTION
The zod schema for replay responses from Ballchasing was being used in `safeParse` mode, which returns a boolean for an error condition rather than throwing. However, on failure, we were simply returning the original object, thus bypassing the zod schema check. 