### PR TITLE
Save salaries to mledb

### DIFF
--- a/core/src/franchise/player/player.service.ts
+++ b/core/src/franchise/player/player.service.ts
@@ -733,6 +733,11 @@ export class PlayerService {
                 }
             } else {
                 await this.updatePlayerStanding(playerDelta.playerId, playerDelta.newSalary);
+                const newMlePlayer = this.mle_playerRepository.merge(mlePlayer, {
+                        salary: playerDelta.newSalary,
+                });
+
+                await this.mle_playerRepository.save(newMlePlayer);
             }
         }))));
     }


### PR DESCRIPTION
Salaries were saved to MLEDB only when a rankout was processed for a given player. Add code to save the new salaries even when there's no rankout. 