### PR TITLE
fix: monospace lobby info to distinguish O and 0

### DIFF
--- a/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/InProgressView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/InProgressView.svelte
@@ -29,9 +29,9 @@
                 <dt>Game Mode</dt>
                 <dd>{scrim.settings.competitive ? "Competitive" : "Casual"} {screamingSnakeToHuman(scrim.settings.mode)} {scrim.gameMode.description}</dd>
                 <dt>Name</dt>
-                <dd>{scrim.lobby.name}</dd>
+                <dd><code>{scrim.lobby.name}</code></dd>
                 <dt>Password</dt>
-                <dd>{scrim.lobby.password}</dd>
+                <dd><code>{scrim.lobby.password}</code></dd>
             </dl>
         </div>
     </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31896377/190032489-efee2e3a-975a-4506-93ff-16219447ef67.png)
