### PR TITLE
Improve Matchmaking for 3s RR Scrims

### DIFF
--- a/microservices/matchmaking-service/config/default.json
+++ b/microservices/matchmaking-service/config/default.json
@@ -2,12 +2,14 @@
   "transport": {
     "url": "",
     "matchmaking_queue": "dev-matchmaking",
+    "image_generation_queue": "dev-ig",
     "core_queue": "dev-core",
     "bot_queue": "dev-bot",
     "analytics_queue": "dev-analytics",
     "events_queue": "dev-events",
     "events_application_key": "matchmaking-service",
-    "notification_queue": "dev-notification"
+    "notification_queue": "dev-notification",
+    "submission_queue": "dev-sub"
   },
   "logger": {
     "levels": true


### PR DESCRIPTION
Initial thought was to go with Ruskey's algorithm for generating unique set partitions of a given size: this turned out to be unnecessarily complicated, so I fell back to a really basic power set expansion and filtered for the ones we wanted. It's horrible time complexity (literally O(2^n)), but n is 6 and we only do it on initialization. 

TL;DR - Fix the 'two people get stuck with each other each 3s scrim' problem. 