### PR TITLE
feat: stack banner to warn on dev/staging

### DIFF
--- a/clients/web/src/app.d.ts
+++ b/clients/web/src/app.d.ts
@@ -31,4 +31,8 @@ declare global {
         chatwootSDK?: ChatwootSDK;
         $chatwoot?: ChatwootGlobal;
     }
+
+    interface ImportMetaEnv {
+        STACK: string | undefined;
+    }
 }

--- a/clients/web/src/lib/components/atoms/StackBanner.svelte
+++ b/clients/web/src/lib/components/atoms/StackBanner.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import {session} from "$app/stores";
+    import cookies from "js-cookie";
+    import FaExclamationTriangle from "svelte-icons/fa/FaExclamationTriangle.svelte";
+    import MdClose from "svelte-icons/md/MdClose.svelte";
+
+    const BANNER_DISABLED_COOKIE = "sprocket.disable-stack-banner";
+
+    let open = cookies.get(BANNER_DISABLED_COOKIE) !== "true";
+
+    const stack = $session.config.stack;
+    const prodUrl = "app.sprocket.gg";
+
+    let showBanner: boolean;
+    $: showBanner = open && (stack === "dev" || stack === "staging");
+
+    const close = () => {
+        open = false;
+        // Set cookie that expires in one day
+        cookies.set(BANNER_DISABLED_COOKIE, "true", {expires: 1});
+    };
+</script>
+
+
+{#if showBanner}
+    <div class="flex flex-row items-center justify-center gap-16 p-2 bg-red-600 text-white font-bold">
+        <span class="h-8">
+            <FaExclamationTriangle />
+        </span>
+        <div class="flex flex-col items-center justify-center">
+            <span>This is not the public Sprocket site!</span>
+            <span>You are probably looking for <a class="underline hover:text-white/90" href={`https://${prodUrl}`}>{prodUrl}</a></span>
+        </div>
+        <span class="h-8">
+            <FaExclamationTriangle />
+        </span>
+
+        <span class="absolute right-8 h-8 hover:cursor-pointer" on:click={close}>
+            <MdClose />
+        </span>
+    </div>
+{/if}

--- a/clients/web/src/lib/components/atoms/index.ts
+++ b/clients/web/src/lib/components/atoms/index.ts
@@ -10,3 +10,4 @@ export {default as Progress} from "./Progress.svelte";
 export {default as Dropdown} from "./Dropdown.svelte";
 export {default as VsIcon} from "./icons/VsIcon.svelte";
 export {default as Accordion} from "./Accordion.svelte";
+export {default as StackBanner} from "./StackBanner.svelte";

--- a/clients/web/src/lib/utils/config.ts
+++ b/clients/web/src/lib/utils/config.ts
@@ -1,5 +1,5 @@
 import {browser} from "$app/env";
-import type {Config} from "./types";
+import type {Config, Stack} from "./types";
 
 export let config: Config;
 
@@ -12,6 +12,8 @@ export const loadConfig = async (): Promise<Config> => {
 
     if (config) return config;
 
+    const stack = (import.meta.env.VITE_STACK ?? "local") as Stack;
+
     config = {
         client: {
             gqlUrl: _config.get<string>("client.gqlUrl"),
@@ -21,12 +23,14 @@ export const loadConfig = async (): Promise<Config> => {
                 url: _config.get<string>("client.chatwoot.url"),
                 websiteToken: _config.get<string>("client.chatwoot.websiteToken"),
             },
+            stack: stack,
         },
         server: {
             chatwoot: {
                 hmacKey: fs.readFileSync("secret/chatwoot-hmac-key.txt").toString()
                     .trim(),
             },
+            stack: stack,
         },
     };
     

--- a/clients/web/src/lib/utils/types/Config.ts
+++ b/clients/web/src/lib/utils/types/Config.ts
@@ -1,3 +1,6 @@
+export type Stack = "local" | "dev" | "staging" | "main";
+
+
 export interface Config {
     client: {
         gqlUrl: string;
@@ -9,10 +12,14 @@ export interface Config {
             url: string;
             websiteToken: string;
         };
+
+        stack: Stack;
     };
     server: {
         chatwoot: {
             hmacKey: string;
         };
+
+        stack: Stack;
     };
 }

--- a/clients/web/src/routes/__layout.svelte
+++ b/clients/web/src/routes/__layout.svelte
@@ -3,7 +3,7 @@
 	import {initializeClient} from "$lib/api/client";
 	import {session} from "$app/stores";
 	import {
-	    AuthGuard, Chatwoot, ToastContainer,
+	    AuthGuard, Chatwoot, StackBanner, ToastContainer,
 	} from "$lib/components";
 	import {navigationStore, ADMIN_NAV_ITEM} from "$lib/stores";
 
@@ -17,9 +17,12 @@
 	initializeClient($session);
 </script>
 
+
 <svelte:head>
 	<title>Sprocket</title>
 </svelte:head>
+
+<StackBanner />
 
 <slot />
 


### PR DESCRIPTION
- Adds a banner to the top of the page that appears when the environment is `dev` or `staging`, links to `app.sprocket.gg`
- Add `VITE_STACK` env to determine stack (pulumi stack, options are `local`, `dev`, `staging`, `main`)
- Set cookie when banner is dismissed, lasts for 1 day (to make it less annoying for people actually testing on dev/staging)

Warning banner

![stack banner](https://user-images.githubusercontent.com/31896377/193734513-efc8cc1a-e4d0-4cf0-8fb8-c3f792de2ff6.PNG)

Warning banner hidden when cookie is set

![stack banner cookie](https://user-images.githubusercontent.com/31896377/193734520-ad967987-aa45-4258-af9c-adca455c8170.PNG)
