### PR TITLE
feat: default token

### DIFF
--- a/common/src/util/config.ts
+++ b/common/src/util/config.ts
@@ -242,4 +242,7 @@ export const config = {
     get defaultOrganizationId(): number {
         return _config.get<number>("defaultOrganizationId");
     },
+    get defaultAuthToken(): string | undefined {
+        if (_config.has("defaultAuthToken")) return _config.get<string>("defaultAuthToken");
+    },
 };

--- a/core/config/default.json
+++ b/core/config/default.json
@@ -1,70 +1,76 @@
 {
-  "transport": {
-    "url": "",
-    "core_queue": "dev-core",
-    "bot_queue": "dev-bot",
-    "analytics_queue": "dev-analytics",
-    "events_queue": "dev-events",
-    "matchmaking_queue": "dev-matchmaking",
-    "image_generation_queue": "dev-ig",
-    "celery-queue": "dev-celery",
-    "submission_queue": "dev-submissions",
-    "notification_queue": "dev-notification"
-  },
-  "logger": {
-    "levels": true
-  },
-  "db": {
-    "host": "",
-    "port": "",
-    "username": "",
-    "database": "",
-    "enable_logs": false
-  },
-  "minio": {
-    "endPoint": "",
-    "port": 80,
-    "bucketNames": {
-      "replays": "",
-      "image_generation": ""
-    }
-  },
-  "celery": {
-    "broker": "",
-    "backend": "",
-    "queue": ""
-  },
-  "web": {
-    "url": "",
-    "api_root": ""
-  },
-  "gql": {
-    "playground": false
-  },
-  "auth": {
-    "google": {
-      "callbackUrl": ""
+    "transport": {
+        "url": "",
+        "events_application_key": "sprocket-core",
+        "core_queue": "dev-core",
+        "bot_queue": "dev-bot",
+        "analytics_queue": "dev-analytics",
+        "events_queue": "dev-events",
+        "matchmaking_queue": "dev-matchmaking",
+        "image_generation_queue": "dev-ig",
+        "celery-queue": "dev-celery",
+        "submission_queue": "dev-submissions",
+        "notification_queue": "dev-notification"
     },
-    "discord": {
-      "callbackUrl": ""
+    "logger": {
+        "levels": true
     },
-    "epic": {
-      "callbackUrl": ""
+    "db": {
+        "host": "",
+        "port": "",
+        "username": "",
+        "database": "",
+        "enable_logs": false
     },
-    "steam": {
-      "callbackUrl": "",
-      "realm": ""
+    "minio": {
+        "endPoint": "",
+        "port": 80,
+        "bucketNames": {
+            "replays": "",
+            "image_generation": ""
+        }
     },
-    "jwt_expiry": "",
-    "access_expiry": "6h",
-    "refresh_expiry": "7d",
-    "frontend_callback": ""
-  },
-  "redis": {
-    "port": 80,
-    "host": "",
-    "prefix": "",
-    "secure": true
-  },
-  "defaultOrganizationId": 2
+    "celery": {
+        "broker": "",
+        "backend": "",
+        "queue": ""
+    },
+    "web": {
+        "url": "",
+        "api_root": ""
+    },
+    "gql": {
+        "playground": false
+    },
+    "auth": {
+        "google": {
+            "callbackUrl": ""
+        },
+        "microsoft": {
+            "callbackUrl": ""
+        },
+        "xbox": {
+            "callbackUrl": ""
+        },
+        "discord": {
+            "callbackUrl": ""
+        },
+        "epic": {
+            "callbackUrl": ""
+        },
+        "steam": {
+            "callbackUrl": "",
+            "realm": ""
+        },
+        "jwt_expiry": "",
+        "frontend_callback": ""
+    },
+    "redis": {
+        "port": 80,
+        "host": "",
+        "prefix": "",
+        "secure": true
+    },
+    "defaultOrganizationId": 2,
+    "defaultAuthToken": ""
 }

--- a/core/src/authentication/strategies/jwt/jwt.strategy.ts
+++ b/core/src/authentication/strategies/jwt/jwt.strategy.ts
@@ -1,16 +1,22 @@
 import {Injectable} from "@nestjs/common";
 import {PassportStrategy} from "@nestjs/passport";
 import {config} from "@sprocketbot/common";
+import type {Request} from "express";
 import {ExtractJwt, Strategy} from "passport-jwt";
 
 import type {JwtPayload} from "./jwt.types";
 import {JwtPayloadSchema} from "./jwt.types";
 
+function fromAuthHeaderOrConfig(req: Request): string | undefined {
+    const tokenFromHeader = ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+    return tokenFromHeader ?? config.defaultAuthToken;
+}
+
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
     constructor() {
         super({
-            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            jwtFromRequest: config.defaultAuthToken ? fromAuthHeaderOrConfig : ExtractJwt.fromAuthHeaderAsBearerToken(),
             ignoreExpiration: false,
             secretOrKey: config.auth.jwt.secret,
         });


### PR DESCRIPTION
Allows you to set a token in your configuration file to authenticate for all requests without needing to set a token. Useful for testing subscriptions because you cannot provide authentication tokens in GQL Playground or Altair. Defaults to the token in the header before trying to use the config token so you can have "multiple users".