### PR TITLE
Fix: Some franchise staff unable to submit or ratify matches

### DIFF
--- a/core/src/franchise/franchise/franchise.service.ts
+++ b/core/src/franchise/franchise/franchise.service.ts
@@ -41,7 +41,7 @@ export class FranchiseService {
     memberId: number
   ): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
     const member = await this.sprocketMemberService.getMemberById(memberId);
-    const userId = member.userId;
+    const { userId } = member;
     const mlePlayer = await this.mledbPlayerService.getMlePlayerBySprocketUser(
       userId
     );

--- a/core/src/franchise/franchise/franchise.service.ts
+++ b/core/src/franchise/franchise/franchise.service.ts
@@ -1,65 +1,80 @@
-import {
-    forwardRef, Inject, Injectable,
-} from "@nestjs/common";
-import {InjectRepository} from "@nestjs/typeorm";
-import type {CoreEndpoint, CoreOutput} from "@sprocketbot/common";
-import type {FindOneOptions} from "typeorm";
-import {Repository} from "typeorm";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import type { CoreEndpoint, CoreOutput } from "@sprocketbot/common";
+import type { FindOneOptions } from "typeorm";
+import { Repository } from "typeorm";
 
-import type {FranchiseProfile} from "../../database";
-import {Franchise} from "../../database";
-import {MledbPlayerService} from "../../mledb";
+import type { FranchiseProfile } from "../../database";
+import { Franchise } from "../../database";
+import { MledbPlayerService } from "../../mledb";
+import { MemberService } from "../../organization";
 
 @Injectable()
 export class FranchiseService {
-    constructor(
-        @InjectRepository(Franchise) private readonly franchiseRepository: Repository<Franchise>,
-        @Inject(forwardRef(() => MledbPlayerService)) private readonly mledbPlayerService: MledbPlayerService,
-    ) {}
+  constructor(
+    @InjectRepository(Franchise)
+    private readonly franchiseRepository: Repository<Franchise>,
+    @Inject(forwardRef(() => MledbPlayerService))
+    private readonly mledbPlayerService: MledbPlayerService,
+    private readonly sprocketMemberService: MemberService
+  ) {}
 
-    async getFranchiseProfile(franchiseId: number): Promise<FranchiseProfile> {
-        const franchise = await this.franchiseRepository.findOneOrFail({
-            where: {id: franchiseId},
-            relations: ["profile"],
-        });
-        return franchise.profile;
+  async getFranchiseProfile(franchiseId: number): Promise<FranchiseProfile> {
+    const franchise = await this.franchiseRepository.findOneOrFail({
+      where: { id: franchiseId },
+      relations: ["profile"],
+    });
+    return franchise.profile;
+  }
+
+  async getFranchiseById(franchiseId: number): Promise<Franchise> {
+    return this.franchiseRepository.findOneOrFail({
+      where: { id: franchiseId },
+    });
+  }
+
+  async getFranchise(query: FindOneOptions<Franchise>): Promise<Franchise> {
+    return this.franchiseRepository.findOneOrFail(query);
+  }
+
+  async getPlayerFranchises(
+    memberId: number
+  ): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
+    const member = await this.sprocketMemberService.getMemberById(memberId);
+    const userId = member.userId;
+    const mlePlayer = await this.mledbPlayerService.getMlePlayerBySprocketUser(
+      userId
+    );
+
+    const playerId = mlePlayer.id;
+
+    const team = await this.mledbPlayerService.getPlayerFranchise(playerId);
+    const isCaptain = await this.mledbPlayerService.playerIsCaptain(playerId);
+
+    const staffPositions: Array<{ id: number; name: string }> = [];
+
+    if (team.franchiseManagerId === playerId) {
+      staffPositions.push({ id: 0, name: "FM" });
+    }
+    if (team.generalManagerId === playerId) {
+      staffPositions.push({ id: 0, name: "GM" });
+    }
+    if (
+      team.doublesAssistantGeneralManagerId === playerId ||
+      team.standardAssistantGeneralManagerId === playerId
+    ) {
+      staffPositions.push({ id: 0, name: "AGM" });
+    }
+    if (isCaptain) {
+      staffPositions.push({ id: 0, name: "CAP" });
     }
 
-    async getFranchiseById(franchiseId: number): Promise<Franchise> {
-        return this.franchiseRepository.findOneOrFail({where: {id: franchiseId} });
-    }
-
-    async getFranchise(query: FindOneOptions<Franchise>): Promise<Franchise> {
-        return this.franchiseRepository.findOneOrFail(query);
-    }
-
-    async getPlayerFranchises(userId: number): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
-        const mlePlayer = await this.mledbPlayerService.getMlePlayerBySprocketUser(userId);
-
-        const playerId = mlePlayer.id;
-
-        const team = await this.mledbPlayerService.getPlayerFranchise(playerId);
-        const isCaptain = await this.mledbPlayerService.playerIsCaptain(playerId);
-
-        const staffPositions: Array<{id: number; name: string;}> = [];
-
-        if (team.franchiseManagerId === playerId) {
-            staffPositions.push({id: 0, name: "FM"});
-        }
-        if (team.generalManagerId === playerId) {
-            staffPositions.push({id: 0, name: "GM"});
-        }
-        if (team.doublesAssistantGeneralManagerId === playerId || team.standardAssistantGeneralManagerId === playerId) {
-            staffPositions.push({id: 0, name: "AGM"});
-        }
-        if (isCaptain) {
-            staffPositions.push({id: 0, name: "CAP"});
-        }
-
-        return [
-            {
-                id: 0, name: team.name, staffPositions: staffPositions,
-            },
-        ];
-    }
+    return [
+      {
+        id: 0,
+        name: team.name,
+        staffPositions: staffPositions,
+      },
+    ];
+  }
 }


### PR DESCRIPTION
Bug was discovered by MLE user Jdogg, who is a blizzard captain but couldn't submit/ratify. Logs showed:

![image](https://github.com/SprocketBot/sprocket/assets/2387785/700292b3-c43e-4a22-b01e-2ec2de1c3b84)

Jdogg is one of a handful of captains who have this issue. Discovered that all players with this issue (correct perms, but still unable) had a mismatch between their Sprocket UserId and MemberId (not designed to match, but by happenstance often do for 80%+ of the current userbase). Explicitly getting UserId from the Member table for a given player fixes this. 