### PR TITLE
Elo Graph Compaction

### DIFF
--- a/core/src/elo/elo-connector/elo-connector.types.ts
+++ b/core/src/elo/elo-connector/elo-connector.types.ts
@@ -12,6 +12,7 @@ export enum EloEndpoint {
     AddPlayerBySalary = "AddPlayerBySalary",
     SGChange = "SGChange",
     EloChange = "EloChange",
+    CompactGraph = "CompactGraph",
 }
 
 export const EloSchemas = {
@@ -42,6 +43,10 @@ export const EloSchemas = {
     [EloEndpoint.EloChange]: {
         input: Schemas.EloChange_Input,
         output: Schemas.EloChange_Output,
+    },
+    [EloEndpoint.CompactGraph]: {
+        input: Schemas.CompactGraph_Input,
+        output: Schemas.CompactGraph_Output,
     },
 };
 

--- a/core/src/elo/elo-connector/schemas/CompactGraph.schema.ts
+++ b/core/src/elo/elo-connector/schemas/CompactGraph.schema.ts
@@ -1,0 +1,4 @@
+import {z} from "zod";
+
+export const CompactGraph_Input = z.object({});
+export const CompactGraph_Output = z.object({});

--- a/core/src/elo/elo-connector/schemas/index.ts
+++ b/core/src/elo/elo-connector/schemas/index.ts
@@ -5,3 +5,4 @@ export * from "./CalculateEloForNcp.schema";
 export * from "./CalculateSalaries.schema";
 export * from "./ManualEloChange.schema";
 export * from "./ManualRankout.schema";
+export * from "./CompactGraph.schema";

--- a/core/src/elo/elo.consumer.ts
+++ b/core/src/elo/elo.consumer.ts
@@ -49,6 +49,12 @@ export class EloConsumer {
         await this.playerService.saveSalaries(salaryData);
     }
 
+    async compactGraph(): Promise<void> {
+        this.logger.debug("Compacting the elo graph");
+
+        await this.eloConnectorService.createJobAndWait(EloEndpoint.CompactGraph, {});
+    }
+
     async onApplicationBootstrap(): Promise<void> {
         const repeatableJobs = await this.eloQueue.getRepeatableJobs();
 

--- a/core/src/elo/elo.resolver.ts
+++ b/core/src/elo/elo.resolver.ts
@@ -63,4 +63,11 @@ export class EloResolver {
         await this.eloConsumer.runSalaries();
         return true;
     }
+
+    @Mutation(() => Boolean)
+    @UseGuards(GqlJwtGuard, MLEOrganizationTeamGuard(MLE_OrganizationTeam.MLEDB_ADMIN))
+    async compactGraph(): Promise<boolean> {
+        await this.eloConsumer.compactGraph();
+        return true;
+    }
 }


### PR DESCRIPTION
Adds a mutation to the elo controller, and a corresponding method to the elo consumer, all to kick off the newly created `compactGraph` job on the elo side. This will allow sprocket admins to, on demand, run a job to compact the elo graph down to a history size of 1. 