### PR TITLE
Uncaught errors killing services

### DIFF
--- a/clients/discord-bot/src/main.ts
+++ b/clients/discord-bot/src/main.ts
@@ -1,5 +1,6 @@
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
+import {AllExceptionsFilter} from "@sprocketbot/common";
 import * as config from "config";
 import fetch from "node-fetch";
 
@@ -21,6 +22,8 @@ async function bootstrap(): Promise<void> {
             heartbeat: 120,
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
     
     await app.listen();
 

--- a/common/src/celery/celery.service.ts
+++ b/common/src/celery/celery.service.ts
@@ -87,11 +87,19 @@ export class CeleryService {
                 .then((r: unknown) => {
                     const result = this.parseResult(task, r);
                     const p = opts.cb!(taskId, result, null);
-                    if (p instanceof Promise) p.catch(err => { this.logger.error(`Celery task callback failed name=${name} taskId=${taskId}`, err);throw err });
+                    if (p instanceof Promise) {
+                        p.catch(err => {
+                            this.logger.error(`Celery task callback failed name=${name} taskId=${taskId}`, err);
+                        });
+                    }
                 })
                 .catch((error: Error) => {
                     const p = opts.cb!(taskId, null, error);
-                    if (p instanceof Promise) p.catch(err => { this.logger.error(`Celery task callback failed name=${name} taskId=${taskId}`, err);throw err });
+                    if (p instanceof Promise) {
+                        p.catch(err => {
+                            this.logger.error(`Celery task callback failed name=${name} taskId=${taskId}`, err);
+                        });
+                    }
                 });
         } else {
             await asyncResult.get() as TaskResult<T>;

--- a/common/src/filters/all-exceptions.filter.ts
+++ b/common/src/filters/all-exceptions.filter.ts
@@ -1,0 +1,25 @@
+import {
+    type ExceptionFilter, Catch, Logger,
+} from "@nestjs/common";
+
+/**
+ * Catches any unhandled error in a NestJS microservice
+ *
+ * Should be used when in `main.ts` `bootstrap()` creating a new microservice
+ * @example
+ * async function bootstrap(): Promise<void> {
+ *     const app = await NestFactory.createMicroservice(AppModule, {
+ *         // ...
+ *     });
+ *     app.useGlobalFilters(new AllExceptionsFilter());
+ *     await app.listen();
+ * }
+ */
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+    private readonly logger = new Logger(AllExceptionsFilter.name);
+
+    catch(exception: unknown): void {
+        this.logger.error("Uncaught exception", exception);
+    }
+}

--- a/common/src/filters/index.ts
+++ b/common/src/filters/index.ts
@@ -1,0 +1,1 @@
+export * from "./all-exceptions.filter";

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./celery";
 export * from "./events";
+export * from "./filters";
 export * from "./global.types";
 export * from "./minio";
 export * from "./redis";

--- a/core/src/main.ts
+++ b/core/src/main.ts
@@ -1,7 +1,7 @@
 import {ValidationPipe} from "@nestjs/common";
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
-import {config} from "@sprocketbot/common";
+import {AllExceptionsFilter, config} from "@sprocketbot/common";
 import {writeFile} from "fs/promises";
 import {SpelunkerModule} from "nestjs-spelunker";
 
@@ -37,6 +37,8 @@ async function bootstrap(): Promise<void> {
     });
     app.enableCors();
     app.useGlobalPipes(new ValidationPipe());
+
+    app.useGlobalFilters(new AllExceptionsFilter());
 
     const port = 3001;
     await app.startAllMicroservices();

--- a/microservices/image-generation-service/src/main.ts
+++ b/microservices/image-generation-service/src/main.ts
@@ -1,6 +1,6 @@
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
-import {config} from "@sprocketbot/common";
+import {AllExceptionsFilter, config} from "@sprocketbot/common";
 
 import {AppModule} from "./app.module";
 
@@ -12,6 +12,9 @@ async function bootstrap(): Promise<void> {
             queue: config.transport.image_generation_queue,
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
+
     await app.listen();
 }
 

--- a/microservices/matchmaking-service/src/main.ts
+++ b/microservices/matchmaking-service/src/main.ts
@@ -1,6 +1,6 @@
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
-import {config} from "@sprocketbot/common";
+import {AllExceptionsFilter, config} from "@sprocketbot/common";
 
 import {AppModule} from "./app.module";
 
@@ -16,6 +16,9 @@ async function bootstrap(): Promise<void> {
             heartbeat: 120,
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
+
     await app.listen();
 }
 

--- a/microservices/notification-service/src/main.ts
+++ b/microservices/notification-service/src/main.ts
@@ -1,6 +1,6 @@
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
-import {config} from "@sprocketbot/common";
+import {AllExceptionsFilter, config} from "@sprocketbot/common";
 
 import {AppModule} from "./app.module";
 
@@ -16,6 +16,9 @@ async function bootstrap(): Promise<void> {
             heartbeat: 120,
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
+
     await app.listen();
 }
 

--- a/microservices/server-analytics-service/src/main.ts
+++ b/microservices/server-analytics-service/src/main.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
+import {AllExceptionsFilter} from "@sprocketbot/common";
 import * as config from "config";
 
 import {AppModule} from "./app.module";
@@ -20,6 +21,9 @@ async function bootstrap(): Promise<void> {
             },
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
+
     await app.listen();
 }
 

--- a/microservices/submission-service/src/main.ts
+++ b/microservices/submission-service/src/main.ts
@@ -1,6 +1,6 @@
 import {NestFactory} from "@nestjs/core";
 import {Transport} from "@nestjs/microservices";
-import {config} from "@sprocketbot/common";
+import {AllExceptionsFilter, config} from "@sprocketbot/common";
 
 import {AppModule} from "./app.module";
 
@@ -16,6 +16,9 @@ async function bootstrap(): Promise<void> {
             heartbeat: 120,
         },
     });
+
+    app.useGlobalFilters(new AllExceptionsFilter());
+
     await app.listen();
 }
 


### PR DESCRIPTION
- Don't throw error in celery callback, it doesn't get caught by anything
- Add global error handlers to all microservices

Celery callback throwing doesn't kill microservice
![dont throw in celery callback](https://user-images.githubusercontent.com/31896377/191390083-32bad938-3f3b-4d0e-84b6-fd0d1b0812a7.PNG)


Timeout error (or other error) is caught by global handler and doesn't kill microservice
![all-exceptions-filter](https://user-images.githubusercontent.com/31896377/191390087-092f5dc5-3575-4e34-8e53-78f4389747f6.PNG)
