### PR TITLE
fix: passing-skill-group-to-GetAllScrims [CU-#43gnqpb]

### DIFF
--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -61,7 +61,7 @@ export class ScrimCrudService {
         );
 
         if (skillGroupIds)
-            scrims = scrims.filter(scrim => skillGroupIds.includes(scrim.skillGroupId) && !scrim.settings.competitive);
+            scrims = scrims.filter(scrim => skillGroupIds.includes(scrim.skillGroupId) || !scrim.settings.competitive);
         if (organizationId) scrims = scrims.filter(scrim => scrim.organizationId === organizationId);
 
         return scrims;


### PR DESCRIPTION
Fixes a bug where passing a skill group to GetAllScrims returns an array as empty. 