### PR TITLE
fix: use name from commandSpec

### DIFF
--- a/clients/discord-bot/src/marshal/commands/command.decorator.ts
+++ b/clients/discord-bot/src/marshal/commands/command.decorator.ts
@@ -73,7 +73,7 @@ export const Command = (commandSpec: CommandSpec): MethodDecorator => <T>(target
                     ["author", message.author.tag],
                     ["guild", message.channel instanceof TextChannel ? message.channel.guild.name : "DMs"],
                     ["channel", message.channel instanceof TextChannel ? message.channel.name : "DMs"],
-                    ["command_name", message.content.split(" ")[0]],
+                    ["command_name", commandSpec.name],
                 ],
                 floats: [
                     ["duration", performance.now() - before],


### PR DESCRIPTION
Use `name` from command decorator so that it doesn't make a difference if a user calls the command with different capitalization