### PR TITLE
Reprocess Matches

### DIFF
--- a/core/src/scheduling/match/match.resolver.ts
+++ b/core/src/scheduling/match/match.resolver.ts
@@ -90,6 +90,13 @@ export class MatchResolver {
         return "OKAY";
     }
 
+    @Mutation(() => String)
+    @UseGuards(GqlJwtGuard, MLEOrganizationTeamGuard(MLE_OrganizationTeam.MLEDB_ADMIN))
+    async reprocessMatches(@Args("startDate") startDate: Date): Promise<string> {
+        await this.matchService.resubmitAllMatchesAfter(startDate);
+        return "Job started";
+    }
+
     @ResolveField()
     async skillGroup(@Root() root: Match): Promise<GameSkillGroup> {
         if (root.skillGroup) return root.skillGroup;

--- a/core/src/scheduling/match/match.service.ts
+++ b/core/src/scheduling/match/match.service.ts
@@ -128,12 +128,12 @@ export class MatchService {
                                 FROM round_played_time
                                          INNER JOIN match m ON "matchId" = m.id
                                          INNER JOIN match_parent mp ON m."matchParentId" = mp.id
-                                WHERE played_at > :start_date
+                                WHERE played_at > $1
                                 GROUP BY "matchId", mp.id, m.id
                                 ORDER BY 2;`;
 
         interface toBeReprocessed {id: number; date: string; is_league_match: boolean;}
-        const results: toBeReprocessed[] = await this.dataSource.manager.query(queryString, [ {start_date: startDate} ]) as toBeReprocessed[];
+        const results: toBeReprocessed[] = await this.dataSource.manager.query(queryString, [startDate]) as toBeReprocessed[];
 
         for (const r of results) {
             const payload = await this.translatePayload(r.id, r.is_league_match);

--- a/core/src/scheduling/match/match.service.ts
+++ b/core/src/scheduling/match/match.service.ts
@@ -5,7 +5,7 @@ import type {
 } from "@sprocketbot/common";
 import type {FindOneOptions, FindOptionsRelations} from "typeorm";
 import {
-    DataSource,    IsNull, MoreThan, Not, Repository,
+    DataSource, IsNull, Not, Repository,
 } from "typeorm";
 
 import type {
@@ -16,7 +16,6 @@ import {
     Franchise,
     Invalidation,
     Match,
-    MatchParent,
     PlayerStatLineStatsSchema,
     Round,
     ScheduleFixture,
@@ -133,10 +132,11 @@ export class MatchService {
                                 GROUP BY "matchId", mp.id, m.id
                                 ORDER BY 2;`;
 
-        const results = await this.dataSource.manager.query(queryString, [ {start_date: startDate} ]);
+        interface toBeReprocessed {id: number; date: string; is_league_match: boolean;}
+        const results: toBeReprocessed[] = await this.dataSource.manager.query(queryString, [ {start_date: startDate} ]) as toBeReprocessed[];
 
         for (const r of results) {
-            const payload = await this.translatePayload(r[0] as number, r[2] as boolean);
+            const payload = await this.translatePayload(r.id, r.is_league_match);
             await this.eloConnectorService.createJob(EloEndpoint.CalculateEloForMatch, payload);
         }
     }


### PR DESCRIPTION
For data integrity purposes (particularly wrt to Elo), we want to have the ability to "hard reset" and reprocess all match data available from a given date/time. This command allows for the second half of that process (the first, deleting the desired elo data, must still be done manually). 

