### PR TITLE
Implement refresh tokens for authentication

### DIFF
--- a/clients/web/src/hooks.ts
+++ b/clients/web/src/hooks.ts
@@ -2,23 +2,83 @@ import type {GetSession, Handle} from "@sveltejs/kit";
 import {constants, loadConfig} from "$lib/utils";
 
 export const handle: Handle = async ({event, resolve}) => {
+    let newCookiesString: string = "";
     if (event.request.headers.has("cookie")) {
         try {
-            const cookies = event.request.headers.get("cookie");
-            if (cookies) {
-                const rawToken = cookies.split("; ").find(c => c.split("=")[0] === constants.auth_cookie_key)
+            const config = await loadConfig();
+            const currentCookies = event.request.headers.get("cookie");
+            if (currentCookies) {
+                const rawToken = currentCookies.split("; ").find(c => c.split("=")[0] === constants.auth_cookie_key)
                     ?.split("=")[1];
                 if (rawToken) {
+                    // Get the meat out of the JWT (the middle third, separated
+                    // by ".")
                     const token = JSON.parse(atob(rawToken.split(".")[1]));
 
+                    // Check if JWT has expired
                     const now = new Date();
                     const exp = new Date(token.exp * 1000);
                     const remaining = exp.getTime() - now.getTime();
 
                     if (remaining < 0) {
-                        // TODO: Attempt refresh token logic here
-                        event.request.headers.delete("cookie");
+                        // If so, refresh it
+                        // Get the refresh token out of user's cookies
+                        const refreshToken = currentCookies.split("; ").find(c => c.split("=")[0] === constants.refresh_token_cookie_key)
+                            ?.split("=")[1];
+                        if (refreshToken) {
+                            // Send that refresh token to the backend, asking
+                            // for a new JWT
+                            const res = await fetch(`http://${config.client.gqlUrl}/refresh`, {
+                                method: "GET",
+                                headers: {
+                                    "Authorization": `Bearer ${refreshToken}`,
+                                },
+                            });
+
+                            // Pull the new tokens out of the response
+                            const tokens = await res.json();
+                            const access_token = tokens.access_token;
+                            const new_refresh_token = tokens.refresh_token;
+
+                            // Store these new tokens back in the user's cookies
+                            const newCookies = currentCookies.split("; ");
+
+                            // Access token cookie
+                            const newCookies1 = newCookies.map(c => {
+                                if (c.split("=")[0] === constants.auth_cookie_key) {
+                                    const timeNow = new Date();
+                                    const time = now.getTime();
+                                    const oneWeek = 1000 * 60 * 30;
+                                    const expiry = time + oneWeek;
+                                    timeNow.setTime(expiry);
+                                    return `${constants.auth_cookie_key}=${access_token};expires=${timeNow.toUTCString()}`;
+                                }
+                                return c;
+                            });
+                            // Refresh token cookie
+                            const newCookies2 = newCookies1.map(c => {
+                                if (c.split("=")[0] === constants.refresh_token_cookie_key) {
+                                    const timeNow = new Date();
+                                    const time = now.getTime();
+                                    const oneWeek = 1000 * 60 * 60 * 24 * 7;
+                                    const expiry = time + oneWeek;
+                                    timeNow.setTime(expiry);
+                                    return `${constants.refresh_token_cookie_key}=${new_refresh_token};expires=${timeNow.toUTCString()}`;
+                                }
+                                return c;
+                            });
+
+                            // Roll our cookies back up into one string
+                            newCookiesString = newCookies2.join("; ");
+                            event.request.headers.set("cookie", newCookiesString);
+
+                            // Refresh the session as well
+                            event.locals.user = JSON.parse(atob(access_token.split(".")[1]));
+                            event.locals.token = access_token;
+                        }
                     } else {
+
+                        // Just refresh the session with current data
                         event.locals.user = token;
                         event.locals.token = rawToken;
                     }
@@ -29,6 +89,8 @@ export const handle: Handle = async ({event, resolve}) => {
         }
     }
     const result = await resolve(event);
+    result.headers.set("Set-Cookie", newCookiesString);
+    console.log(result.headers);
     return result;
 };
 

--- a/clients/web/src/lib/utils/constants.ts
+++ b/clients/web/src/lib/utils/constants.ts
@@ -1,3 +1,4 @@
 export const constants = {
     auth_cookie_key: "sprocket.token",
+    refresh_token_cookie_key: "sprocket.refresh",
 };

--- a/clients/web/src/routes/auth/login.svelte
+++ b/clients/web/src/routes/auth/login.svelte
@@ -21,14 +21,15 @@
     import {session} from "$app/stores";
 
     async function login(e: CustomEvent<string>) {
-        const token = e.detail;
+        const tokens = e.detail.split(",");
 
-        $session.user = extractJwt<SessionUser>(token);
-        $session.token = token;
+        $session.user = extractJwt<SessionUser>(tokens[0]);
+        $session.token = tokens[0];
 
-        cookies.set(constants.auth_cookie_key, token, { expires: 7 });
+        cookies.set(constants.auth_cookie_key, tokens[0], { expires: 1/48 });
+        cookies.set(constants.refresh_token_cookie_key, tokens[1], {expires: 7})
 
-        window.location.pathname = "/scrims";
+        //window.location.pathname = "/scrims";
     }
 </script>
 

--- a/core/src/identity/auth/auth.module.ts
+++ b/core/src/identity/auth/auth.module.ts
@@ -10,7 +10,7 @@ import {OrganizationModule} from "../../organization";
 import {IdentityModule} from "../identity.module";
 import {GqlJwtGuard} from "./gql-auth-guard";
 import {
-    DiscordStrategy, GoogleStrategy, JwtConstants, JwtStrategy, OauthController, OauthService,
+    DiscordStrategy, GoogleStrategy, JwtConstants, JwtRefreshStrategy, JwtStrategy, OauthController, OauthService,
 } from "./oauth";
 
 @Module({
@@ -31,6 +31,7 @@ import {
         GqlJwtGuard,
         OauthService,
         JwtStrategy,
+        JwtRefreshStrategy,
         GoogleStrategy,
         DiscordStrategy,
     ],

--- a/core/src/identity/auth/oauth/guards/jwt-refresh.guard.ts
+++ b/core/src/identity/auth/oauth/guards/jwt-refresh.guard.ts
@@ -1,0 +1,5 @@
+import {Injectable} from "@nestjs/common";
+import {AuthGuard} from "@nestjs/passport";
+
+@Injectable()
+export class JwtRefreshGuard extends AuthGuard("jwt-refresh") {}

--- a/core/src/identity/auth/oauth/oauth.service.ts
+++ b/core/src/identity/auth/oauth/oauth.service.ts
@@ -1,22 +1,32 @@
-import {Injectable} from "@nestjs/common";
+import {Injectable, Logger} from "@nestjs/common";
 import {JwtService} from "@nestjs/jwt";
 
 import type {AccessToken, AuthPayload} from "./types";
 
 @Injectable()
 export class OauthService {
+    private readonly logger = new Logger(OauthService.name);
+
     constructor(private jwtService: JwtService) {}
 
     async login(user: AuthPayload): Promise<AccessToken> {
         const payload = {username: user.username, sub: user.userId};
         return {
-            access_token: this.jwtService.sign(payload),
+            access_token: this.jwtService.sign(payload, {expiresIn: "15m"}),
+            refresh_token: this.jwtService.sign(payload, {expiresIn: "7d"}),
         };
     }
 
     async loginDiscord(user: AuthPayload): Promise<AccessToken> {
         return {
-            access_token: this.jwtService.sign(user),
+            access_token: this.jwtService.sign(user, {expiresIn: "1m"}),
+            refresh_token: this.jwtService.sign(user, {expiresIn: "7d"}),
         };
+    }
+
+    async refreshTokens(user: AuthPayload, refreshToken: string): Promise<AccessToken> {
+        this.logger.verbose(refreshToken);
+        const tokens = await this.loginDiscord(user);
+        return tokens;
     }
 }

--- a/core/src/identity/auth/oauth/oauth.service.ts
+++ b/core/src/identity/auth/oauth/oauth.service.ts
@@ -12,14 +12,14 @@ export class OauthService {
     async login(user: AuthPayload): Promise<AccessToken> {
         const payload = {username: user.username, sub: user.userId};
         return {
-            access_token: this.jwtService.sign(payload, {expiresIn: "15m"}),
+            access_token: this.jwtService.sign(payload, {expiresIn: "30m"}),
             refresh_token: this.jwtService.sign(payload, {expiresIn: "7d"}),
         };
     }
 
     async loginDiscord(user: AuthPayload): Promise<AccessToken> {
         return {
-            access_token: this.jwtService.sign(user, {expiresIn: "1m"}),
+            access_token: this.jwtService.sign(user, {expiresIn: "30m"}),
             refresh_token: this.jwtService.sign(user, {expiresIn: "7d"}),
         };
     }

--- a/core/src/identity/auth/oauth/strategies/index.ts
+++ b/core/src/identity/auth/oauth/strategies/index.ts
@@ -1,3 +1,4 @@
 export * from "./discord.strategy";
 export * from "./google.strategy";
+export * from "./oauth.jwt.refresh.strategy";
 export * from "./oauth.jwt.strategy";

--- a/core/src/identity/auth/oauth/strategies/oauth.jwt.refresh.strategy.ts
+++ b/core/src/identity/auth/oauth/strategies/oauth.jwt.refresh.strategy.ts
@@ -1,0 +1,28 @@
+import type {Request} from "@nestjs/common";
+import {Injectable} from "@nestjs/common";
+import {PassportStrategy} from "@nestjs/passport";
+import {ExtractJwt, Strategy} from "passport-jwt";
+
+import {JwtConstants} from "../constants";
+import type {AuthPayload, UserPayload} from "../types";
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
+    constructor() {
+        super({
+            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            ignoreExpiration: true,
+            secretOrKey: JwtConstants.secret,
+            passReqToCallback: true,
+        });
+    }
+
+    async validate(req: Request, payload: AuthPayload): Promise<UserPayload> {
+        return {
+            userId: payload.userId,
+            username: payload.username,
+            currentOrganizationId: payload.currentOrganizationId,
+            orgTeams: payload.orgTeams ?? [],
+        };
+    }
+}

--- a/core/src/identity/auth/oauth/types/accesstoken.type.ts
+++ b/core/src/identity/auth/oauth/types/accesstoken.type.ts
@@ -1,3 +1,5 @@
 export class AccessToken {
     access_token: string;
+
+    refresh_token: string;
 }


### PR DESCRIPTION
Old behavior:

- Log in
- Get JWT from the backend, valid for 7 days from the first login. 
- After 7 days, you have to log in again, regardless of last usage.

New behavior:

- Log in
- Get JWT from the backend, valid for 30 minutes, as well as a refresh token valid for 7 days.
- If at any point after 30 minutes but before 7 days you refresh the app, sprocket will *automatically* refresh your tokens, and you'll be logged in for another 30 minutes (with a new refresh token, valid for 7 days from the *refresh point*)

Thus, the only way a user will have to start the authorization process from scratch is if they haven't used Sprocket in more than 7 days. 