### PR TITLE
chore: move configs

### DIFF
--- a/clients/image-generation-frontend/.gitignore
+++ b/clients/image-generation-frontend/.gitignore
@@ -7,3 +7,4 @@ node_modules
 
 src/config.json
 src/ca-certificate.cer
+secret/

--- a/clients/image-generation-frontend/Dockerfile
+++ b/clients/image-generation-frontend/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE AS test_image
-ENTRYPOINT npm run test --workspace=clients/web
+ENTRYPOINT npm run test --workspace=clients/image-generation-frontend
 
 FROM $BASE_IMAGE AS app_image
-RUN cp ./clients/web/src/config.template.json ./clients/web/src/config.json
+RUN cp ./clients/image-generation-frontend/src/config.template.json ./clients/image-generation-frontend/src/config.json
 RUN npm run build --workspace=clients/image-generation-frontend
 ENTRYPOINT node /app/clients/image-generation-frontend/build/index.js

--- a/clients/image-generation-frontend/src/config.template.json
+++ b/clients/image-generation-frontend/src/config.template.json
@@ -1,18 +1,17 @@
 {
-    "minio": {
+    "minio":{
+        "endpoint":"",
+        "port": 0,
+        "ssl": true,
         "access": "",
-        "secret": "",
-        "endpoint": "",
-        "bucket": "",
-        "ssl": true     
-    },
+        "bucket": "sprocket-image-gen-dev"
+      },
     "knex":{
         "host": "",
         "port":0,
         "user": "",
         "database": "",
         "enable_logs": false,
-        "password": "",
         "ssl":{ "rejectUnauthorized": false }
       },
     "transport": {

--- a/clients/image-generation-frontend/src/config.ts
+++ b/clients/image-generation-frontend/src/config.ts
@@ -1,3 +1,8 @@
 import {readFileSync} from "fs";
 
-export default JSON.parse(readFileSync("./src/config.json").toString());
+const config = JSON.parse(readFileSync("./src/config.json").toString());
+config.minio.access = readFileSync("./secret/minio-access.txt").toString()
+config.minio.secret = readFileSync("./secret/minio-secret.txt").toString()
+config.knex.password = readFileSync("./secret/db-secret.txt").toString()
+
+export default config;


### PR DESCRIPTION
Fixes config setting for image-generation-frontend so that we can properly inject them into docker.

Also pulls the config file in from the right project