### PR TITLE
Form data binding

### DIFF
--- a/clients/web/histoire.config.ts
+++ b/clients/web/histoire.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     plugins: [HstSvelte()],
 
     // https://histoire.dev/guide/config.html#global-js-and-css
-    setupFile: "/src/histoire.setup.ts",
+    setupFile: "/src/lib/histoire/setup.ts",
 
     theme: {
         title: "Histoire | Sprocket",

--- a/clients/web/src/lib/components/atoms/Accordion/Accordion.story.svelte
+++ b/clients/web/src/lib/components/atoms/Accordion/Accordion.story.svelte
@@ -1,22 +1,23 @@
 <script lang="ts">
     import type {Hst as _Hst} from "@histoire/plugin-svelte";
+    import {Props} from "../../../histoire";
     import Accordion from "./Accordion.svelte";
 
     export let Hst: _Hst;
+
+    let flush = false;
 </script>
 
-<Hst.Story title="Atoms/Accordion">
-    <Hst.Variant title="Default">
-        <Accordion>
+<Hst.Story title="Atoms/Accordion" layout={{type: "grid", width: 800}}>
+    <svelte:fragment slot="controls">
+        <Hst.Checkbox title="Flush" bind:value={flush} />
+
+        <Props props={{flush}} />
+    </svelte:fragment>
+
+    <Hst.Variant title="Default" {flush}>
+        <Accordion {flush}>
             <span slot="title">Accordion 1</span>
-            <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
-                distinctio earum placeat debitis vel repellat ex quia aut nostrum facere error veritatis. Iusto, dolorum
-                quaerat?
-            </p>
-        </Accordion>
-        <Accordion>
-            <span slot="title">Accordion 2</span>
             <p>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
                 distinctio earum placeat debitis vel repellat ex quia aut nostrum facere error veritatis. Iusto, dolorum
@@ -24,8 +25,9 @@
             </p>
         </Accordion>
     </Hst.Variant>
-    <Hst.Variant title="Flush">
-        <Accordion flush>
+
+    <Hst.Variant title="Several accordions" {flush}>
+        <Accordion {flush}>
             <span slot="title">Accordion 1</span>
             <p>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
@@ -33,8 +35,24 @@
                 quaerat?
             </p>
         </Accordion>
-        <Accordion flush>
-            <span slot="title">Accordion 2</span>
+        <Accordion {flush}>
+            <span slot="title">Accordion 1</span>
+            <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
+                distinctio earum placeat debitis vel repellat ex quia aut nostrum facere error veritatis. Iusto, dolorum
+                quaerat?
+            </p>
+        </Accordion>
+        <Accordion {flush}>
+            <span slot="title">Accordion 1</span>
+            <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
+                distinctio earum placeat debitis vel repellat ex quia aut nostrum facere error veritatis. Iusto, dolorum
+                quaerat?
+            </p>
+        </Accordion>
+        <Accordion {flush}>
+            <span slot="title">Accordion 1</span>
             <p>
                 Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime nulla dolorem non accusamus aperiam,
                 distinctio earum placeat debitis vel repellat ex quia aut nostrum facere error veritatis. Iusto, dolorum

--- a/clients/web/src/lib/components/atoms/Alert/Alert.story.svelte
+++ b/clients/web/src/lib/components/atoms/Alert/Alert.story.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type {Hst as _Hst} from "@histoire/plugin-svelte";
+    import {Props} from "../../../histoire";
     import Alert, {type AlertVariant} from "./Alert.svelte";
 
     export let Hst: _Hst;
@@ -16,7 +17,8 @@
         <Hst.Select title="Variant" bind:value={variant} options={variants} />
         <Hst.Checkbox title="Dismissible" bind:value={dismissible} />
         <Hst.Checkbox title="With Icon" bind:value={withIcon} />
-        <pre class="m-2 p-2 bg-black/20 ">{JSON.stringify({variant, dismissible, withIcon}, null, 2)}</pre>
+
+        <Props props={{variant, dismissible, withIcon}} />
     </svelte:fragment>
 
     <Hst.Variant title="Default" {variant} {dismissible} {withIcon}>

--- a/clients/web/src/lib/components/atoms/form/Input/Input.story.svelte
+++ b/clients/web/src/lib/components/atoms/form/Input/Input.story.svelte
@@ -17,6 +17,7 @@
     let disabled = false;
     let state: FormControlState = "none";
     let error = "";
+    let value = "";
 </script>
 
 <Hst.Story title="Atoms/Input" layout={{type: "grid", width: 500}}>
@@ -27,23 +28,24 @@
         <Hst.Checkbox title="Disabled" bind:value={disabled} />
         <Hst.Select title="State" bind:value={state} options={states} />
         <Hst.Text title="Error" bind:value={error} />
+        <Hst.Text title="Value" bind:value={value} />
 
-        <Props props={{label, size, placeholder, disabled, state, error}} />
+        <Props props={{label, size, placeholder, disabled, state, error, value}} />
     </svelte:fragment>
 
-    <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error}>
-        <Input {label} {size} {placeholder} {disabled} {state} {error} />
+    <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error} {value}>
+        <Input {label} {size} {placeholder} {disabled} {state} {error} bind:value />
     </Hst.Variant>
 
