### PR TITLE
refactor: switch generic "id" to "userId" in scrims and submissions [CU-2r76umu]

### DIFF
--- a/clients/web/src/lib/api/queries/scrims/ActiveScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/ActiveScrims.store.ts
@@ -70,18 +70,18 @@ export class ActiveScrimsStore extends LiveQueryStore<
                     mode
                 }
                 players {
-                    id
+                    userId
                     name
                     checkedIn
                 }
                 playersAdmin {
-                    id
+                    userId
                     name
                 }
                 games {
                     teams {
                         players {
-                            id
+                            userId
                             name
                         }
                     }
@@ -119,18 +119,18 @@ export class ActiveScrimsStore extends LiveQueryStore<
                         mode
                     }
                     players {
-                        id
+                        userId
                         name
                         checkedIn
                     }
                     playersAdmin {
-                        id
+                        userId
                         name
                     }
                     games {
                         teams {
                             players {
-                                id
+                                userId
                                 name
                             }
                         }

--- a/clients/web/src/lib/api/queries/scrims/AllCurrentScrims.ts
+++ b/clients/web/src/lib/api/queries/scrims/AllCurrentScrims.ts
@@ -15,7 +15,7 @@ export const AllCurrentScrimsQuery = gql`
                 mode
             }
             players {
-                id
+                userId
                 name
                 checkedIn
             }

--- a/clients/web/src/lib/api/queries/scrims/CurrentScrim.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/CurrentScrim.store.ts
@@ -31,7 +31,7 @@ export interface CurrentScrim {
         mode: string;
     };
     players: Array<{
-        id: number;
+        userId: number;
         name: string;
         checkedIn: boolean;
     }>;
@@ -107,7 +107,7 @@ class CurrentScrimStore extends LiveQueryStore<
                     mode
                 }
                 players {
-                    id
+                    userId
                     name
                     checkedIn
                 }
@@ -118,7 +118,7 @@ class CurrentScrimStore extends LiveQueryStore<
                 games {
                     teams {
                         players {
-                            id
+                            userId
                             name
                         }
                     }
@@ -159,7 +159,7 @@ class CurrentScrimStore extends LiveQueryStore<
                         mode
                     }
                     players {
-                        id
+                        userId
                         name
                         checkedIn
                     }
@@ -170,7 +170,7 @@ class CurrentScrimStore extends LiveQueryStore<
                     games {
                         teams {
                             players {
-                                id
+                                userId
                                 name
                             }
                         }

--- a/clients/web/src/lib/api/queries/submissions/ActiveSubmissions.store.ts
+++ b/clients/web/src/lib/api/queries/submissions/ActiveSubmissions.store.ts
@@ -50,7 +50,7 @@ export class ActiveSubmissionsStore extends QueryStore<
                 scrimId
                 matchId
 
-                creatorId
+                creatorUserId
 
                 status
 
@@ -82,7 +82,7 @@ export class ActiveSubmissionsStore extends QueryStore<
                 ratifiers
                 requiredRatifications
                 rejections {
-                    playerId
+                    userId
                     reason
                     rejectedAt
                 }

--- a/clients/web/src/lib/api/queries/submissions/Submission.store.ts
+++ b/clients/web/src/lib/api/queries/submissions/Submission.store.ts
@@ -28,7 +28,7 @@ export class SubmissionStore extends LiveQueryStore<
         query ($submissionId: String!) {
             submission: getSubmission(submissionId: $submissionId) {
                 id
-                creatorId
+                creatorUserId
                 ratifications
                 requiredRatifications
                 userHasRatified
@@ -78,7 +78,7 @@ export class SubmissionStore extends LiveQueryStore<
         subscription ($submissionId: String!) {
             submission: followSubmission(submissionId: $submissionId) {
                 id
-                creatorId
+                creatorUserId
                 ratifications
                 requiredRatifications
                 userHasRatified

--- a/clients/web/src/lib/api/queries/submissions/submission.types.ts
+++ b/clients/web/src/lib/api/queries/submissions/submission.types.ts
@@ -1,5 +1,5 @@
 export interface SubmissionRejection {
-    playerId: string;
+    userId: string;
     playerName: string;
     reason: string;
     stale: boolean;
@@ -17,7 +17,7 @@ export interface SubmissionProgress {
 export interface Submission {
     id: string;
     status: string;
-    creatorId: number;
+    creatorUserId: number;
     ratifications: number;
     requiredRatifications: number;
     userHasRatified: boolean;

--- a/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/PoppedView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/PoppedView.svelte
@@ -31,7 +31,8 @@
         }
     }
 
-    $: canCheckIn = !scrim.players.find(p => p.userId === $user.userId)!.checkedIn;
+    $: canCheckIn = !scrim.players.find(p => p.userId === $user.userId)!
+        .checkedIn;
 </script>
 
 <section>

--- a/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/PoppedView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/QueuedSubViews/PoppedView.svelte
@@ -31,7 +31,7 @@
         }
     }
 
-    $: canCheckIn = !scrim.players.find(p => p.id === $user.userId)!.checkedIn;
+    $: canCheckIn = !scrim.players.find(p => p.userId === $user.userId)!.checkedIn;
 </script>
 
 <section>
@@ -54,7 +54,7 @@
                     Has {#if !p.checkedIn}<strong>not</strong>{/if} checked in.
                 </p>
 
-                {#if p.id === $user.userId}
+                {#if p.userId === $user.userId}
                     <button
                         class="btn btn-accent mr-2"
                         disabled={!canCheckIn}
@@ -75,7 +75,7 @@
 <!--    </thead>-->
 <!--    {#each scrim.players as p}-->
 <!--        <tr class="h-20">-->
-<!--            <td>{p.name} {p.id === $user.userId ? "(You)" : ""}</td>-->
+<!--            <td>{p.name} {p.userId === $user.userId ? "(You)" : ""}</td>-->
 <!--            <td>-->
 <!--                <input type="checkbox" class="toggle" on:click|capture|preventDefault={() => false} checked={Boolean(p.checkedIn)} readonly/>-->
 <!--            </td>-->

--- a/common/src/service-connectors/matchmaking/schemas/scrim/CheckInToScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/CheckInToScrim.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const CheckInToScrim_Request = z.object({
     scrimId: z.string().uuid(),
-    playerId: z.number(),
+    userId: z.number(),
 });
 
 export const CheckInToScrim_Response = z.boolean();

--- a/common/src/service-connectors/matchmaking/schemas/scrim/CompleteScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/CompleteScrim.schema.ts
@@ -4,7 +4,7 @@ import {ScrimDatabaseIdsSchema} from "../../../../events";
 
 export const CompleteScrim_Request = z.object({
     scrimId: z.string().uuid(),
-    playerId: z.number(),
+    userId: z.number(),
     databaseIds: ScrimDatabaseIdsSchema,
 });
 

--- a/common/src/service-connectors/matchmaking/schemas/scrim/CreateScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/CreateScrim.schema.ts
@@ -3,7 +3,7 @@ import {z} from "zod";
 import {ScrimJoinOptionsSchema, ScrimSchema, ScrimSettingsSchema} from "../../types";
 
 export const CreateScrim_Request = z.object({
-    authorId: z.number(),
+    authorUserId: z.number(),
     organizationId: z.number(),
     gameModeId: z.number(),
     skillGroupId: z.number(),

--- a/common/src/service-connectors/matchmaking/schemas/scrim/GetScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/GetScrim.schema.ts
@@ -2,6 +2,8 @@ import {z} from "zod";
 
 import {ScrimSchema} from "../../types";
 
-export const GetScrim_Request = z.string().uuid();
+export const GetScrim_Request = z.object({
+    scrimId: z.string().uuid(),
+});
 
 export const GetScrim_Response = ScrimSchema.nullable();

--- a/common/src/service-connectors/matchmaking/schemas/scrim/GetScrimByPlayer.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/GetScrimByPlayer.schema.ts
@@ -2,6 +2,8 @@ import {z} from "zod";
 
 import {ScrimSchema} from "../../types";
 
-export const GetScrimByPlayer_Request = z.number().min(0);
+export const GetScrimByPlayer_Request = z.object({
+    userId: z.number().min(0),
+});
 
 export const GetScrimByPlayer_Response = ScrimSchema.nullable();

--- a/common/src/service-connectors/matchmaking/schemas/scrim/GetScrimBySubmissionId.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/GetScrimBySubmissionId.schema.ts
@@ -2,6 +2,8 @@ import {z} from "zod";
 
 import {ScrimSchema} from "../../types";
 
-export const GetScrimBySubmissionId_Request = z.string();
+export const GetScrimBySubmissionId_Request = z.object({
+    submissionId: z.string(),
+});
 
 export const GetScrimBySubmissionId_Response = ScrimSchema.nullable();

--- a/common/src/service-connectors/matchmaking/schemas/scrim/LeaveScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/LeaveScrim.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const LeaveScrim_Request = z.object({
     scrimId: z.string().uuid(),
-    playerId: z.number(),
+    userId: z.number(),
 });
 
 export const LeaveScrim_Response = z.boolean();

--- a/common/src/service-connectors/matchmaking/types/Scrim.ts
+++ b/common/src/service-connectors/matchmaking/types/Scrim.ts
@@ -15,7 +15,7 @@ export const ScrimSchema = z.object({
     status: z.nativeEnum(ScrimStatus),
     unlockedStatus: z.nativeEnum(ScrimStatus).optional(),
 
-    authorId: z.number(),
+    authorUserId: z.number(),
     organizationId: z.number(),
     gameModeId: z.number(),
     skillGroupId: z.number(),

--- a/common/src/service-connectors/matchmaking/types/ScrimJoinOptions.ts
+++ b/common/src/service-connectors/matchmaking/types/ScrimJoinOptions.ts
@@ -1,7 +1,7 @@
 import {z} from "zod";
 
 export const ScrimJoinOptionsSchema = z.object({
-    playerId: z.number(),
+    userId: z.number(),
     playerName: z.string(),
     leaveAfter: z.number().min(0),
     createGroup: z.boolean().optional(),

--- a/common/src/service-connectors/matchmaking/types/ScrimPlayer.ts
+++ b/common/src/service-connectors/matchmaking/types/ScrimPlayer.ts
@@ -3,7 +3,7 @@ import {z} from "zod";
 import {DateSchema} from "../../../types";
 
 export const ScrimPlayerSchema = z.object({
-    id: z.number(),
+    userId: z.number(),
     name: z.string(),
     joinedAt: DateSchema,
     leaveAt: DateSchema,

--- a/common/src/service-connectors/submission/schemas/CanSubmitReplays.schema.ts
+++ b/common/src/service-connectors/submission/schemas/CanSubmitReplays.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const CanSubmitReplays_Request = z.object({
     submissionId: z.string(),
-    playerId: z.number(),
+    userId: z.number(),
 });
 
 export const CanSubmitReplays_Response = z.union([

--- a/common/src/service-connectors/submission/schemas/GetSubmissionRejections.schema.ts
+++ b/common/src/service-connectors/submission/schemas/GetSubmissionRejections.schema.ts
@@ -4,4 +4,4 @@ export const GetSubmissionRejections_Request = z.object({
     submissionId: z.string(),
 });
 
-export const GetSubmissionRejections_Response = z.array(z.string());
+export const GetSubmissionRejections_Response = z.array(z.number());

--- a/common/src/service-connectors/submission/schemas/Submission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/Submission.schema.ts
@@ -4,7 +4,7 @@ import {ReplaySubmissionStatus, ReplaySubmissionType} from "../types";
 
 const BaseSubmission = z.object({
     id: z.string(),
-    creatorId: z.number(),
+    creatorUserId: z.number(),
     status: z.nativeEnum(ReplaySubmissionStatus),
     taskIds: z.string().array(),
     items: z.any().array(), // TODO ReplaySubmissionItem schema

--- a/common/src/service-connectors/submission/schemas/SubmitReplays.schema.ts
+++ b/common/src/service-connectors/submission/schemas/SubmitReplays.schema.ts
@@ -8,6 +8,6 @@ export const SubmitReplays_Request = z.object({
         }),
     ),
     submissionId: z.string(),
-    creatorId: z.number(),
+    creatorUserId: z.number(),
 });
 export const SubmitReplays_Response = z.array(z.string());

--- a/common/src/service-connectors/submission/schemas/ratification/CanRatifySubmission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/ratification/CanRatifySubmission.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const CanRatifySubmission_Request = z.object({
     submissionId: z.string(),
-    playerId: z.number(),
+    userId: z.number(),
 });
 
 export const CanRatifySubmission_Response = z.union([

--- a/common/src/service-connectors/submission/schemas/ratification/RatifySubmission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/ratification/RatifySubmission.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const RatifySubmission_Request = z.object({
     submissionId: z.string(),
-    playerId: z.number(),
+    userId: z.number(),
 });
 
 export const RatifySubmission_Response = z.literal(true);

--- a/common/src/service-connectors/submission/schemas/ratification/RejectSubmission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/ratification/RejectSubmission.schema.ts
@@ -2,7 +2,7 @@ import {z} from "zod";
 
 export const RejectSubmission_Request = z.object({
     submissionId: z.string(),
-    playerId: z.number(),
+    userId: z.number(),
     reason: z.string(),
 });
 

--- a/common/src/service-connectors/submission/schemas/ratification/ResetSubmission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/ratification/ResetSubmission.schema.ts
@@ -3,7 +3,7 @@ import {z} from "zod";
 export const ResetSubmission_Request = z.object({
     submissionId: z.string(),
     override: z.boolean().default(false),
-    playerId: z.string(),
+    userId: z.number(),
 });
 
 export const ResetSubmission_Response = z.literal(true);

--- a/common/src/service-connectors/submission/types/replay-submission-rejection.ts
+++ b/common/src/service-connectors/submission/types/replay-submission-rejection.ts
@@ -5,7 +5,7 @@ export type RejectedItem = Omit<ReplaySubmissionItem, "progress">;
 export const REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID = -1;
 
 export interface ReplaySubmissionRejection {
-    playerId: number;
+    userId: number;
     reason: string;
     rejectedItems: RejectedItem[];
     rejectedAt: string;

--- a/common/src/service-connectors/submission/types/replay-submission.ts
+++ b/common/src/service-connectors/submission/types/replay-submission.ts
@@ -17,7 +17,7 @@ export enum ReplaySubmissionStatus {
 
 export interface BaseReplaySubmission {
     id: string;
-    creatorId: number;
+    creatorUserId: number;
 
     status: ReplaySubmissionStatus;
 

--- a/core/src/internal/authorization/guards/player.guard.ts
+++ b/core/src/internal/authorization/guards/player.guard.ts
@@ -31,7 +31,7 @@ export abstract class AbstractPlayerGuard implements CanActivate {
         return true;
     }
 
-    abstract getGame(ctx: GqlExecutionContext, userPayload?: JwtAuthPayload): Promise<{gameId: number}>;
+    abstract getGame(ctx: GqlExecutionContext, userPayload: JwtAuthPayload): Promise<{gameId: number}>;
 }
 
 @Injectable()
@@ -45,7 +45,10 @@ export abstract class AbstractMemberPlayerGuard implements CanActivate {
         const data = JwtAuthPayloadSchema.safeParse(ctx.req.user);
         if (!data.success || !data.data.currentOrganizationId) return false;
 
-        const {gameId, organizationId} = await this.getGameAndOrganization(ctx, data.data);
+        const gameAndOrganization = await this.getGameAndOrganization(ctx, data.data);
+        if (!gameAndOrganization) return false;
+
+        const {gameId, organizationId} = gameAndOrganization;
         if (data.data.currentOrganizationId !== organizationId) return false;
 
         const player = await this.playerRepository.getOrNull({
@@ -62,6 +65,6 @@ export abstract class AbstractMemberPlayerGuard implements CanActivate {
 
     abstract getGameAndOrganization(
         ctx: GqlExecutionContext,
-        userPayload?: JwtAuthPayload,
-    ): Promise<{gameId: number; organizationId: number}>;
+        userPayload: JwtAuthPayload,
+    ): Promise<{gameId: number; organizationId: number} | undefined>;
 }

--- a/core/src/internal/mledb/mledb-scrim/mledb-finalization.service.ts
+++ b/core/src/internal/mledb/mledb-scrim/mledb-finalization.service.ts
@@ -1,4 +1,4 @@
-import {forwardRef, Inject, Injectable} from "@nestjs/common";
+import {Injectable} from "@nestjs/common";
 import {InjectRepository} from "@nestjs/typeorm";
 import type {
     BallchasingPlayer,
@@ -29,7 +29,6 @@ import type {GameMode, GameSkillGroup} from "$models";
 import {Match} from "$models";
 import {GameModeRepository, GameSkillGroupRepository, UserAuthenticationAccountRepository} from "$repositories";
 
-import {GameSkillGroupService} from "../../franchise";
 import type {MatchReplaySubmission, ScrimReplaySubmission} from "../../replay-parse";
 import {SprocketRatingService} from "../../sprocket-rating/sprocket-rating.service";
 import {MledbMatchService} from "../mledb-match/mledb-match.service";
@@ -45,7 +44,6 @@ export class MledbFinalizationService {
         private readonly mlePlayerAccountRepository: Repository<MLE_PlayerAccount>,
         @InjectRepository(MLE_Player)
         private readonly mlePlayerRepository: Repository<MLE_Player>,
-        @Inject(forwardRef(() => GameSkillGroupService))
         private readonly skillGroupRepository: GameSkillGroupRepository,
         private readonly gameModeRepository: GameModeRepository,
         private readonly userAuthenticationAccountRepository: UserAuthenticationAccountRepository,

--- a/core/src/internal/mledb/mledb-scrim/mledb-finalization.service.ts
+++ b/core/src/internal/mledb/mledb-scrim/mledb-finalization.service.ts
@@ -150,7 +150,7 @@ export class MledbFinalizationService {
                 scrimObject.players.map(async p => {
                     const playerEligibility = em.create(MLE_EligibilityData);
                     const discordAccount = await this.userAuthenticationAccountRepository.getDiscordAccountByUserId(
-                        p.id,
+                        p.userId,
                     );
                     const player = await this.mlePlayerRepository.findOneOrFail({
                         where: {

--- a/core/src/internal/replay-parse/replay-parse.resolver.ts
+++ b/core/src/internal/replay-parse/replay-parse.resolver.ts
@@ -30,10 +30,10 @@ export class SubmissionRejectionResolver {
     @ResolveField(() => String)
     async playerName(@Root() rejection: SubmissionRejection): Promise<string> {
         if (rejection.playerName) return rejection.playerName;
-        if (rejection.playerId === REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID) return "Sprocket";
+        if (rejection.userId === REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID) return "Sprocket";
         // TODO: Is it possible to map to an organization from here?
 
-        const profile = await this.userProfileRepository.getByUserId(parseInt(rejection.playerId.toString()));
+        const profile = await this.userProfileRepository.getByUserId(rejection.userId);
         return profile.displayName;
     }
 

--- a/core/src/internal/replay-parse/replay-parse.service.ts
+++ b/core/src/internal/replay-parse/replay-parse.service.ts
@@ -45,11 +45,11 @@ export class ReplayParseService {
     /**
      * @returns if the scrim has been reset
      */
-    async resetBrokenReplays(submissionId: string, playerId: number, override = false): Promise<boolean> {
+    async resetBrokenReplays(submissionId: string, userId: number, override = false): Promise<boolean> {
         const resetResponse = await this.submissionService.send(SubmissionEndpoint.ResetSubmission, {
             submissionId: submissionId,
             override: override,
-            playerId: playerId.toString(),
+            userId: userId,
         });
         if (resetResponse.status === ResponseStatus.ERROR) throw resetResponse.error;
         return true;
@@ -58,10 +58,10 @@ export class ReplayParseService {
     async parseReplays(
         streams: Array<{stream: Readable; filename: string}>,
         submissionId: string,
-        playerId: number,
+        userId: number,
     ): Promise<string[]> {
         const canSubmitReponse = await this.submissionService.send(SubmissionEndpoint.CanSubmitReplays, {
-            playerId: playerId,
+            userId: userId,
             submissionId: submissionId,
         });
         if (canSubmitReponse.status === ResponseStatus.ERROR) throw canSubmitReponse.error;
@@ -85,16 +85,16 @@ export class ReplayParseService {
         const submissionResponse = await this.submissionService.send(SubmissionEndpoint.SubmitReplays, {
             submissionId: submissionId,
             filepaths: filepaths,
-            creatorId: playerId,
+            creatorUserId: userId,
         });
         if (submissionResponse.status === ResponseStatus.ERROR) throw submissionResponse.error;
         // Return taskIds, directly correspond to the files that were uploaded
         return submissionResponse.data;
     }
 
-    async ratifySubmission(submissionId: string, playerId: number): Promise<void> {
+    async ratifySubmission(submissionId: string, userId: number): Promise<void> {
         const canRatifyReponse = await this.submissionService.send(SubmissionEndpoint.CanRatifySubmission, {
-            playerId: playerId,
+            userId: userId,
             submissionId: submissionId,
         });
         if (canRatifyReponse.status === ResponseStatus.ERROR) throw canRatifyReponse.error;
@@ -102,15 +102,15 @@ export class ReplayParseService {
 
         const ratificationResponse = await this.submissionService.send(SubmissionEndpoint.RatifySubmission, {
             submissionId: submissionId,
-            playerId: playerId,
+            userId: userId,
         });
         if (ratificationResponse.status === ResponseStatus.ERROR) throw ratificationResponse.error;
     }
 
-    async rejectSubmissionByPlayer(submissionId: string, playerId: number, reason: string): Promise<void> {
+    async rejectSubmissionByPlayer(submissionId: string, userId: number, reason: string): Promise<void> {
         const rejectionResponse = await this.submissionService.send(SubmissionEndpoint.RejectSubmission, {
             submissionId: submissionId,
-            playerId: playerId,
+            userId: userId,
             reason: reason,
         });
         if (rejectionResponse.status === ResponseStatus.ERROR) throw rejectionResponse.error;

--- a/core/src/internal/replay-parse/types/replay-submission.types.ts
+++ b/core/src/internal/replay-parse/types/replay-submission.types.ts
@@ -21,7 +21,7 @@ export class GqlReplaySubmission {
     id: string;
 
     @Field(() => Int)
-    creatorId: number;
+    creatorUserId: number;
 
     @Field(() => [String])
     taskIds: string[];

--- a/core/src/internal/replay-parse/types/submission-rejection.types.ts
+++ b/core/src/internal/replay-parse/types/submission-rejection.types.ts
@@ -7,7 +7,7 @@ export type RejectedItem = Omit<ReplaySubmissionItem, "progress">;
 @ObjectType()
 export class SubmissionRejection {
     @Field()
-    playerId: number;
+    userId: number;
 
     @Field()
     playerName: string;

--- a/core/src/internal/scheduling/match/match.resolver.ts
+++ b/core/src/internal/scheduling/match/match.resolver.ts
@@ -16,7 +16,7 @@ import {SeriesToMatchParent} from "$bridge/series_to_match_parent.model";
 import type {League} from "$mledb";
 import {LegacyGameMode, MLE_OrganizationTeam, MLE_Series, MLE_SeriesReplay, MLE_Team} from "$mledb";
 import type {GameMode, GameSkillGroup, Round} from "$models";
-import {Franchise, Match, MatchParent, Player, ScheduleFixture, ScheduleGroup} from "$models";
+import {Franchise, Match, MatchParent, Member, Player, ScheduleFixture, ScheduleGroup} from "$models";
 import {MatchRepository, RoundRepository, TeamRepository} from "$repositories";
 import type {MatchSubmissionStatus} from "$types";
 
@@ -33,7 +33,7 @@ export class MatchResolver {
     private readonly logger = new Logger(MatchResolver.name);
 
     constructor(
-        private readonly populate: PopulateService,
+        private readonly populateService: PopulateService,
         private readonly matchService: MatchService,
         private readonly mledbMatchService: MledbMatchService,
         private readonly eventsService: EventsService,
@@ -66,20 +66,20 @@ export class MatchResolver {
             },
         });
 
-        const fixture = await this.populate.populateOne(MatchParent, match.matchParent, "fixture");
+        const fixture = await this.populateService.populateOne(MatchParent, match.matchParent, "fixture");
         if (!fixture) {
             throw new Error("Fixture not found, this may not be league play!");
         }
-        const awayFranchise = await this.populate.populateOneOrFail(ScheduleFixture, fixture, "awayFranchise");
-        const homeFranchise = await this.populate.populateOneOrFail(ScheduleFixture, fixture, "homeFranchise");
+        const awayFranchise = await this.populateService.populateOneOrFail(ScheduleFixture, fixture, "awayFranchise");
+        const homeFranchise = await this.populateService.populateOneOrFail(ScheduleFixture, fixture, "homeFranchise");
 
-        const awayFranchiseProfile = await this.populate.populateOneOrFail(Franchise, awayFranchise, "profile");
-        const homeFranchiseProfile = await this.populate.populateOneOrFail(Franchise, homeFranchise, "profile");
+        const awayFranchiseProfile = await this.populateService.populateOneOrFail(Franchise, awayFranchise, "profile");
+        const homeFranchiseProfile = await this.populateService.populateOneOrFail(Franchise, homeFranchise, "profile");
 
-        const week = await this.populate.populateOneOrFail(ScheduleFixture, fixture, "scheduleGroup");
-        const season = await this.populate.populateOneOrFail(ScheduleGroup, week, "parentGroup");
+        const week = await this.populateService.populateOneOrFail(ScheduleFixture, fixture, "scheduleGroup");
+        const season = await this.populateService.populateOneOrFail(ScheduleGroup, week, "parentGroup");
 
-        const gameMode = await this.populate.populateOneOrFail(Match, match, "gameMode");
+        const gameMode = await this.populateService.populateOneOrFail(Match, match, "gameMode");
 
         const mleSeries = await this.mledbMatchService.getMleSeries(
             awayFranchiseProfile.title,
@@ -337,7 +337,7 @@ export class MatchResolver {
 
     @ResolveField()
     async skillGroup(@Root() match: Partial<Match>): Promise<GameSkillGroup> {
-        return match.skillGroup ?? this.populate.populateOneOrFail(Match, match as Match, "skillGroup");
+        return match.skillGroup ?? this.populateService.populateOneOrFail(Match, match as Match, "skillGroup");
     }
 
     @ResolveField()
@@ -388,8 +388,11 @@ export class MatchResolver {
         if (root.canSubmit) return root.canSubmit;
         if (!root.submissionId) throw new Error(`Match has no submissionId`);
 
+        const member = await this.populateService.populateOneOrFail(Player, player, "member");
+        const user = await this.populateService.populateOneOrFail(Member, member, "user");
+
         const result = await this.submissionService.send(SubmissionEndpoint.CanSubmitReplays, {
-            playerId: player.member.id,
+            userId: user.id,
             submissionId: root.submissionId,
         });
         if (result.status === ResponseStatus.ERROR) throw result.error;
@@ -402,8 +405,11 @@ export class MatchResolver {
         if (root.canRatify) return root.canRatify;
         if (!root.submissionId) throw new Error(`Match has no submissionId`);
 
+        const member = await this.populateService.populateOneOrFail(Player, player, "member");
+        const user = await this.populateService.populateOneOrFail(Member, member, "user");
+
         const result = await this.submissionService.send(SubmissionEndpoint.CanRatifySubmission, {
-            playerId: player.member.id,
+            userId: user.id,
             submissionId: root.submissionId,
         });
         if (result.status === ResponseStatus.ERROR) throw result.error;
@@ -412,16 +418,16 @@ export class MatchResolver {
 
     @ResolveField()
     async gameMode(@Root() match: Partial<Match>): Promise<GameMode | undefined> {
-        return match.gameMode ?? this.populate.populateOne(Match, match as Match, "gameMode");
+        return match.gameMode ?? this.populateService.populateOne(Match, match as Match, "gameMode");
     }
 
     @ResolveField()
     async rounds(@Root() match: Partial<Match>): Promise<Round[]> {
-        return match.rounds ?? this.populate.populateMany(Match, match as Match, "rounds");
+        return match.rounds ?? this.populateService.populateMany(Match, match as Match, "rounds");
     }
 
     @ResolveField()
     async matchParent(@Root() match: Partial<Match>): Promise<MatchParent> {
-        return match.matchParent ?? this.populate.populateOneOrFail(Match, match as Match, "matchParent");
+        return match.matchParent ?? this.populateService.populateOneOrFail(Match, match as Match, "matchParent");
     }
 }

--- a/core/src/internal/scrim/scrim.consumer.ts
+++ b/core/src/internal/scrim/scrim.consumer.ts
@@ -53,7 +53,7 @@ export class ScrimConsumer {
 
         for (const player of playersNotCheckedIn) {
             const member = await this.memberRepository.get({
-                where: {user: {id: player.id}},
+                where: {user: {id: player.userId}},
                 relations: {organization: true},
             });
 

--- a/core/src/internal/scrim/scrim.mod.resolver.ts
+++ b/core/src/internal/scrim/scrim.mod.resolver.ts
@@ -79,6 +79,7 @@ export class ScrimModuleResolver {
         status?: ScrimStatus,
     ): Promise<Scrim[]> {
         const scrims = await this.scrimService.getAllScrims(member.organizationId);
+
         return (status ? scrims.filter(scrim => scrim.status === status) : scrims) as Scrim[];
     }
 
@@ -136,13 +137,13 @@ export class ScrimModuleResolver {
         };
 
         return this.scrimService.createScrim({
-            authorId: user.userId,
+            authorUserId: user.userId,
             organizationId: user.currentOrganizationId,
             gameModeId: gameMode.id,
             skillGroupId: player.skillGroupId,
             settings: settings,
             join: {
-                playerId: user.userId,
+                userId: user.userId,
                 playerName: user.username,
                 leaveAfter: data.leaveAfter,
                 createGroup: data.createGroup,
@@ -180,7 +181,7 @@ export class ScrimModuleResolver {
         try {
             return await this.scrimService.joinScrim({
                 scrimId: scrimId,
-                playerId: user.userId,
+                userId: user.userId,
                 playerName: user.username,
                 leaveAfter: leaveAfter,
                 createGroup: createGroup,
@@ -204,10 +205,10 @@ export class ScrimModuleResolver {
         const scrim = await this.scrimService.getScrimByPlayer(user.userId);
         if (!scrim) throw new GraphQLError("You must be in a scrim to check in");
 
-        const player = scrim.players.find(p => p.id === user.userId);
+        const player = scrim.players.find(p => p.userId === user.userId);
         if (!player) throw new GraphQLError("You must be in a scrim to checkin");
 
-        return this.scrimService.checkIn(player.id, scrim.id);
+        return this.scrimService.checkIn(player.userId, scrim.id);
     }
 
     @Mutation(() => Scrim)

--- a/core/src/internal/scrim/scrim.resolver.ts
+++ b/core/src/internal/scrim/scrim.resolver.ts
@@ -53,11 +53,14 @@ export class ScrimResolver {
 
     @ResolveField(() => String, {nullable: true})
     currentGroup(@Root() scrim: Scrim, @AuthenticatedUser() user: JwtAuthPayload): ScrimGroup | undefined {
-        const code = scrim.players.find(p => p.id === user.userId)?.group;
-        if (!code) return undefined;
+        const scrimPlayer = scrim.players.find(p => p.userId === user.userId);
+        if (!scrimPlayer?.group) return undefined;
+
         return {
-            code: code,
-            players: scrim.players.filter(p => p.group === code && p.id !== user.userId).map(p => p.name),
+            code: scrimPlayer.group,
+            players: scrim.players
+                .filter(p => p.group === scrimPlayer.group && p.userId !== user.userId)
+                .map(p => p.name),
         };
     }
 

--- a/core/src/internal/scrim/scrim.service.ts
+++ b/core/src/internal/scrim/scrim.service.ts
@@ -70,8 +70,8 @@ export class ScrimService {
         throw result.error;
     }
 
-    async getScrimByPlayer(playerId: number): Promise<IScrim | null> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimByPlayer, playerId);
+    async getScrimByPlayer(userId: number): Promise<IScrim | null> {
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimByPlayer, {userId});
         if (result.status === ResponseStatus.SUCCESS) {
             return result.data;
         }
@@ -79,7 +79,7 @@ export class ScrimService {
     }
 
     async getScrimBySubmissionId(submissionId: string): Promise<IScrim | null> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, submissionId);
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, {submissionId});
         if (result.status === ResponseStatus.SUCCESS) {
             return result.data;
         }
@@ -87,7 +87,7 @@ export class ScrimService {
     }
 
     async getScrimById(scrimId: string): Promise<IScrim | null> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, scrimId);
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, {scrimId});
         if (result.status === ResponseStatus.SUCCESS) {
             return result.data;
         }
@@ -108,9 +108,9 @@ export class ScrimService {
         throw result.error;
     }
 
-    async leaveScrim(playerId: number, scrimId: string): Promise<boolean> {
+    async leaveScrim(userId: number, scrimId: string): Promise<boolean> {
         const result = await this.matchmakingService.send(MatchmakingEndpoint.LeaveScrim, {
-            playerId: playerId,
+            userId: userId,
             scrimId: scrimId,
         });
 
@@ -118,8 +118,8 @@ export class ScrimService {
         throw result.error;
     }
 
-    async checkIn(playerId: number, scrimId: string): Promise<boolean> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.CheckInToScrim, {playerId, scrimId});
+    async checkIn(userId: number, scrimId: string): Promise<boolean> {
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.CheckInToScrim, {userId, scrimId});
 
         if (result.status === ResponseStatus.SUCCESS) return result.data;
         throw result.error;
@@ -183,7 +183,7 @@ export class ScrimService {
         // TODO: Refactor after we move to sprocket rosters
         const franchiseProfiles = await Promise.all(
             scrim.players.map(async p => {
-                const mleFranchise = await this.franchiseService.getPlayerFranchises(p.id).catch(() => null);
+                const mleFranchise = await this.franchiseService.getPlayerFranchises(p.userId).catch(() => null);
                 if (!mleFranchise?.length) return undefined;
                 const mleTeam = mleFranchise[0];
 

--- a/core/src/internal/scrim/types/Scrim.ts
+++ b/core/src/internal/scrim/types/Scrim.ts
@@ -42,7 +42,7 @@ export class Scrim implements IScrim {
     status: ScrimStatus;
 
     @Field(() => Int)
-    authorId: number;
+    authorUserId: number;
 
     @Field(() => Int)
     organizationId: number;

--- a/core/src/internal/scrim/types/ScrimPlayer.ts
+++ b/core/src/internal/scrim/types/ScrimPlayer.ts
@@ -4,7 +4,7 @@ import type {ScrimPlayer as IScrimPlayer} from "@sprocketbot/common";
 @ObjectType()
 export class ScrimPlayer implements IScrimPlayer {
     @Field(() => Int)
-    id: number;
+    userId: number;
 
     @Field(() => String)
     name: string;

--- a/core/src/internal/submission/submission.service.ts
+++ b/core/src/internal/submission/submission.service.ts
@@ -17,7 +17,7 @@ export class SubmissionService {
         const result = await this.commonService.send(SubmissionEndpoint.ResetSubmission, {
             submissionId: submissionId,
             override: true,
-            playerId: "-1", // playerId is not used when `override=true`
+            userId: -1, // playerId is not used when `override=true`
         });
 
         if (result.status === ResponseStatus.SUCCESS) return result.data;

--- a/microservices/matchmaking-service/src/scrim/game-order/game-order.service.ts
+++ b/microservices/matchmaking-service/src/scrim/game-order/game-order.service.ts
@@ -71,10 +71,11 @@ export class GameOrderService {
         const output: ScrimGame[] = [];
         const {teamSize, teamCount} = scrim.settings;
         const possibleTeams = createCombinations(scrim.players, teamSize, {
-            sort: (a, b) => a.id - b.id,
+            sort: (a, b) => a.userId - b.userId,
         });
         const possibleGames = createCombinations<ScrimPlayer[]>(possibleTeams, teamCount, {
-            check: ([teamA, teamB]) => teamA.every(playerA => !teamB.find(playerB => playerA.id === playerB.id)),
+            check: ([teamA, teamB]) =>
+                teamA.every(playerA => !teamB.find(playerB => playerA.userId === playerB.userId)),
         });
         shuffle(possibleGames);
         const numGames = 3; // for now

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -15,7 +15,7 @@ export class ScrimCrudService {
     constructor(private readonly redisService: RedisService) {}
 
     async createScrim({
-        authorId,
+        authorUserId,
         organizationId,
         gameModeId,
         skillGroupId,
@@ -30,7 +30,7 @@ export class ScrimCrudService {
             createdAt: at,
             updatedAt: at,
             status: ScrimStatus.PENDING,
-            authorId: authorId,
+            authorUserId: authorUserId,
             organizationId: organizationId,
             gameModeId: gameModeId,
             skillGroupId: skillGroupId,
@@ -98,7 +98,7 @@ export class ScrimCrudService {
 
     async removePlayerFromScrim(scrimId: string, playerId: number): Promise<void> {
         let [players] = await this.redisService.getJson<ScrimPlayer[][]>(`${this.prefix}${scrimId}`, "$.players");
-        players = players.filter(p => p.id !== playerId);
+        players = players.filter(p => p.userId !== playerId);
         await this.redisService.deleteJsonField(`${this.prefix}${scrimId}`, "$.players");
         await this.redisService.setJsonField(`${this.prefix}${scrimId}`, "$.players", players);
         await this.updateScrimUpdatedAt(scrimId);
@@ -106,7 +106,7 @@ export class ScrimCrudService {
 
     async updatePlayer(scrimId: string, player: ScrimPlayer): Promise<void> {
         const [players] = await this.redisService.getJson<ScrimPlayer[][]>(`${this.prefix}${scrimId}`, "$.players");
-        const pi = players.findIndex(p => p.id === player.id);
+        const pi = players.findIndex(p => p.userId === player.userId);
         if (pi === -1) throw new Error("Player not in scrim!");
         players[pi] = player;
         await this.redisService.deleteJsonField(`${this.prefix}${scrimId}`, "$.players");

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -70,7 +70,7 @@ export class ScrimCrudService {
     async getScrimByPlayer(id: number): Promise<Scrim | null> {
         const scrimKeys = await this.redisService.redis.keys(`${this.prefix}*`);
         for (const key of scrimKeys) {
-            const playerIds = await this.redisService.getJson<number[] | null | undefined>(key, "$.players[*].id");
+            const playerIds = await this.redisService.getJson<number[] | null | undefined>(key, "$.players[*].userId");
 
             if (!playerIds) {
                 this.logger.verbose(`GetScrimByPlayer id=${id} key=${key} playerIds is null`);
@@ -117,7 +117,7 @@ export class ScrimCrudService {
     async playerInAnyScrim(playerId: number): Promise<boolean> {
         const scrimKeys = await this.redisService.redis.keys(`${this.prefix}*`);
         const allScrimPlayers = await Promise.all(
-            scrimKeys.map(async k => this.redisService.getJson(k, "$.players[*].id")),
+            scrimKeys.map(async k => this.redisService.getJson(k, "$.players[*].userId")),
         );
         return allScrimPlayers.flat().includes(playerId);
     }

--- a/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
@@ -36,7 +36,7 @@ export class ScrimConsumer {
                     if (scrim.players.length === 1) {
                         await this.scrimService.cancelScrim(scrim.id);
                     } else {
-                        await this.scrimService.leaveScrim(scrim.id, player.id);
+                        await this.scrimService.leaveScrim(scrim.id, player.userId);
                     }
                 }
             }

--- a/microservices/matchmaking-service/src/scrim/scrim.controller.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.controller.ts
@@ -30,7 +30,7 @@ export class ScrimController {
     @MessagePattern(MatchmakingEndpoint.GetScrim)
     async getScrim(@Payload() payload: unknown): Promise<Scrim> {
         const data = MatchmakingSchemas.GetScrim.input.parse(payload);
-        const scrim = await this.scrimCrudService.getScrim(data);
+        const scrim = await this.scrimCrudService.getScrim(data.scrimId);
 
         if (!scrim) throw new RpcException(MatchmakingError.ScrimNotFound);
         return scrim;
@@ -46,14 +46,14 @@ export class ScrimController {
     @MessagePattern(MatchmakingEndpoint.LeaveScrim)
     async leaveScrim(@Payload() payload: unknown): Promise<boolean> {
         const data = MatchmakingSchemas.LeaveScrim.input.parse(payload);
-        await this.scrimService.leaveScrim(data.scrimId, data.playerId);
+        await this.scrimService.leaveScrim(data.scrimId, data.userId);
         return true;
     }
 
     @MessagePattern(MatchmakingEndpoint.CheckInToScrim)
     async checkIn(@Payload() payload: unknown): Promise<boolean> {
         const data = MatchmakingSchemas.CheckInToScrim.input.parse(payload);
-        await this.scrimService.checkIn(data.scrimId, data.playerId);
+        await this.scrimService.checkIn(data.scrimId, data.userId);
         return true;
     }
 
@@ -71,13 +71,13 @@ export class ScrimController {
     @MessagePattern(MatchmakingEndpoint.GetScrimByPlayer)
     async getScrimByPlayer(@Payload() payload: unknown): Promise<Scrim | null> {
         const data = MatchmakingSchemas.GetScrimByPlayer.input.parse(payload);
-        return this.scrimCrudService.getScrimByPlayer(data);
+        return this.scrimCrudService.getScrimByPlayer(data.userId);
     }
 
     @MessagePattern(MatchmakingEndpoint.GetScrimBySubmissionId)
     async getScrimBySubmissionId(@Payload() payload: unknown): Promise<Scrim> {
         const data = MatchmakingSchemas.GetScrimBySubmissionId.input.parse(payload);
-        const result = await this.scrimCrudService.getScrimBySubmissionId(data);
+        const result = await this.scrimCrudService.getScrimBySubmissionId(data.submissionId);
 
         if (!result) throw new RpcException(MatchmakingError.ScrimSubmissionNotFound);
         return result;
@@ -86,7 +86,7 @@ export class ScrimController {
     @MessagePattern(MatchmakingEndpoint.CompleteScrim)
     async completeScrim(@Payload() payload: unknown): Promise<Scrim | null> {
         const data = MatchmakingSchemas.CompleteScrim.input.parse(payload);
-        return this.scrimService.completeScrim(data.scrimId, data.playerId);
+        return this.scrimService.completeScrim(data.scrimId, data.userId);
     }
 
     @MessagePattern(MatchmakingEndpoint.SetScrimLocked)

--- a/microservices/matchmaking-service/src/scrim/scrim.service.spec.helpers.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.spec.helpers.ts
@@ -19,14 +19,14 @@ export function getMockScrimSettings(
 }
 
 export function getMockScrimPlayer(
-    id: number,
+    userId: number,
     name: string,
     joinedAt: Date,
     leaveAt: Date,
     group?: string,
 ): ScrimPlayer {
     return {
-        id,
+        userId,
         name,
         joinedAt,
         leaveAt,
@@ -35,18 +35,18 @@ export function getMockScrimPlayer(
 }
 
 export function getMockScrimIds(
-    authorId = 1,
+    authorUserId = 1,
     organizationId = 1,
     gameModeId = 1,
     skillGroupId = 1,
 ): {
-    authorId: number;
+    authorUserId: number;
     organizationId: number;
     gameModeId: number;
     skillGroupId: number;
 } {
     return {
-        authorId,
+        authorUserId,
         organizationId,
         gameModeId,
         skillGroupId,

--- a/microservices/matchmaking-service/src/scrim/scrim.service.spec.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.spec.ts
@@ -89,7 +89,7 @@ describe("ScrimService", () => {
                 ...getMockScrimIds(),
                 settings: getMockScrimSettings(3, 2, ScrimMode.ROUND_ROBIN, true, false, 1000),
                 join: {
-                    playerId: 1,
+                    userId: 1,
                     playerName: "HyperCoder",
                     leaveAfter: 1000,
                 },
@@ -108,7 +108,7 @@ describe("ScrimService", () => {
                 ...getMockScrimIds(),
                 settings: getMockScrimSettings(3, 2, ScrimMode.ROUND_ROBIN, true, false, 1000),
                 join: {
-                    playerId: 1,
+                    userId: 1,
                     playerName: "HyperCoder",
                     leaveAfter: 1000,
                     createGroup: true,
@@ -128,7 +128,7 @@ describe("ScrimService", () => {
                 ...getMockScrimIds(),
                 settings: getMockScrimSettings(3, 2, ScrimMode.ROUND_ROBIN, true, false, 1000),
                 join: {
-                    playerId: 1,
+                    userId: 1,
                     playerName: "HyperCoder",
                     leaveAfter: 1000,
                 },
@@ -151,13 +151,13 @@ describe("ScrimService", () => {
 
             expect(actual).toEqual(expected);
             expect(crudCreateScrim).toHaveBeenCalledWith({
-                authorId: expected.authorId,
+                authorUserId: expected.authorUserId,
                 organizationId: expected.organizationId,
                 gameModeId: expected.gameModeId,
                 skillGroupId: expected.skillGroupId,
                 settings: expected.settings,
                 player: {
-                    id: createScrimData.join?.playerId,
+                    userId: createScrimData.join?.userId,
                     name: createScrimData.join?.playerName,
                     joinedAt: expect.any(Date) as Date,
                     leaveAt: expect.any(Date) as Date,
@@ -170,7 +170,7 @@ describe("ScrimService", () => {
                 ...getMockScrimIds(),
                 settings: getMockScrimSettings(3, 2, ScrimMode.TEAMS, true, false, 1000),
                 join: {
-                    playerId: 1,
+                    userId: 1,
                     playerName: "HyperCoder",
                     leaveAfter: 1000,
                     createGroup: true,
@@ -200,13 +200,13 @@ describe("ScrimService", () => {
 
             expect(actual).toEqual(expected);
             expect(crudCreateScrim).toHaveBeenCalledWith({
-                authorId: expected.authorId,
+                authorUserId: expected.authorUserId,
                 organizationId: expected.organizationId,
                 gameModeId: expected.gameModeId,
                 skillGroupId: expected.skillGroupId,
                 settings: expected.settings,
                 player: {
-                    id: createScrimData.join?.playerId,
+                    userId: createScrimData.join?.userId,
                     name: createScrimData.join?.playerName,
                     joinedAt: expect.any(Date) as Date,
                     leaveAt: expect.any(Date) as Date,
@@ -214,7 +214,7 @@ describe("ScrimService", () => {
                 },
             });
             expect(crudUpdatePlayer).toHaveBeenCalledWith(scrim.id, {
-                id: createScrimData.join?.playerId,
+                userId: createScrimData.join?.userId,
                 name: createScrimData.join?.playerName,
                 joinedAt: expect.any(Date) as Date,
                 leaveAt: expect.any(Date) as Date,
@@ -227,7 +227,7 @@ describe("ScrimService", () => {
         it("Should throw with ScrimNotFound when a player tries to join a scrim that doesn't exist", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!!!!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
             };
@@ -243,7 +243,7 @@ describe("ScrimService", () => {
         it("Should throw with ScrimAlreadyInProgress when a player tries to join a scrim when it is already in progress", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
             };
@@ -269,7 +269,7 @@ describe("ScrimService", () => {
         it("Should throw with PlayerAlreadyInScrim when a player tries to join a scrim when they are already in a scrim", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
             };
@@ -296,7 +296,7 @@ describe("ScrimService", () => {
         it("Should throw with GroupNotFound when a player tries to join a group with an invalid group", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
                 joinGroup: "tekssxisawful",
@@ -324,7 +324,7 @@ describe("ScrimService", () => {
         it("Should throw with GroupFull when a player tries to join a group when the group has the number of players on a team", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
                 joinGroup: "tekssxisbad",
@@ -355,7 +355,7 @@ describe("ScrimService", () => {
         it("Should throw with MaxGroupsCreated when a player tries to create a group when there are already the number teams being the number of groups", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
                 createGroup: true,
@@ -386,7 +386,7 @@ describe("ScrimService", () => {
         it("Player should join the scrim successfully", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
             };
@@ -417,7 +417,7 @@ describe("ScrimService", () => {
 
             expect(actual).toEqual(expected);
             expect(crudAddPlayerToScrim).toHaveBeenCalledWith(scrim.id, {
-                id: joinScrimData.playerId,
+                userId: joinScrimData.userId,
                 name: joinScrimData.playerName,
                 joinedAt: expect.any(Date) as Date,
                 leaveAt: expect.any(Date) as Date,
@@ -427,7 +427,7 @@ describe("ScrimService", () => {
         it("Player should join the scrim and group successfully", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 2,
+                userId: 2,
                 playerName: "tekssx",
                 leaveAfter: 1000,
                 joinGroup: "tekssxisbad",
@@ -459,7 +459,7 @@ describe("ScrimService", () => {
 
             expect(actual).toEqual(expected);
             expect(crudAddPlayerToScrim).toHaveBeenCalledWith(scrim.id, {
-                id: joinScrimData.playerId,
+                userId: joinScrimData.userId,
                 name: joinScrimData.playerName,
                 joinedAt: expect.any(Date) as Date,
                 leaveAt: expect.any(Date) as Date,
@@ -470,7 +470,7 @@ describe("ScrimService", () => {
         it("The scrim should pop when the last player joins and it is full", async () => {
             const joinScrimData: JoinScrimOptions = {
                 scrimId: "hello world!",
-                playerId: 4,
+                userId: 4,
                 playerName: "Nigel Thornbrake",
                 leaveAfter: 1000,
             };
@@ -535,7 +535,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
 
             const func = async (): Promise<Scrim> =>
-                service.leaveScrim("hello world!", mockPlayerFactories.shuckle(someDate).id);
+                service.leaveScrim("hello world!", mockPlayerFactories.shuckle(someDate).userId);
             const expectedError = MatchmakingError.ScrimAlreadyInProgress;
 
             await expect(func).rejects.toThrow(expectedError);
@@ -556,7 +556,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
 
             const func = async (): Promise<Scrim> =>
-                service.leaveScrim("hello world!", mockPlayerFactories.tekssx(someDate).id);
+                service.leaveScrim("hello world!", mockPlayerFactories.tekssx(someDate).userId);
             const expectedError = MatchmakingError.PlayerNotInScrim;
 
             await expect(func).rejects.toThrow(expectedError);
@@ -577,7 +577,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
             logicDeleteScrim.mockResolvedValueOnce({});
 
-            const actual = await service.leaveScrim("hello world!", mockPlayerFactories.hyper(someDate).id);
+            const actual = await service.leaveScrim("hello world!", mockPlayerFactories.hyper(someDate).userId);
             const expected: Scrim = {
                 ...scrim,
                 players: [],
@@ -603,7 +603,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
             crudRemovePlayerFromScrim.mockResolvedValueOnce({});
 
-            const actual = await service.leaveScrim("hello world!", mockPlayerFactories.shuckle(someDate).id);
+            const actual = await service.leaveScrim("hello world!", mockPlayerFactories.shuckle(someDate).userId);
             const expected: Scrim = {
                 ...scrim,
                 players: [mockPlayerFactories.hyper(someDate)],
@@ -611,7 +611,10 @@ describe("ScrimService", () => {
 
             expect(actual).toStrictEqual(expected);
             expect(logicDeleteScrim).toHaveBeenCalledTimes(0);
-            expect(crudRemovePlayerFromScrim).toHaveBeenCalledWith(scrim.id, mockPlayerFactories.shuckle(someDate).id);
+            expect(crudRemovePlayerFromScrim).toHaveBeenCalledWith(
+                scrim.id,
+                mockPlayerFactories.shuckle(someDate).userId,
+            );
         });
     });
 
@@ -649,7 +652,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
 
             const func = async (): Promise<Scrim> =>
-                service.checkIn(scrim.id, mockPlayerFactories.shuckle(someDate).id);
+                service.checkIn(scrim.id, mockPlayerFactories.shuckle(someDate).userId);
             const expectedError = MatchmakingError.PlayerNotInScrim;
 
             await expect(func).rejects.toThrow(expectedError);
@@ -670,7 +673,8 @@ describe("ScrimService", () => {
 
             crudGetScrim.mockResolvedValueOnce(scrim);
 
-            const func = async (): Promise<Scrim> => service.checkIn(scrim.id, mockPlayerFactories.tekssx(someDate).id);
+            const func = async (): Promise<Scrim> =>
+                service.checkIn(scrim.id, mockPlayerFactories.tekssx(someDate).userId);
             const expectedError = MatchmakingError.PlayerAlreadyCheckedIn;
 
             await expect(func).rejects.toThrow(expectedError);
@@ -713,7 +717,7 @@ describe("ScrimService", () => {
             publishScrimUpdate.mockReset();
             publishScrimUpdate.mockResolvedValueOnce(expected);
 
-            const func = await service.checkIn(scrim.id, mockPlayerFactories.hyper(someDate).id);
+            const func = await service.checkIn(scrim.id, mockPlayerFactories.hyper(someDate).userId);
 
             expect(func).toEqual(expected);
             expect(crudUpdatePlayer).toHaveBeenCalledWith(scrim.id, {
@@ -757,7 +761,7 @@ describe("ScrimService", () => {
             publishScrimUpdate.mockReset();
             publishScrimUpdate.mockResolvedValueOnce(expected);
 
-            const actual = await service.checkIn(scrim.id, mockPlayerFactories.hyper(someDate).id);
+            const actual = await service.checkIn(scrim.id, mockPlayerFactories.hyper(someDate).userId);
 
             expect(actual).toEqual(expected);
             expect(crudUpdatePlayer).toHaveBeenCalledWith(scrim.id, {
@@ -831,7 +835,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
 
             const func = async (): Promise<Scrim> =>
-                service.completeScrim(scrim.id, mockPlayerFactories.shuckle(someDate).id);
+                service.completeScrim(scrim.id, mockPlayerFactories.shuckle(someDate).userId);
             const expectedError = MatchmakingError.PlayerNotInScrim;
 
             await expect(func).rejects.toThrow(expectedError);
@@ -847,7 +851,7 @@ describe("ScrimService", () => {
             crudGetScrim.mockResolvedValueOnce(scrim);
             crudRemoveScrim.mockResolvedValueOnce({});
 
-            const actual = await service.completeScrim(scrim.id, mockPlayerFactories.hyper(someDate).id);
+            const actual = await service.completeScrim(scrim.id, mockPlayerFactories.hyper(someDate).userId);
             const expected = {
                 ...scrim,
                 status: ScrimStatus.COMPLETE,

--- a/microservices/notification-service/src/scrim/scrim.service.ts
+++ b/microservices/notification-service/src/scrim/scrim.service.ts
@@ -54,7 +54,7 @@ export class ScrimService extends SprocketEventMarshal {
         await this.botService.send(BotEndpoint.SendWebhookMessage, {
             webhookUrl: skillGroupWebhook.data.scrim,
             payload: {
-                content: skillGroupWebhook.data.scrimRole ? `<@&${skillGroupWebhook.data.scrimRole}>` : "",
+                // content: skillGroupWebhook.data.scrimRole ? `<@&${skillGroupWebhook.data.scrimRole}>` : undefined,
                 embeds: [
                     {
                         title: "Scrim Created",

--- a/microservices/notification-service/src/scrim/scrim.service.ts
+++ b/microservices/notification-service/src/scrim/scrim.service.ts
@@ -94,7 +94,7 @@ export class ScrimService extends SprocketEventMarshal {
 
         await Promise.all(
             scrim.players.map(async p => {
-                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.id);
+                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.userId);
                 if (userResult.status === ResponseStatus.ERROR) throw userResult.error;
                 if (!userResult.data) return;
 
@@ -157,7 +157,7 @@ export class ScrimService extends SprocketEventMarshal {
 
         await Promise.all(
             scrim.players.map(async p => {
-                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.id);
+                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.userId);
                 if (userResult.status === ResponseStatus.ERROR) throw userResult.error;
                 if (!userResult.data) return;
 
@@ -232,7 +232,7 @@ export class ScrimService extends SprocketEventMarshal {
 
         const discordUserIds = await Promise.all(
             scrim.players.map(async player => {
-                const discordUserResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, player.id);
+                const discordUserResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, player.userId);
                 if (discordUserResult.status !== ResponseStatus.SUCCESS) return undefined;
 
                 return discordUserResult.data;
@@ -312,7 +312,7 @@ export class ScrimService extends SprocketEventMarshal {
     }
 
     async getScrim(scrimId: string): Promise<Scrim | null> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, scrimId);
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, {scrimId});
         if (result.status === ResponseStatus.SUCCESS) {
             return result.data;
         }

--- a/microservices/notification-service/src/submission/submission.service.ts
+++ b/microservices/notification-service/src/submission/submission.service.ts
@@ -65,7 +65,9 @@ export class SubmissionService extends SprocketEventMarshal {
     }
 
     async sendScrimSubmissionRatifyingNotifications(submission: ScrimReplaySubmission): Promise<void> {
-        const scrimResult = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, submission.scrimId);
+        const scrimResult = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, {
+            scrimId: submission.scrimId,
+        });
         if (scrimResult.status === ResponseStatus.ERROR) throw scrimResult.error;
 
         const scrim = scrimResult.data;
@@ -78,7 +80,7 @@ export class SubmissionService extends SprocketEventMarshal {
 
         await Promise.all(
             scrim.players.map(async p => {
-                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.id);
+                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.userId);
                 if (userResult.status === ResponseStatus.ERROR || !userResult.data) return;
 
                 await this.botService.send(BotEndpoint.SendDirectMessage, {
@@ -213,7 +215,9 @@ export class SubmissionService extends SprocketEventMarshal {
     }
 
     async sendScrimSubmissionRejectedNotifications(submission: ScrimReplaySubmission): Promise<void> {
-        const scrimResult = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, submission.scrimId);
+        const scrimResult = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, {
+            scrimId: submission.scrimId,
+        });
         if (scrimResult.status === ResponseStatus.ERROR) throw scrimResult.error;
 
         const scrim = scrimResult.data;
@@ -226,7 +230,7 @@ export class SubmissionService extends SprocketEventMarshal {
 
         await Promise.all(
             scrim.players.map(async p => {
-                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.id);
+                const userResult = await this.coreService.send(CoreEndpoint.GetDiscordIdByUser, p.userId);
                 if (userResult.status === ResponseStatus.ERROR) throw userResult.error;
                 if (!userResult.data) return;
 

--- a/microservices/submission-service/src/replay-submission/replay-submission-crud/replay-submission-crud.controller.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-crud/replay-submission-crud.controller.ts
@@ -37,6 +37,6 @@ export class ReplaySubmissionCrudController {
     ): Promise<SubmissionOutput<SubmissionEndpoint.GetSubmissionRejections>> {
         const data = SubmissionSchemas.RemoveSubmission.input.parse(payload);
         const rejections = await this.crudService.getSubmissionRejections(data.submissionId);
-        return rejections.map(r => r.playerId.toString());
+        return rejections.map(r => r.userId);
     }
 }

--- a/microservices/submission-service/src/replay-submission/replay-submission-ratification/replay-submission-ratification.controller.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-ratification/replay-submission-ratification.controller.ts
@@ -11,21 +11,21 @@ export class ReplaySubmissionRatificationController {
     @MessagePattern(SubmissionEndpoint.ResetSubmission)
     async resetSubmission(@Payload() payload: unknown): Promise<true> {
         const data = SubmissionSchemas.ResetSubmission.input.parse(payload);
-        await this.ratificationService.resetSubmission(data.submissionId, data.override, data.playerId);
+        await this.ratificationService.resetSubmission(data.submissionId, data.override, data.userId);
         return true;
     }
 
     @MessagePattern(SubmissionEndpoint.RatifySubmission)
     async ratifySubmission(@Payload() payload: unknown): Promise<true> {
         const data = SubmissionSchemas.RatifySubmission.input.parse(payload);
-        await this.ratificationService.ratifyScrim(data.playerId, data.submissionId);
+        await this.ratificationService.ratifyScrim(data.userId, data.submissionId);
         return true;
     }
 
     @MessagePattern(SubmissionEndpoint.RejectSubmission)
     async rejectSubmission(@Payload() payload: unknown): Promise<true> {
         const data = SubmissionSchemas.RejectSubmission.input.parse(payload);
-        await this.ratificationService.rejectSubmission(data.playerId, data.submissionId, [data.reason]);
+        await this.ratificationService.rejectSubmission(data.userId, data.submissionId, [data.reason]);
         return true;
     }
 }

--- a/microservices/submission-service/src/replay-submission/replay-submission-ratification/replay-submission-ratification.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-ratification/replay-submission-ratification.service.ts
@@ -21,20 +21,18 @@ export class ReplaySubmissionRatificationService {
         private readonly matchmakingService: MatchmakingService,
     ) {}
 
-    async resetSubmission(submissionId: string, override: boolean, playerId: string): Promise<void> {
+    async resetSubmission(submissionId: string, override: boolean, playerId: number): Promise<void> {
         if (!override) {
             if (submissionIsScrim(submissionId)) {
-                const scrimResponse = await this.matchmakingService.send(
-                    MatchmakingEndpoint.GetScrimBySubmissionId,
+                const scrimResponse = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, {
                     submissionId,
-                );
+                });
                 if (scrimResponse.status === ResponseStatus.ERROR || !scrimResponse.data) {
                     if (scrimResponse.status === ResponseStatus.ERROR) this.logger.error(scrimResponse.error);
                     throw new Error("Error fetching scrim");
                 }
                 const scrim = scrimResponse.data;
-                if (!scrim.players.some(p => p.id.toString() === playerId))
-                    throw new Error("You cannot reset this scrim");
+                if (!scrim.players.some(p => p.userId === playerId)) throw new Error("You cannot reset this scrim");
             }
         }
 

--- a/microservices/submission-service/src/replay-submission/replay-submission-util.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-util.service.ts
@@ -30,7 +30,7 @@ export class ReplaySubmissionUtilService {
         return submission.ratifiers.length >= submission.requiredRatifications;
     }
 
-    async canSubmitReplays(submissionId: string, playerId: number): Promise<ICanSubmitReplays_Response> {
+    async canSubmitReplays(submissionId: string, userId: number): Promise<ICanSubmitReplays_Response> {
         const submission = await this.submissionCrudService.getSubmission(submissionId);
 
         if (submission?.items.length) {
@@ -41,7 +41,9 @@ export class ReplaySubmissionUtilService {
         }
 
         if (submissionIsScrim(submissionId)) {
-            const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, submissionId);
+            const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, {
+                submissionId,
+            });
             if (result.status === ResponseStatus.ERROR) throw result.error;
             const scrim = result.data;
             if (!scrim)
@@ -49,7 +51,7 @@ export class ReplaySubmissionUtilService {
                     canSubmit: false,
                     reason: `Could not find a associated scrim`,
                 };
-            if (!scrim.players.some(p => p.id === playerId)) {
+            if (!scrim.players.some(p => p.userId === userId)) {
                 // TODO: Check player's organization teams (i.e. Support override)
                 return {
                     canSubmit: false,
@@ -76,7 +78,7 @@ export class ReplaySubmissionUtilService {
                 };
             const {homeFranchise, awayFranchise} = match;
 
-            const franchiseResult = await this.coreService.send(CoreEndpoint.GetPlayerFranchises, {memberId: playerId});
+            const franchiseResult = await this.coreService.send(CoreEndpoint.GetPlayerFranchises, {memberId: userId});
             if (franchiseResult.status === ResponseStatus.ERROR) throw franchiseResult.error;
             const franchises = franchiseResult.data;
             const targetFranchise = franchises.find(
@@ -86,7 +88,7 @@ export class ReplaySubmissionUtilService {
             if (!targetFranchise) {
                 // TODO: Check for LO Override
                 this.logger.log(
-                    `Player ${playerId} is on ${franchises.map(f => f.name).join(", ")}, not on expected franchises ${
+                    `Player ${userId} is on ${franchises.map(f => f.name).join(", ")}, not on expected franchises ${
                         homeFranchise.name
                     }, ${awayFranchise.name}`,
                 );
@@ -115,7 +117,7 @@ export class ReplaySubmissionUtilService {
         return {canSubmit: true};
     }
 
-    async canRatifySubmission(submissionId: string, playerId: number): Promise<CanRatifySubmissionResponse> {
+    async canRatifySubmission(submissionId: string, userId: number): Promise<CanRatifySubmissionResponse> {
         const submission = await this.submissionCrudService.getSubmission(submissionId);
 
         if (!submission) {
@@ -133,7 +135,9 @@ export class ReplaySubmissionUtilService {
         }
 
         if (submissionIsScrim(submissionId)) {
-            const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, submissionId);
+            const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, {
+                submissionId,
+            });
             if (result.status === ResponseStatus.ERROR) throw result.error;
             const scrim = result.data;
             if (!scrim)
@@ -141,7 +145,7 @@ export class ReplaySubmissionUtilService {
                     canRatify: false,
                     reason: `Could not find a associated scrim`,
                 };
-            if (!scrim.players.some(p => p.id === playerId)) {
+            if (!scrim.players.some(p => p.userId === userId)) {
                 // TODO: Check player's organization teams (i.e. Support override)
                 return {
                     canRatify: false,
@@ -168,7 +172,7 @@ export class ReplaySubmissionUtilService {
                 };
             const {homeFranchise, awayFranchise} = match;
 
-            const franchiseResult = await this.coreService.send(CoreEndpoint.GetPlayerFranchises, {memberId: playerId});
+            const franchiseResult = await this.coreService.send(CoreEndpoint.GetPlayerFranchises, {memberId: userId});
             if (franchiseResult.status === ResponseStatus.ERROR) throw franchiseResult.error;
             const franchises = franchiseResult.data;
             const targetFranchise = franchises.find(
@@ -178,7 +182,7 @@ export class ReplaySubmissionUtilService {
             if (!targetFranchise) {
                 // TODO: Check for LO Override
                 this.logger.log(
-                    `Player ${playerId} is on ${franchises.map(f => f.name).join(", ")}, not on expected franchises ${
+                    `Player ${userId} is on ${franchises.map(f => f.name).join(", ")}, not on expected franchises ${
                         homeFranchise.name
                     }, ${awayFranchise.name}`,
                 );

--- a/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
+++ b/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
@@ -17,19 +17,19 @@ export class ReplayUploadController {
     @MessagePattern(SubmissionEndpoint.CanSubmitReplays)
     async canSubmitReplays(@Payload() payload: unknown): Promise<ICanSubmitReplays_Response> {
         const data = SubmissionSchemas.CanSubmitReplays.input.parse(payload);
-        return this.replaySubmissionUtilService.canSubmitReplays(data.submissionId, data.playerId);
+        return this.replaySubmissionUtilService.canSubmitReplays(data.submissionId, data.userId);
     }
 
     @MessagePattern(SubmissionEndpoint.CanRatifySubmission)
     async canRatifySubmission(@Payload() payload: unknown): Promise<CanRatifySubmissionResponse> {
         const data = SubmissionSchemas.CanRatifySubmission.input.parse(payload);
-        return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.playerId);
+        return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.userId);
     }
 
     @MessagePattern(SubmissionEndpoint.SubmitReplays)
     async submitReplays(@Payload() payload: unknown): Promise<string[]> {
         const data = SubmissionSchemas.SubmitReplays.input.parse(payload);
-        return this.replaySubmissionService.beginSubmission(data.filepaths, data.submissionId, data.creatorId);
+        return this.replaySubmissionService.beginSubmission(data.filepaths, data.submissionId, data.creatorUserId);
     }
 
     @MessagePattern(SubmissionEndpoint.GetSubmissionRedisKey)

--- a/microservices/submission-service/src/replay-validation/replay-validation.service.ts
+++ b/microservices/submission-service/src/replay-validation/replay-validation.service.ts
@@ -40,7 +40,9 @@ export class ReplayValidationService {
     }
 
     private async validateScrimSubmission(submission: ScrimReplaySubmission): Promise<ValidationResult> {
-        const scrimResponse = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, submission.scrimId);
+        const scrimResponse = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, {
+            scrimId: submission.scrimId,
+        });
         if (scrimResponse.status === ResponseStatus.ERROR) throw scrimResponse.error;
         if (!scrimResponse.data) throw new Error("Scrim not found");
 
@@ -182,7 +184,7 @@ export class ReplayValidationService {
 
         const players = playersResponse.data as GetPlayerSuccessResponse[];
         // Get 3D array of scrim player ids
-        const scrimPlayerIds = scrim.games.map(g => g.teams.map(t => t.players.map(p => p.id)));
+        const scrimPlayerIds = scrim.games.map(g => g.teams.map(t => t.players.map(p => p.userId)));
 
         // Get 3D array of submission player ids
         const submissionUserIds = stats.map(s =>


### PR DESCRIPTION
- Changed generic "id" to "userId" to make sure we know what Id something is referring to.