### PR TITLE
[Form Atoms] `Textarea`

### DIFF
--- a/clients/web/src/lib/components/atoms/form/Input/Input.svelte
+++ b/clients/web/src/lib/components/atoms/form/Input/Input.svelte
@@ -104,7 +104,7 @@
             @apply text-success-500;
         }
         .input-container {
-            @apply dark:bg-gray-700 dark:border-success-500 dark:ring-success-500 dark:text-success-500 dark:placeholder-success-500;
+            @apply dark:bg-gray-700 dark:border-success-500 dark:ring-success-500 dark:text-success-500 dark:placeholder-success-700;
         }
     }
 
@@ -113,7 +113,7 @@
             @apply text-danger-500;
         }
         .input-container {
-            @apply dark:bg-gray-700 dark:border-danger-500 dark:ring-danger-500 dark:text-danger-500 dark:placeholder-danger-500;
+            @apply dark:bg-gray-700 dark:border-danger-500 dark:ring-danger-500 dark:text-danger-500 dark:placeholder-danger-700;
         }
         .error {
             @apply text-danger-500;

--- a/clients/web/src/lib/components/atoms/form/Input/Input.svelte
+++ b/clients/web/src/lib/components/atoms/form/Input/Input.svelte
@@ -1,6 +1,3 @@
-<script lang="ts" context="module">
-</script>
-
 <script lang="ts">
     import {slide} from "svelte/transition";
     import {nanoid} from "nanoid";

--- a/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
+++ b/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import type {Hst as _Hst} from "@histoire/plugin-svelte";
+    import type {FormControlState, FormControlSize} from "../form.types";
+    import Textarea from "./Textarea.svelte";
+
+    export let Hst: _Hst;
+
+    const sizes: FormControlSize[] = ["sm", "md", "lg"];
+    const states: FormControlState[] = ["none", "valid", "invalid"];
+
+    let label = "Description";
+    let size: FormControlSize = "md";
+    let placeholder = "";
+    let disabled = false;
+    let state: FormControlState = "none";
+    let error = "";
+</script>
+
+<Hst.Story title="Atoms/Textarea" layout={{type: "grid", width: 500}}>
+    <svelte:fragment slot="controls">
+        <Hst.Text title="Label" bind:value={label} />
+        <Hst.Select title="Size" bind:value={size} options={sizes} />
+        <Hst.Text title="Placeholder" bind:value={placeholder} />
+        <Hst.Checkbox title="Disabled" bind:value={disabled} />
+        <Hst.Select title="State" bind:value={state} options={states} />
+        <Hst.Text title="Error" bind:value={error} />
+    </svelte:fragment>
+
+    <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error}>
+        <Textarea {label} {size} {placeholder} {disabled} {state} {error} />
+    </Hst.Variant>
+</Hst.Story>

--- a/clients/web/src/lib/components/atoms/form/Textarea/Textarea.svelte
+++ b/clients/web/src/lib/components/atoms/form/Textarea/Textarea.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    import {slide} from "svelte/transition";
+    import {nanoid} from "nanoid";
+
+    import type {FormControlSize, FormControlState} from "../form.types";
+
+    export let size: FormControlSize = "md";
+    export let label: string;
+    export let placeholder: string | undefined = undefined;
+    export let disabled: boolean = false;
+    export let state: FormControlState = "none";
+    export let error: string | undefined = undefined;
+
+    const labelId = `textarea_${nanoid()}`;
+    const errorId = `textarea-error_${nanoid()}`;
+
+    let rows: number;
+    $: {
+        switch (size) {
+            case "sm":
+                rows = 2;
+                break;
+            case "md":
+                rows = 4;
+                break;
+            case "lg":
+                rows = 8;
+                break;
+        }
+    }
+</script>
+
+<div class="size-{size} state-{state}">
+    <label for={labelId}>{label}</label>
+    <textarea id={labelId} aria-describedby={error ? errorId : undefined} {rows} {placeholder} {disabled} />
+
+    {#if error && state === "invalid"}
+        <span class="error" id={errorId} transition:slide>{error}</span>
+    {/if}
+</div>
+
+<style lang="postcss">
+    /* General styling */
+    label {
+        @apply block mb-2 text-sm font-medium text-gray-300;
+    }
+
+    textarea {
+        @apply w-full flex items-stretch
+            rounded-lg border outline-none
+            focus-within:ring-1 focus-within:ring-primary focus-within:border-primary
+            bg-gray-700 border-gray-600 text-white placeholder-gray-400;
+
+        &:disabled {
+            @apply cursor-not-allowed text-gray-400 placeholder-gray-500;
+        }
+    }
+
+    /* Size styling */
+    .size-sm textarea {
+        @apply p-2 sm:text-xs;
+    }
+
+    .size-md textarea {
+        @apply p-2.5 text-sm;
+    }
+
+    .size-lg textarea {
+        @apply p-4 sm:text-base;
+    }
+
+    /* State styling */
+    .state-valid {
+        label {
+            @apply text-success-500;
+        }
+        textarea {
+            @apply dark:bg-gray-700 dark:border-success-500 dark:ring-success-500 dark:text-success-500 dark:placeholder-success-700;
+        }
+    }
+
+    .state-invalid {
+        label {
+            @apply text-danger-500;
+        }
+        textarea {
+            @apply dark:bg-gray-700 dark:border-danger-500 dark:ring-danger-500 dark:text-danger-500 dark:placeholder-danger-700;
+        }
+        .error {
+            @apply text-danger-500;
+        }
+    }
+</style>

--- a/clients/web/src/lib/components/atoms/form/Textarea/index.ts
+++ b/clients/web/src/lib/components/atoms/form/Textarea/index.ts
@@ -1,0 +1,1 @@
+export {default as Textarea} from "./Textarea.svelte";

--- a/clients/web/src/lib/components/atoms/form/index.ts
+++ b/clients/web/src/lib/components/atoms/form/index.ts
@@ -1,1 +1,3 @@
+export * from "./form.types";
 export * from "./Input";
+export * from "./Textarea";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31896377/195235854-941e1deb-56dc-49ca-85f6-b68a91768968.png)

Adds `Textarea` form element. Very similar to `Input`.