-    <Hst.Variant title="With addonLeft" {label} {size} {placeholder} {disabled} {state} {error}>
-        <Input {label} {size} {placeholder} {disabled} {state} {error}>
+    <Hst.Variant title="With addonLeft" {label} {size} {placeholder} {disabled} {state} {error} {value}>
+        <Input {label} {size} {placeholder} {disabled} {state} {error} bind:value>
             <!-- Addons can be anything, including icons! -->
             <Icon slot="addonLeft" class="h-3/6" src={Pencil} />
         </Input>
     </Hst.Variant>
 
-    <Hst.Variant title="With addonRight" {label} {size} {placeholder} {disabled} {state} {error}>
-        <Input {label} {size} {placeholder} {disabled} {state} {error}>
+    <Hst.Variant title="With addonRight" {label} {size} {placeholder} {disabled} {state} {error} {value}>
+        <Input {label} {size} {placeholder} {disabled} {state} {error} bind:value>
             <!-- Addons can be anything, including text with additional styling! -->
             <span slot="addonRight" class="h-full text-xl font-bold bg-gray-600">%</span>
         </Input>

--- a/clients/web/src/lib/components/atoms/form/Input/Input.story.svelte
+++ b/clients/web/src/lib/components/atoms/form/Input/Input.story.svelte
@@ -2,6 +2,7 @@
     import type {Hst as _Hst} from "@histoire/plugin-svelte";
     import {Icon} from "@steeze-ui/svelte-icon";
     import {Pencil} from "@steeze-ui/heroicons";
+    import {Props} from "../../../../histoire";
     import type {FormControlState, FormControlSize} from "../form.types";
     import Input from "./Input.svelte";
 
@@ -26,6 +27,8 @@
         <Hst.Checkbox title="Disabled" bind:value={disabled} />
         <Hst.Select title="State" bind:value={state} options={states} />
         <Hst.Text title="Error" bind:value={error} />
+
+        <Props props={{label, size, placeholder, disabled, state, error}} />
     </svelte:fragment>
 
     <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error}>

--- a/clients/web/src/lib/components/atoms/form/Input/Input.svelte
+++ b/clients/web/src/lib/components/atoms/form/Input/Input.svelte
@@ -10,6 +10,7 @@
     export let disabled: boolean = false;
     export let state: FormControlState = "none";
     export let error: string | undefined = undefined;
+    export let value: string | undefined = undefined;
 
     const labelId = `input_${nanoid()}`;
     const errorId = `input-error_${nanoid()}`;
@@ -25,7 +26,7 @@
             </div>
         {/if}
 
-        <input id={labelId} type="text" aria-describedby={error ? errorId : undefined} {placeholder} {disabled} />
+        <input id={labelId} type="text" bind:value aria-describedby={error ? errorId : undefined} {placeholder} {disabled} />
 
         {#if $$slots.addonRight}
             <div class="addon">

--- a/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
+++ b/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type {Hst as _Hst} from "@histoire/plugin-svelte";
+    import Props from "../../../../histoire/Props.svelte";
     import type {FormControlState, FormControlSize} from "../form.types";
     import Textarea from "./Textarea.svelte";
 
@@ -24,6 +25,8 @@
         <Hst.Checkbox title="Disabled" bind:value={disabled} />
         <Hst.Select title="State" bind:value={state} options={states} />
         <Hst.Text title="Error" bind:value={error} />
+
+        <Props props={{label, size, placeholder, disabled, state, error}} />
     </svelte:fragment>
 
     <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error}>

