### PR TITLE
Add multi-game support for user intake

### DIFF
--- a/core/src/franchise/player/player.resolver.ts
+++ b/core/src/franchise/player/player.resolver.ts
@@ -65,6 +65,9 @@ export class IntakePlayerAccount {
 
 @Resolver(() => Player)
 export class PlayerResolver {
+
+    private readonly logger = new Logger(PlayerResolver.name);
+
     constructor(
         private readonly popService: PopulateService,
         private readonly playerService: PlayerService,
@@ -76,8 +79,6 @@ export class PlayerResolver {
         @InjectRepository(UserAuthenticationAccount) private userAuthRepository: Repository<UserAuthenticationAccount>,
         @Inject(forwardRef(() => OrganizationService)) private readonly organizationService: OrganizationService,
     ) {}
-
-    private readonly logger = new Logger(PlayerResolver.name);
 
     @ResolveField()
     async skillGroup(@Root() player: Player): Promise<GameSkillGroup> {
@@ -359,9 +360,9 @@ export class PlayerResolver {
         @Args("preferredPlatform") platform: string,
         @Args("timezone", {type: () => Timezone}) timezone: Timezone,
         @Args("preferredMode", {type: () => ModePreference}) mode: ModePreference,
-        @Args("accounts", { type: () => [IntakePlayerAccount] }) accounts: IntakePlayerAccount[],
+        @Args("accounts", {type: () => [IntakePlayerAccount]}) accounts: IntakePlayerAccount[],
     ): Promise<Player> {
-        const sg = await this.skillGroupService.getGameSkillGroup({ where: { ordinal: LeagueOrdinals.indexOf(league) + 1 } });
-        return await this.playerService.updatePlayer(mleid, name, sg.id, salary, platform, accounts, timezone, mode);
+        const sg = await this.skillGroupService.getGameSkillGroup({where: {ordinal: LeagueOrdinals.indexOf(league) + 1} });
+        return this.playerService.updatePlayer(mleid, name, sg.id, salary, platform, accounts, timezone, mode);
     }
 }

--- a/core/src/franchise/player/player.service.ts
+++ b/core/src/franchise/player/player.service.ts
@@ -185,17 +185,17 @@ export class PlayerService {
         let player: Player;
 
         try {
-            const mlePlayer = await this.mle_playerRepository.findOne({ where: { mleid } });
+            const mlePlayer = await this.mle_playerRepository.findOne({where: {mleid} });
 
             if (mlePlayer) {
-                const bridge = await this.ptpRepo.findOneOrFail({ where: { mledPlayerId: mlePlayer.id } });
+                const bridge = await this.ptpRepo.findOneOrFail({where: {mledPlayerId: mlePlayer.id} });
                 player = await this.playerRepository.findOneOrFail({
-                    where: { id: bridge.sprocketPlayerId },
-                    relations: { member: { user: true, profile: true } },
+                    where: {id: bridge.sprocketPlayerId},
+                    relations: {member: {user: true, profile: true} },
                 });
 
-                player = this.playerRepository.merge(player, { skillGroupId: skillGroup.id, salary: salary });
-                this.memberProfileRepository.merge(player.member.profile, { name });
+                player = this.playerRepository.merge(player, {skillGroupId: skillGroup.id, salary: salary});
+                this.memberProfileRepository.merge(player.member.profile, {name});
 
                 await runner.manager.save(player);
                 await runner.manager.save(player.member.profile);

--- a/core/src/franchise/player/player.types.ts
+++ b/core/src/franchise/player/player.types.ts
@@ -1,12 +1,24 @@
+import {
+    Field, Float, InputType,
+    Int,
+} from "@nestjs/graphql";
 import {z} from "zod";
 
 import {
     League, ModePreference, Timezone,
 } from "../../database/mledb";
-
 export interface GameAndOrganization {
     gameId: number;
     organizationId: number;
+}
+
+@InputType()
+export class CreatePlayerTuple {
+    @Field(() => Int)
+    gameSkillGroupId: number;
+
+    @Field(() => Float)
+    salary: number;
 }
 
 export const IntakeSchema = z.array(z.tuple([

--- a/core/src/identity/user/user.resolver.ts
+++ b/core/src/identity/user/user.resolver.ts
@@ -10,7 +10,10 @@ import {
     Member, User, UserAuthenticationAccountType,
 } from "../../database";
 import {MLE_OrganizationTeam} from "../../database/mledb";
+import {PlayerService} from "../../franchise";
+import {CreatePlayerTuple} from "../../franchise/player/player.types";
 import {MLEOrganizationTeamGuard} from "../../mledb/mledb-player/mle-organization-team.guard";
+import {MemberService} from "../../organization";
 import {PopulateService} from "../../util/populate/populate.service";
 import type {AuthPayload} from "../auth";
 import {UserPayload} from "../auth";
@@ -19,6 +22,8 @@ import {GqlJwtGuard} from "../auth/gql-auth-guard";
 import {IdentityService} from "../identity.service";
 import {UserService} from "./user.service";
 
+const MLE_ORGANIZATION_ID = 2;
+
 @Resolver(() => User)
 export class UserResolver {
     private readonly logger = new Logger(UserResolver.name);
@@ -26,6 +31,8 @@ export class UserResolver {
     constructor(
         private readonly identityService: IdentityService,
         private readonly userService: UserService,
+        private readonly memberService: MemberService,
+        private readonly playerService: PlayerService,
         private readonly popService: PopulateService,
         private readonly jwtService: JwtService,
     ) {}
@@ -102,5 +109,34 @@ export class UserResolver {
         this.logger.log(`${authedUser.username} (${authedUser.userId}) generated an authentication token for ${user.profile.displayName} (${user.id})`);
 
         return this.jwtService.sign(payload, {expiresIn: "5m"});
+    }
+    
+    @Mutation(() => [User])
+    @UseGuards(GqlJwtGuard, MLEOrganizationTeamGuard([MLE_OrganizationTeam.MLEDB_ADMIN, MLE_OrganizationTeam.LEAGUE_OPERATIONS]))
+    async intakeUser(
+        @Args("name", {type: () => String}) name: string,
+        @Args("discord_id", {type: () => String}) d_id: string,
+        @Args("playersToLink", {type: () => [CreatePlayerTuple]}) ptl: CreatePlayerTuple[],
+    ): Promise<User> {
+        // This looks a little backwards, but the identity service actually
+        // creates the user object *and* the associated auth account for login
+        // at the same time.
+        const user = await this.identityService.registerUser(UserAuthenticationAccountType.DISCORD, d_id);
+        
+        // Once we have the user, we can create the member as part of MLE
+        const member = await this.memberService.createMember(
+            {name: name},
+            MLE_ORGANIZATION_ID,
+            user.id,
+        );
+        
+        // Finally, for each game this user is going to participate in, create
+        // the corresponding player
+        for (const pt of ptl) {
+            await this.playerService.createPlayer(member.id, pt.gameSkillGroupId, pt.salary);
+        }
+
+        // Send the newly created user back to the caller
+        return user;
     }
 }

--- a/core/src/organization/member/member.service.ts
+++ b/core/src/organization/member/member.service.ts
@@ -159,8 +159,8 @@ export class MemberService {
         return this.memberRepository.findOneOrFail({
             where: {
                 organizationId: organizationId,
-                userId: userId
-            }
-        })
+                userId: userId,
+            },
+        });
     }
 }


### PR DESCRIPTION
- Refactor player service (particularly the create MLE player function for default args)
- Add new mutation in user resolver, which:
  - Registers a user and UAA
  - Creates a member within MLE
  - Loops over the input list of tuples of `(skill_group, salary)` to create a player for each corresponding game
  - Creates a single MLE player with the last salary and player ID from that loop