### PR TITLE
Revert "chore(deps): bump numpy from 1.18.2 to 1.22.0 in /microservices/replay-parse-service"

### DIFF
--- a/microservices/replay-parse-service/requirements.txt
+++ b/microservices/replay-parse-service/requirements.txt
@@ -13,7 +13,7 @@ Deprecated==1.2.13
 idna==3.3
 kombu==5.2.3
 minio==7.1.3
-numpy==1.22.0
+numpy==1.18.2
 packaging==21.3
 pandas==1.0.3
 prompt-toolkit==3.0.28


### PR DESCRIPTION
Reverts SprocketBot/sprocket#146