--- a/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
+++ b/clients/web/src/lib/components/atoms/form/Textarea/Textarea.story.svelte
@@ -15,6 +15,7 @@
     let disabled = false;
     let state: FormControlState = "none";
     let error = "";
+    let value = "";
 </script>
 
 <Hst.Story title="Atoms/Textarea" layout={{type: "grid", width: 500}}>
@@ -25,11 +26,12 @@
         <Hst.Checkbox title="Disabled" bind:value={disabled} />
         <Hst.Select title="State" bind:value={state} options={states} />
         <Hst.Text title="Error" bind:value={error} />
+        <Hst.Text title="Value" bind:value={value} />
 
-        <Props props={{label, size, placeholder, disabled, state, error}} />
+        <Props props={{label, size, placeholder, disabled, state, error, value}} />
     </svelte:fragment>
 
-    <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error}>
-        <Textarea {label} {size} {placeholder} {disabled} {state} {error} />
+    <Hst.Variant title="Default" {label} {size} {placeholder} {disabled} {state} {error} {value}>
+        <Textarea {label} {size} {placeholder} {disabled} {state} {error} bind:value />
     </Hst.Variant>
 </Hst.Story>

--- a/clients/web/src/lib/components/atoms/form/Textarea/Textarea.svelte
+++ b/clients/web/src/lib/components/atoms/form/Textarea/Textarea.svelte
@@ -10,6 +10,7 @@
     export let disabled: boolean = false;
     export let state: FormControlState = "none";
     export let error: string | undefined = undefined;
+    export let value: string | undefined = undefined;
 
     const labelId = `textarea_${nanoid()}`;
     const errorId = `textarea-error_${nanoid()}`;
@@ -32,7 +33,7 @@
 
 <div class="size-{size} state-{state}">
     <label for={labelId}>{label}</label>
-    <textarea id={labelId} aria-describedby={error ? errorId : undefined} {rows} {placeholder} {disabled} />
+    <textarea id={labelId} bind:value aria-describedby={error ? errorId : undefined} {rows} {placeholder} {disabled} />
 
     {#if error && state === "invalid"}
         <span class="error" id={errorId} transition:slide>{error}</span>

--- a/clients/web/src/lib/histoire/Props.svelte
+++ b/clients/web/src/lib/histoire/Props.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    export let props: Record<string, unknown>
+</script>
+
+<div class="flex flex-col items-center">    
+    <pre class="w-11/12 m-2 p-2 rounded-md bg-gray-800">{JSON.stringify(props, null, 2)}</pre>
+</div>

--- a/clients/web/src/lib/histoire/index.ts
+++ b/clients/web/src/lib/histoire/index.ts
@@ -1,0 +1,1 @@
+export {default as Props} from "./Props.svelte";

--- a/clients/web/src/lib/histoire/setup.ts
+++ b/clients/web/src/lib/histoire/setup.ts
@@ -1,3 +1,3 @@
 // Inject Tailwind into Histoire so our utility classes still work
 // https://histoire.dev/guide/config.html#global-js-and-css
-import "./app.postcss";
+import "../../app.postcss";

--- a/package-lock.json
+++ b/package-lock.json
@@ -25965,7 +25965,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-svelte3": "^4.0.0",
         "histoire": "^0.11.0",
-        "nanoid": "*",
+        "nanoid": "^4.0.0",
         "postcss": "^8.4.14",
         "postcss-load-config": "^4.0.1",
         "svelte": "^3.44.0",


### PR DESCRIPTION
- Move around histoire stuff to feature folder
- Add `<Props />` component to histoire folder to show props being passed to Svelte component from controls
- Add `value` data binding for Input and Textarea

![image](https://user-images.githubusercontent.com/31896377/195733564-6ebdfc11-2a7c-4143-b16e-1f3ac08eedeb.png)
