### PR TITLE
Front-end changes for LFS Scrims

### DIFF
--- a/clients/web/src/lib/api/mutations/scrims/CreateLFSScrim.mutation.ts
+++ b/clients/web/src/lib/api/mutations/scrims/CreateLFSScrim.mutation.ts
@@ -48,6 +48,7 @@ export const createLFSScrimMutation = async (vars: CreateLFSScrimVariables): Pro
     const r = await client.mutation<CreateLFSScrimResponse, CreateLFSScrimVariables>(mutationString, vars).toPromise();
     if (r.data) {
         currentScrim.invalidate();
+        console.log(`Got response: ${JSON.stringify(r.data)}`);
         return r.data;
     }
     throw r.error as Error;

--- a/clients/web/src/lib/api/mutations/scrims/CreateLFSScrim.mutation.ts
+++ b/clients/web/src/lib/api/mutations/scrims/CreateLFSScrim.mutation.ts
@@ -1,0 +1,54 @@
+import {gql} from "@urql/core";
+import {currentScrim} from "../../queries";
+import {client} from "../../client";
+
+interface CreateLFSScrimResponse {
+    id: string;
+    playerCount: number;
+    settings: {
+        competitive: boolean;
+        mode: "TEAMS" | "ROUND_ROBIN";
+    };
+}
+
+interface CreateLFSScrimVariables {
+    settings: {
+        mode: "TEAMS" | "ROUND_ROBIN";
+        competitive: boolean;
+        observable: boolean;
+        lfs: boolean;
+    };
+    gameModeId: number;
+    createGroup: boolean;
+    leaveAfter: number;
+}
+
+const mutationString = gql`
+    mutation (
+        $gameModeId: Int!
+        $settings: ScrimSettingsInput!
+        $leaveAfter: Int!
+        $numRounds: Int!
+        $createGroup: Boolean
+    ) {
+        createLFSScrim(data: {gameModeId: $gameModeId, settings: $settings, createGroup: $createGroup, leaveAfter: $leaveAfter, numRounds: $numRounds}) {
+            id
+            playerCount
+            settings {
+                competitive
+                mode
+                lfs
+            }
+        }
+    }
+`;
+
+export const createLFSScrimMutation = async (vars: CreateLFSScrimVariables): Promise<CreateLFSScrimResponse> => {
+    console.log("Trying LFS mutation.");
+    const r = await client.mutation<CreateLFSScrimResponse, CreateLFSScrimVariables>(mutationString, vars).toPromise();
+    if (r.data) {
+        currentScrim.invalidate();
+        return r.data;
+    }
+    throw r.error as Error;
+};

--- a/clients/web/src/lib/api/mutations/scrims/CreateScrim.mutation.ts
+++ b/clients/web/src/lib/api/mutations/scrims/CreateScrim.mutation.ts
@@ -16,6 +16,7 @@ interface CreateScrimVariables {
         mode: "TEAMS" | "ROUND_ROBIN";
         competitive: boolean;
         observable: boolean;
+        lfs: boolean;
     };
     gameModeId: number;
     createGroup: boolean;

--- a/clients/web/src/lib/api/mutations/scrims/index.ts
+++ b/clients/web/src/lib/api/mutations/scrims/index.ts
@@ -1,5 +1,6 @@
 export * from "./CheckIn.mutation";
 export * from "./CreateScrim.mutation";
+export * from "./CreateLFSScrim.mutation";
 export * from "./JoinScrim.mutation";
 export * from "./LeaveScrim.mutation";
 export * from "./ResetSubmission.mutation";

--- a/clients/web/src/lib/api/queries/scrims/CurrentScrim.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/CurrentScrim.store.ts
@@ -28,6 +28,7 @@ export interface CurrentScrim {
     settings: {
         competitive: boolean;
         mode: string;
+        lfs: boolean;
     };
     players: Array<{
         id: number;
@@ -172,6 +173,8 @@ class CurrentScrimStore extends LiveQueryStore<CurrentScrimStoreValue, CurrentSc
         }
     }
     `;
+
+    protected _subVars: CurrentScrimStoreSubscriptionVariables = {};
 
     constructor() {
         super();

--- a/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
@@ -1,0 +1,127 @@
+import type {OperationResult} from "@urql/core";
+import {gql} from "@urql/core";
+import {LiveQueryStore} from "../../core/LiveQueryStore";
+
+export interface LFSScrim {
+    id: string;
+    playerCount: number;
+    maxPlayers: number;
+    status: "PENDING" | "EMPTY" | "POPPED";
+    createdAt: Date;
+    gameMode: {
+        description: string;
+        game: {
+            title: string;
+        };
+    };
+    settings: {
+        competitive: boolean;
+        mode: "TEAMS" | "ROUND_ROBIN";
+    };
+    skillGroup: {
+        profile: {
+            description: string;
+        };
+    };
+}
+
+
+interface LFSScrimsData {
+    LFSScrims: LFSScrim[];
+}
+
+interface LFSScrimsVars {
+
+}
+
+interface LFSScrimsSub {
+    LFSScrim: LFSScrim;
+}
+
+class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScrimsSub> {
+    protected queryString = gql<LFSScrimsData, LFSScrimsVars>`
+    query {
+        LFSScrims: getLFSScrims() {
+            id
+            playerCount
+            maxPlayers
+            status
+            createdAt
+            gameMode {
+                description
+                game {
+                    title
+                }
+            }
+            settings {
+                competitive
+                mode
+            }
+            skillGroup {
+                profile {
+                    description
+                }
+            }
+        }
+    }`;
+
+    protected subscriptionString = gql<LFSScrimsSub, {}>`
+        subscription {
+            LFSScrim: followLFSScrims {
+                id
+                playerCount
+                maxPlayers
+                status
+                createdAt
+                gameMode {
+                    description
+                    game {
+                        title
+                    }
+                }
+                settings {
+                    competitive
+                    mode
+                }
+                skillGroup {
+                    profile {
+                        description
+                    }
+                }
+            }
+        }
+    `;
+    
+    protected _subVars = {};
+
+    constructor() {
+        super();
+        // No variables needed
+        this._vars = {};
+        this.subscriptionVariables = {};
+    }
+
+    protected handleGqlMessage = (message: OperationResult<LFSScrimsSub>) => {
+        if (!message.data) {
+            console.warn(`Recieved erroneous message from followLFSScrims: ${message.error}`);
+            return;
+        }
+        if (!this.currentValue.data) {
+            console.warn(`Recieved subscription before query completed!`);
+            return;
+        }
+        const scrim = message.data.LFSScrim;
+        let existingScrims = [...this.currentValue.data.LFSScrims];
+        const existingScrim = existingScrims.findIndex(s => s.id === scrim.id);
+        if (existingScrim >= 0) {
+            existingScrims[existingScrim] = scrim;
+        } else {
+            existingScrims.push(scrim);
+        }
+
+        this.currentValue.data.LFSScrims = existingScrims;
+        this.pub();
+    };
+}
+
+export const LFSScrims = new LFSScrimsStore();

--- a/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
@@ -17,6 +17,7 @@ export interface LFSScrim {
     settings: {
         competitive: boolean;
         mode: "TEAMS" | "ROUND_ROBIN";
+        lfs: boolean;
     };
     skillGroup: {
         profile: {
@@ -41,7 +42,7 @@ interface LFSScrimsSub {
 class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScrimsSub> {
     protected queryString = gql<LFSScrimsData, LFSScrimsVars>`
     query {
-        LFSScrims: getLFSScrims() {
+        LFSScrims: getLFSScrims {
             id
             playerCount
             maxPlayers

--- a/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
@@ -1,34 +1,35 @@
 import type {OperationResult} from "@urql/core";
 import {gql} from "@urql/core";
 import {LiveQueryStore} from "../../core/LiveQueryStore";
+import type {PendingScrim} from "./PendingScrims.store";
 
-export interface LFSScrim {
-    id: string;
-    playerCount: number;
-    maxPlayers: number;
-    status: "PENDING" | "EMPTY" | "POPPED";
-    createdAt: Date;
-    gameMode: {
-        description: string;
-        game: {
-            title: string;
-        };
-    };
-    settings: {
-        competitive: boolean;
-        mode: "TEAMS" | "ROUND_ROBIN";
-        lfs: boolean;
-    };
-    skillGroup: {
-        profile: {
-            description: string;
-        };
-    };
-}
+// export interface LFSScrim {
+//     id: string;
+//     playerCount: number;
+//     maxPlayers: number;
+//     status: "PENDING" | "EMPTY" | "POPPED";
+//     createdAt: Date;
+//     gameMode: {
+//         description: string;
+//         game: {
+//             title: string;
+//         };
+//     };
+//     settings: {
+//         competitive: boolean;
+//         mode: "TEAMS" | "ROUND_ROBIN";
+//         lfs: boolean;
+//     };
+//     skillGroup: {
+//         profile: {
+//             description: string;
+//         };
+//     };
+// }
 
 
 interface LFSScrimsData {
-    LFSScrims: LFSScrim[];
+    LFSScrims: PendingScrim[];
 }
 
 interface LFSScrimsVars {
@@ -36,7 +37,7 @@ interface LFSScrimsVars {
 }
 
 interface LFSScrimsSub {
-    LFSScrim: LFSScrim;
+    LFSScrim: PendingScrim;
 }
 
 export class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScrimsSub> {

--- a/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
@@ -111,7 +111,7 @@ class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScr
             return;
         }
         const scrim = message.data.LFSScrim;
-        let existingScrims = [...this.currentValue.data.LFSScrims];
+        const existingScrims = [...this.currentValue.data.LFSScrims];
         const existingScrim = existingScrims.findIndex(s => s.id === scrim.id);
         if (existingScrim >= 0) {
             existingScrims[existingScrim] = scrim;

--- a/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/LFSScrims.store.ts
@@ -39,7 +39,7 @@ interface LFSScrimsSub {
     LFSScrim: LFSScrim;
 }
 
-class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScrimsSub> {
+export class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScrimsSub> {
     protected queryString = gql<LFSScrimsData, LFSScrimsVars>`
     query {
         LFSScrims: getLFSScrims {
@@ -125,4 +125,3 @@ class LFSScrimsStore extends LiveQueryStore<LFSScrimsData, LFSScrimsVars, LFSScr
     };
 }
 
-export const LFSScrims = new LFSScrimsStore();

--- a/clients/web/src/lib/api/queries/scrims/PendingScrims.store.ts
+++ b/clients/web/src/lib/api/queries/scrims/PendingScrims.store.ts
@@ -17,6 +17,7 @@ export interface PendingScrim {
     settings: {
         competitive: boolean;
         mode: "TEAMS" | "ROUND_ROBIN";
+        lfs: boolean;
     };
     skillGroup: {
         profile: {
@@ -91,6 +92,8 @@ class PendingScrimsStore extends LiveQueryStore<PendingScrimsData, PendingScrims
             }
         }
     `;
+
+    protected _subVars = [];
 
     constructor() {
         super();

--- a/clients/web/src/lib/api/queries/scrims/index.ts
+++ b/clients/web/src/lib/api/queries/scrims/index.ts
@@ -2,6 +2,7 @@ export * from "./ActiveScrimPlayers.store";
 export * from "./ActiveScrims.store";
 export * from "./AllCurrentScrims";
 export * from "./CurrentScrim.store";
+export * from "./LFSScrims.store";
 export * from "./PendingScrims.store";
 export * from "./ScrimMetrics.store";
 export * from "./ScrimsDisabled.store";

--- a/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import {screamingSnakeToHuman} from "$lib/utils";
-    import type {PendingScrim} from "$lib/api";
+    import type {CurrentScrim, PendingScrim} from "$lib/api";
     import {format} from "date-fns";
     import dateFns from "date-fns-tz";
     const {utcToZonedTime} = dateFns;
 
     export let lfs: boolean = false;
-    export let scrims: PendingScrim[];
+    export let scrims: PendingScrim[] | CurrentScrim[];
     export let joinScrim: (scrim: PendingScrim) => void;
 </script>
 

--- a/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
@@ -3,8 +3,10 @@
     import type {PendingScrim} from "$lib/api";
     import {format} from "date-fns";
     import dateFns from "date-fns-tz";
+  import { Upload } from "graphql-upload";
     const {utcToZonedTime} = dateFns;
 
+    export let lfs: boolean = false;
     export let scrims: PendingScrim[];
     export let joinScrim: (scrim: PendingScrim) => void;
 </script>
@@ -34,7 +36,11 @@
             <td>{format(utcToZonedTime(new Date(scrim.createdAt), "America/New_York"), "MM'/'d h:mmaaa 'ET")}</td>
             <td>
                 <button on:click={() => { joinScrim(scrim) }} class="btn btn-outline float-right lg:btn-sm">
-                    Join
+                    {#if lfs}
+                        Upload
+                    {:else}
+                        Join
+                    {/if}
                 </button>
             </td>
         </tr>

--- a/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
@@ -3,7 +3,6 @@
     import type {PendingScrim} from "$lib/api";
     import {format} from "date-fns";
     import dateFns from "date-fns-tz";
-  import { Upload } from "graphql-upload";
     const {utcToZonedTime} = dateFns;
 
     export let lfs: boolean = false;

--- a/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
@@ -44,7 +44,7 @@
 {/if}
 
 {#if createModalVisible}
-    <CreateScrimModal bind:visible={createModalVisible} />
+    <CreateScrimModal bind:visible={createModalVisible} lfs={true} />
 {/if}
 {#if joinModalVisible && targetScrim}
     <JoinScrimModal scrim={targetScrim} bind:visible={joinModalVisible} />

--- a/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
@@ -4,6 +4,8 @@
     import {
         ScrimCard, ScrimTable, CreateScrimModal, JoinScrimModal,
     } from "$lib/components";
+    
+    import {redirect} from "@sveltejs/kit";
 
     let scrims: LFSScrim[] | undefined;
     $: scrims = $LFSScrims.data?.LFSScrims;
@@ -16,8 +18,8 @@
         createModalVisible = true;
     };
     const openJoinScrimModal = (scrim: LFSScrim) => {
-        targetScrim = scrim;
-        joinModalVisible = true;
+        // Redirect to /league/scrims/[submissionId].svelte
+        throw redirect(302, `/league/scrims/${scrim.id}`);
     };
 </script>
 

--- a/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/LFSScrimsView.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import {LFSScrims, type LFSScrim} from "$lib/api";
+
+    import {
+        ScrimCard, ScrimTable, CreateScrimModal, JoinScrimModal,
+    } from "$lib/components";
+
+    let scrims: LFSScrim[] | undefined;
+    $: scrims = $LFSScrims.data?.LFSScrims;
+
+    let createModalVisible = false;
+    let joinModalVisible = false;
+    let targetScrim: LFSScrim | undefined;
+
+    const openCreateScrimModal = () => {
+        createModalVisible = true;
+    };
+    const openJoinScrimModal = (scrim: LFSScrim) => {
+        targetScrim = scrim;
+        joinModalVisible = true;
+    };
+</script>
+
+
+
+{#if scrims === undefined}
+    Loading...
+{:else}
+    <div class="flex flex-col md:flex-row justify-between mb-4">
+        <h2>Available Scrims</h2>
+        <button class="btn btn-primary w-full md:w-auto" on:click={openCreateScrimModal}>
+            Create Scrim
+        </button>
+    </div>
+
+    <div class="flex md:hidden flex-col gap-4">
+        {#each scrims as scrim (scrim.id)}
+            <ScrimCard {scrim} joinScrim={openJoinScrimModal} />
+        {/each}
+    </div>
+    <div class="hidden md:block">
+        <ScrimTable {scrims} joinScrim={openJoinScrimModal} />
+    </div>
+{/if}
+
+{#if createModalVisible}
+    <CreateScrimModal bind:visible={createModalVisible} />
+{/if}
+{#if joinModalVisible && targetScrim}
+    <JoinScrimModal scrim={targetScrim} bind:visible={joinModalVisible} />
+{/if}
+
+
+
+<style lang="postcss">
+    h2 {
+        @apply text-4xl font-bold text-sprocket mb-2;
+    }
+</style>

--- a/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+    import {type GamesAndModesValue, createLFSScrimMutation} from "$lib/api";
+    import {gamesAndModes} from "$lib/api/queries/GamesAndModes.store";
+    import {Modal} from "$lib/components";
+
+    export let visible = false;
+    export let lfs = false;
+
+    let game: GamesAndModesValue["games"][0];
+    let mode: GamesAndModesValue["games"][0]["modes"][0];
+    let scrimType: "TEAMS" | "ROUND_ROBIN";
+    let leaveAfter: number = 1800;
+    let competitive: boolean = true;
+    let createGroup: boolean = false;
+    let numRounds: number = 0;
+    let buttonEnabled = true;
+
+    async function createScrim() {
+        buttonEnabled = false;
+        try {
+            console.log("Creating scrim:");
+            console.log(`Mode: ${scrimType}, Competitive: ${competitive}, LFS: ${lfs}`);
+            const data = {
+                settings: {
+                    mode: "TEAMS",
+                    competitive: competitive,
+                    observable: false,
+                    lfs: true,
+                },
+                gameModeId: mode.id,
+                createGroup: createGroup,
+                leaveAfter: leaveAfter,
+                numRounds: numRounds,
+            };
+            await createLFSScrimMutation(data)
+            visible = false;
+        } finally {
+            buttonEnabled = true;
+        }
+    }
+</script>
+
+<Modal title="Create LFS (Team) Scrim" bind:visible id="create-scrim-modal">
+    <form on:submit|preventDefault={createScrim} slot="body">
+        <div class="divider my-1"></div>
+
+        <div class="form-control">
+            <label class="label" for="game">
+                <span class="label-text">Game:</span>
+            </label>
+            <select
+                    name="game"
+                    bind:value={game}
+            >
+                <option disabled selected>Make a selection</option>
+                {#each $gamesAndModes?.data?.games ?? [] as g (g.id)}
+                    <option value={g}>{g.title}</option>
+                {/each}
+            </select>
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="game-mode">
+                <span class="label-text">Game Mode:</span>
+            </label>
+            <select name="game-mode" bind:value={mode}>
+                <option disabled selected>Make a selection</option>
+                {#each game?.modes ?? [] as g (g.id)}
+                    <option value={g}>{g.description}</option>
+                {/each}
+            </select>
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="scrim-type">
+                <span class="label-text">Number of Games:</span>
+            </label>
+            <input type="number" name="num-rounds" bind:value={numRounds} />
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="scrim-leave-after">
+                <span class="label-text">Leave After:</span>
+            </label>
+            <select name="scrim-leave-after" bind:value={leaveAfter}>
+                <option value={1800} selected>30 Minutes</option>
+                <option value={3600}>1 Hour</option>
+                <option value={10800}>3 Hours</option>
+                <option value={21600}>6 Hours</option>
+            </select>
+        </div>
+
+        <div class="form-control inline">
+            <label class="cursor-pointer label" for="competitive">
+                <span class="label-text">Competitive</span>
+                <input
+                    type="checkbox"
+                    bind:checked={competitive}
+                    class="toggle toggle-primary"
+                    name="competitive"
+                />
+            </label>
+        </div>
+
+        <button class="btn btn-primary btn-wide flex mx-auto mb-4" disabled={!buttonEnabled}>Create</button>
+    </form>
+</Modal>
+
+<style lang="postcss">
+    form {
+        @apply flex flex-col gap-2 md:gap-4;
+
+        .form-control.inline {
+            @apply flex flex-row justify-between items-center py-2;
+        }
+
+        label {
+            @apply contents;
+        }
+
+        select {
+            @apply mt-2 outline-1 select select-bordered select-sm;
+
+            option {
+                @apply py-2;
+            }
+
+            &:disabled {
+                @apply bg-gray-700 cursor-not-allowed;
+            }
+        }
+
+        input {
+            @apply ml-auto;
+        }
+
+        input:disabled {
+            @apply text-right px-4 py-1 bg-gray-700;
+        }
+    }
+</style>

--- a/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
@@ -4,11 +4,10 @@
     import {Modal} from "$lib/components";
 
     export let visible = false;
-    export let lfs = false;
 
     let game: GamesAndModesValue["games"][0];
     let mode: GamesAndModesValue["games"][0]["modes"][0];
-    let scrimType: "TEAMS" | "ROUND_ROBIN";
+    let scrimType: "TEAMS" | "ROUND_ROBIN" = "TEAMS";
     let leaveAfter: number = 1800;
     let competitive: boolean = true;
     let createGroup: boolean = false;
@@ -18,11 +17,9 @@
     async function createScrim() {
         buttonEnabled = false;
         try {
-            console.log("Creating scrim:");
-            console.log(`Mode: ${scrimType}, Competitive: ${competitive}, LFS: ${lfs}`);
             const data = {
                 settings: {
-                    mode: "TEAMS",
+                    mode: scrimType,
                     competitive: competitive,
                     observable: false,
                     lfs: true,
@@ -32,7 +29,7 @@
                 leaveAfter: leaveAfter,
                 numRounds: numRounds,
             };
-            await createLFSScrimMutation(data)
+            await createLFSScrimMutation(data);
             visible = false;
         } finally {
             buttonEnabled = true;

--- a/clients/web/src/lib/components/organisms/scrims/modals/CreateScrimModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/CreateScrimModal.svelte
@@ -4,6 +4,7 @@
     import {Modal} from "$lib/components";
 
     export let visible = false;
+    export let lfs = false;
 
     let game: GamesAndModesValue["games"][0];
     let mode: GamesAndModesValue["games"][0]["modes"][0];
@@ -22,6 +23,7 @@
                     mode: scrimType,
                     competitive: competitive,
                     observable: false,
+                    lfs: lfs,
                 },
                 gameModeId: mode.id,
                 createGroup: createGroup,

--- a/clients/web/src/lib/components/organisms/scrims/modals/index.ts
+++ b/clients/web/src/lib/components/organisms/scrims/modals/index.ts
@@ -1,4 +1,5 @@
 export {default as CreateScrimModal} from "./CreateScrimModal.svelte";
+export {default as CreateLFSScrimModal} from "./CreateLFSScrimModal.svelte";
 export {default as JoinScrimModal} from "./JoinScrimModal.svelte";
 export {default as ScrimManagementModal} from "./ScrimManagementModal.svelte";
 export {default as UploadReplaysModal} from "./UploadReplaysModal.svelte";

--- a/clients/web/src/lib/stores/navigation.store.ts
+++ b/clients/web/src/lib/stores/navigation.store.ts
@@ -2,6 +2,7 @@ import {writable} from "svelte/store";
 
 export const SCRIM_NAV_ITEM = {target: "/scrims", label: "Play"};
 export const LEAGUE_NAV_ITEM = {target: "/league", label: "League Play"};
+export const LFS_NAV_ITEM = {target: "/league/scrim", label: "LFS Scrims"};
 export const ADMIN_NAV_ITEM = {target: "/admin", label: "Admin"};
 
 export interface NavigationItem {
@@ -9,4 +10,4 @@ export interface NavigationItem {
     target: string;
 }
 
-export const navigationStore = writable<NavigationItem[]>([SCRIM_NAV_ITEM, LEAGUE_NAV_ITEM]);
+export const navigationStore = writable<NavigationItem[]>([SCRIM_NAV_ITEM, LEAGUE_NAV_ITEM, LFS_NAV_ITEM]);

--- a/clients/web/src/routes/__layout.svelte
+++ b/clients/web/src/routes/__layout.svelte
@@ -10,7 +10,10 @@
 	$: {
 	    const isAdmin = $session.user?.orgTeams.some(s => s === 0);
 	    if (isAdmin) {
-	        navigationStore.update(prev => [...prev, ADMIN_NAV_ITEM]);
+	        navigationStore.update((prev) => {
+				if (prev.includes(ADMIN_NAV_ITEM)) return prev;
+				return [...prev, ADMIN_NAV_ITEM];
+			});
 	    }
 	}
 

--- a/clients/web/src/routes/league/scrim/_layout.svelte
+++ b/clients/web/src/routes/league/scrim/_layout.svelte
@@ -1,0 +1,12 @@
+<script lang="ts" context="module">
+  import type {LoadInput, LoadOutput} from "@sveltejs/kit";
+
+  export function load({session}: LoadInput): LoadOutput {
+      if (!session.user) {
+          return {redirect: "/auth/login", status: 302};
+      }
+      return {};
+  }
+</script>
+
+<slot/>

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -1,29 +1,48 @@
 <script lang="ts">
 	import {
-	    DashboardLayout, DashboardCard, Spinner
+	    CreateLFSScrimModal, DashboardLayout, DashboardCard, ScrimTable, Spinner, UploadReplaysModal
 	} from "$lib/components";
 	import {
-		LFSScrimsStore, type LFSScrim
+		LFSScrimsStore, type PendingScrim
 	} from "$lib/api";
 
 	const store = new LFSScrimsStore();
 	let fetching = true;
-	let scrims: LFSScrim[] | undefined = [];
+	let uploading = false;
+	let creating = false;
+	let submissionId: string = "";
+	let scrims: PendingScrim[] | undefined = [];
 
 	$: {
 		// @ts-expect-error `fetching` exists on the query store but isn't defined in the type
 	    fetching = $store.fetching;
 		scrims = $store.data?.LFSScrims;
 	}
+
+	const openUploadModal = (scrim: PendingScrim) => {
+        submissionId = scrim.id;
+        uploading = true;
+    };
+	
+	const openCreateScrimModal = () => {
+		creating = true;
+	}
 </script>
 
 <DashboardLayout>
 	<DashboardCard class="col-span-8 row-span-3" title="LFS (Team) Scrims">
+		<div class="flex flex-col md:flex-row justify-between mb-4">
+			<h2>Available Scrims</h2>
+			<button class="btn btn-primary w-full md:w-auto" on:click={openCreateScrimModal}>
+				Create LFS Scrim
+			</button>
+		</div>
 		{#if fetching}
 			<div class="h-full w-full flex items-center justify-center">
 				<Spinner class="h-16 w-full"/>
 			</div>
 		{:else if scrims}
+			<ScrimTable scrims={scrims} lfs={true} joinScrim={(scrim) => openUploadModal(scrim)}/>
 			{#each scrims as scrim (scrim.id)}
 				<h2 class="text-2xl text-accent font-bold mb-8">{scrim.id}</h2>
 			{/each}
@@ -34,3 +53,6 @@
 		{/if}
 	</DashboardCard>
 </DashboardLayout>
+
+<UploadReplaysModal bind:visible={uploading} submissionId={submissionId}/>
+<CreateLFSScrimModal bind:visible={creating} />

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -43,9 +43,6 @@
 			</div>
 		{:else if scrims}
 			<ScrimTable scrims={scrims} lfs={true} joinScrim={(scrim) => openUploadModal(scrim)}/>
-			{#each scrims as scrim (scrim.id)}
-				<h2 class="text-2xl text-accent font-bold mb-8">{scrim.id}</h2>
-			{/each}
 		{:else}
 			<div class="h-full w-full flex items-center justify-center">
 				No scrims found

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -3,7 +3,7 @@
 	    CreateLFSScrimModal, DashboardLayout, DashboardCard, ScrimTable, Spinner, UploadReplaysModal
 	} from "$lib/components";
 	import {
-		LFSScrimsStore, type PendingScrim
+		LFSScrimsStore, type CurrentScrim
 	} from "$lib/api";
 
 	const store = new LFSScrimsStore();
@@ -11,7 +11,7 @@
 	let uploading = false;
 	let creating = false;
 	let submissionId: string = "";
-	let scrims: PendingScrim[] | undefined = [];
+	let scrims: CurrentScrim[] | undefined = [];
 
 	$: {
 		// @ts-expect-error `fetching` exists on the query store but isn't defined in the type
@@ -19,8 +19,9 @@
 		scrims = $store.data?.LFSScrims;
 	}
 
-	const openUploadModal = (scrim: PendingScrim) => {
-        submissionId = scrim.id;
+	const openUploadModal = (scrim: CurrentScrim) => {
+		console.log(JSON.stringify(scrim));
+        submissionId = scrim.submissionId ?? "";
         uploading = true;
     };
 	

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import {
+	    DashboardLayout, DashboardCard, Spinner, LeagueScheduleGroup,
+	} from "$lib/components";
+	import {
+	    LeagueScheduleStore, type LeagueScheduleSeason, type LeagueScheduleWeek,
+	} from "$lib/api";
+
+	const store = new LeagueScheduleStore();
+	let fetching = true;
+	let schedule: LeagueScheduleSeason | undefined;
+	let scheduleGroups: LeagueScheduleWeek[] = [];
+	let currentWeek: LeagueScheduleWeek | undefined;
+
+	$: {
+	    // @ts-expect-error `fetching` exists on the query store but isn't defined in the type
+	    fetching = $store.fetching;
+
+	    schedule = $store.data?.seasons[0];
+	    scheduleGroups = schedule ? schedule?.childGroups.sort((a, b) => Date.parse(a.start) - Date.parse(b.start)) : [];
+
+		const nextWeekIndex = scheduleGroups.findIndex(sg => Date.parse(sg.start) > Date.now());
+		const currentWeekIndex = nextWeekIndex >= 1 ? nextWeekIndex - 1 : -1
+		currentWeek = currentWeekIndex ? scheduleGroups[currentWeekIndex] : undefined
+	}
+</script>
+
+<DashboardLayout>
+	<DashboardCard class="col-span-8 row-span-3" title="League Play Schedule">
+		{#if fetching}
+			<div class="h-full w-full flex items-center justify-center">
+				<Spinner class="h-16 w-full"/>
+			</div>
+		{:else if schedule}
+			<h2 class="text-2xl text-accent font-bold mb-8">{schedule.game.title} | {schedule.description}</h2>
+
+			<div class="flex flex-col gap-10">
+				{#if currentWeek}
+					<LeagueScheduleGroup scheduleGroup={currentWeek} isCurrentWeek />
+				{/if}
+
+				{#each scheduleGroups as week (week?.id)}
+					<LeagueScheduleGroup scheduleGroup={week} />
+				{/each}
+			</div>
+		{/if}
+	</DashboardCard>
+</DashboardLayout>

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -1,47 +1,35 @@
 <script lang="ts">
 	import {
-	    DashboardLayout, DashboardCard, Spinner, LeagueScheduleGroup,
+	    DashboardLayout, DashboardCard, Spinner
 	} from "$lib/components";
 	import {
-	    LeagueScheduleStore, type LeagueScheduleSeason, type LeagueScheduleWeek,
+		LFSScrimsStore, type LFSScrim
 	} from "$lib/api";
 
-	const store = new LeagueScheduleStore();
+	const store = new LFSScrimsStore();
 	let fetching = true;
-	let schedule: LeagueScheduleSeason | undefined;
-	let scheduleGroups: LeagueScheduleWeek[] = [];
-	let currentWeek: LeagueScheduleWeek | undefined;
+	let scrims: LFSScrim[] | undefined = [];
 
 	$: {
-	    // @ts-expect-error `fetching` exists on the query store but isn't defined in the type
+		// @ts-expect-error `fetching` exists on the query store but isn't defined in the type
 	    fetching = $store.fetching;
-
-	    schedule = $store.data?.seasons[0];
-	    scheduleGroups = schedule ? schedule?.childGroups.sort((a, b) => Date.parse(a.start) - Date.parse(b.start)) : [];
-
-		const nextWeekIndex = scheduleGroups.findIndex(sg => Date.parse(sg.start) > Date.now());
-		const currentWeekIndex = nextWeekIndex >= 1 ? nextWeekIndex - 1 : -1
-		currentWeek = currentWeekIndex ? scheduleGroups[currentWeekIndex] : undefined
+		scrims = $store.data?.LFSScrims;
 	}
 </script>
 
 <DashboardLayout>
-	<DashboardCard class="col-span-8 row-span-3" title="League Play Schedule">
+	<DashboardCard class="col-span-8 row-span-3" title="LFS (Team) Scrims">
 		{#if fetching}
 			<div class="h-full w-full flex items-center justify-center">
 				<Spinner class="h-16 w-full"/>
 			</div>
-		{:else if schedule}
-			<h2 class="text-2xl text-accent font-bold mb-8">{schedule.game.title} | {schedule.description}</h2>
-
-			<div class="flex flex-col gap-10">
-				{#if currentWeek}
-					<LeagueScheduleGroup scheduleGroup={currentWeek} isCurrentWeek />
-				{/if}
-
-				{#each scheduleGroups as week (week?.id)}
-					<LeagueScheduleGroup scheduleGroup={week} />
-				{/each}
+		{:else if scrims}
+			{#each scrims as scrim (scrim.id)}
+				<h2 class="text-2xl text-accent font-bold mb-8">{scrim.id}</h2>
+			{/each}
+		{:else}
+			<div class="h-full w-full flex items-center justify-center">
+				No scrims found
 			</div>
 		{/if}
 	</DashboardCard>

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -8,7 +8,8 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"outDir": ".svelte-kit"
 	},
 	"typeAcquisition": {
 		"include": ["src/app.d.ts"]

--- a/common/src/service-connectors/matchmaking/schemas/scrim/CreateLFSScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/CreateLFSScrim.schema.ts
@@ -13,7 +13,7 @@ export const CreateLFSScrim_Request = z.object({
     skillGroupId: z.number(),
     settings: ScrimSettingsSchema,
     numRounds: z.number(),
-    join: z.array(ScrimJoinOptionsSchema),
+    join: ScrimJoinOptionsSchema,
 });
 
 export type CreateLFSScrimRequest = z.infer<typeof CreateLFSScrim_Request>;

--- a/common/src/service-connectors/matchmaking/types/ScrimSettings.ts
+++ b/common/src/service-connectors/matchmaking/types/ScrimSettings.ts
@@ -8,6 +8,7 @@ export const ScrimSettingsSchema = z.object({
     mode: z.nativeEnum(ScrimMode),
     competitive: z.boolean(),
     observable: z.boolean(),
+    lfs: z.boolean().default(false),
     checkinTimeout: z.number(),
 });
 

--- a/core/config/default.json
+++ b/core/config/default.json
@@ -16,10 +16,10 @@
         "levels": true
     },
     "db": {
-        "host": "",
-        "port": "",
-        "username": "",
-        "database": "",
+        "host": "localhost",
+        "port": "5432",
+        "username": "postgres",
+        "database": "sprocket_dev",
         "enable_logs": false
     },
     "minio": {
@@ -36,8 +36,8 @@
         "queue": ""
     },
     "web": {
-        "url": "",
-        "api_root": ""
+        "url": "localhost:3000",
+        "api_root": "localhost:3001/graphql"
     },
     "gql": {
         "playground": false
@@ -53,7 +53,7 @@
             "callbackUrl": ""
         },
         "discord": {
-            "callbackUrl": ""
+            "callbackUrl": "http://localhost:3001/login"
         },
         "epic": {
             "callbackUrl": ""
@@ -68,10 +68,10 @@
         "frontend_callback": ""
     },
     "redis": {
-        "port": 80,
-        "host": "",
-        "prefix": "",
-        "secure": true
+        "port": 6379,
+        "host": "localhost",
+        "prefix": "local-",
+        "secure": false
     },
     "defaultOrganizationId": 2,
     "defaultAuthToken": ""

--- a/core/config/default.json
+++ b/core/config/default.json
@@ -1,6 +1,6 @@
 {
     "transport": {
-        "url": "",
+        "url": "amqp://localhost",
         "events_application_key": "sprocket-core",
         "core_queue": "dev-core",
         "bot_queue": "dev-bot",

--- a/core/src/database/game/game.module.ts
+++ b/core/src/database/game/game.module.ts
@@ -15,7 +15,7 @@ export const gameEntities = [
     GameMode,
     Game,
     GameFeature,
-    Feature,
+//    Feature,
 ];
 
 const ormModule = TypeOrmModule.forFeature(gameEntities);

--- a/core/src/scrim/scrim.mod.resolver.ts
+++ b/core/src/scrim/scrim.mod.resolver.ts
@@ -117,6 +117,16 @@ export class ScrimModuleResolver {
             && (!s.settings.competitive || players.some(p => s.skillGroupId === p.skillGroupId))
             && s.status === status) as Scrim[];
     }
+    
+    @Query(() => [Scrim])
+    @UseGuards(FormerPlayerScrimGuard)
+    async getLFSScrims(@CurrentUser() user: UserPayload): Promise<Scrim[]> {
+        if (!user.currentOrganizationId) throw new GraphQLError("User is not connected to an organization");
+
+        const scrims = await this.scrimService.getAllScrims();
+        return scrims.filter(s => s.organizationId === user.currentOrganizationId
+            && s.settings.lfs) as Scrim[];
+    }
 
     @Query(() => Scrim, {nullable: true})
     async getCurrentScrim(@CurrentUser() user: UserPayload): Promise<Scrim | null> {
@@ -152,6 +162,7 @@ export class ScrimModuleResolver {
             mode: data.settings.mode,
             competitive: data.settings.competitive,
             observable: data.settings.observable,
+            lfs: false,
             checkinTimeout: minutesToMilliseconds(checkinTimeout),
         };
 
@@ -193,6 +204,7 @@ export class ScrimModuleResolver {
             mode: data.settings.mode,
             competitive: data.settings.competitive,
             observable: data.settings.observable,
+            lfs: true,
             checkinTimeout: minutesToMilliseconds(checkinTimeout),
         };
 

--- a/core/src/scrim/scrim.mod.resolver.ts
+++ b/core/src/scrim/scrim.mod.resolver.ts
@@ -181,8 +181,8 @@ export class ScrimModuleResolver {
         }) as Promise<Scrim>;
     }
 
-    @Mutation(() => Boolean)
-    @UseGuards(QueueBanGuard, JoinScrimPlayerGuard, FormerPlayerScrimGuard)
+    @Mutation(() => Scrim)
+    @UseGuards(QueueBanGuard, CreateScrimPlayerGuard, FormerPlayerScrimGuard)
     async createLFSScrim(
         @CurrentUser() user: UserPayload,
         @Args("data") data: CreateLFSScrimInput,

--- a/core/src/scrim/scrim.mod.resolver.ts
+++ b/core/src/scrim/scrim.mod.resolver.ts
@@ -214,6 +214,7 @@ export class ScrimModuleResolver {
             gameModeId: gameMode.id,
             skillGroupId: player.skillGroupId,
             settings: settings,
+            numRounds: data.numRounds,
             join: {
                 playerId: user.userId,
                 playerName: user.username,

--- a/core/src/scrim/scrim.service.ts
+++ b/core/src/scrim/scrim.service.ts
@@ -6,6 +6,7 @@ import type {
     CoreEndpoint,
     CoreInput,
     CoreOutput,
+    CreateLFSScrimRequest,
     CreateScrimOptions,
     JoinScrimOptions,
     Scrim as IScrim,
@@ -100,7 +101,7 @@ export class ScrimService {
         throw result.error;
     }
     
-    async createLFSScrim(data: CreateLFSScrimOptions): Promise<IScrim> {
+    async createLFSScrim(data: CreateLFSScrimRequest): Promise<IScrim> {
         const result = await this.matchmakingService.send(MatchmakingEndpoint.CreateLFSScrim, data);
         
         if (result.status === ResponseStatus.SUCCESS) return result.data;

--- a/core/src/scrim/scrim.service.ts
+++ b/core/src/scrim/scrim.service.ts
@@ -52,6 +52,8 @@ export class ScrimService {
     get pendingScrimsSubTopic(): string { return "scrims.created" }
 
     get allActiveScrimsSubTopic(): string { return "scrims.updated" }
+    
+    get lfsScrimsSubTopic(): string { return "scrims.lfs" }
 
     async getAllScrims(skillGroupId?: number): Promise<IScrim[]> {
         const result = await this.matchmakingService.send(MatchmakingEndpoint.GetAllScrims, {skillGroupId});

--- a/core/src/scrim/types/CreateLFSScrimInput.ts
+++ b/core/src/scrim/types/CreateLFSScrimInput.ts
@@ -2,7 +2,6 @@ import {
     Field, InputType, Int,
 } from "@nestjs/graphql";
 
-import type {ScrimPlayer} from "./ScrimPlayer";
 import {ScrimSettingsInput} from "./ScrimSettings";
 
 @InputType()
@@ -18,12 +17,6 @@ export class CreateLFSScrimInput {
 
     @Field(() => Int)
     leaveAfter: number;
-
-    @Field()
-    players: ScrimPlayer[];
-
-    @Field()
-    teams: ScrimPlayer[][];
 
     @Field(() => Int)
     numRounds: number;

--- a/core/src/scrim/types/ScrimSettings.ts
+++ b/core/src/scrim/types/ScrimSettings.ts
@@ -20,6 +20,9 @@ export class ScrimSettings implements IScrimSettings {
 
     @Field(() => Boolean)
     observable: boolean;
+    
+    @Field(() => Boolean)
+    lfs: boolean;
 
     @Field(() => Int)
     checkinTimeout: number;
@@ -35,4 +38,8 @@ export class ScrimSettingsInput {
 
     @Field(() => Boolean)
     observable: boolean;
+
+    @Field(() => Boolean)
+    lfs: boolean;
+
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       POSTGRES_DB: sprocket_dev
 
   redis:
-    image: redis
+    image: redis/redis-stack-server
     restart: always
     ports:
       - 6379:6379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+# Background/local services for local development
+# $ docker-compose up in the sprocket folder
+# Then npm run dev your desired services
+services:
+  db:
+    image: postgres
+    restart: always
+    ports:
+      - 5432:5432
+    shm_size: 128mb
+    # or set shared memory limit when deploy via swarm stack
+    #volumes:
+    #  - type: tmpfs
+    #    target: /dev/shm
+    #    tmpfs:
+    #      size: 134217728 # 128*2^20 bytes = 128Mb
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sprocket_dev
+
+  redis:
+    image: redis
+    restart: always
+    ports:
+      - 6379:6379
+
+  rabbitmq:
+    image: rabbitmq
+    restart: always
+    ports:
+      - 5672:5672
+      - 15672:15672

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,12 +8,8 @@ services:
     ports:
       - 5432:5432
     shm_size: 128mb
-    # or set shared memory limit when deploy via swarm stack
-    #volumes:
-    #  - type: tmpfs
-    #    target: /dev/shm
-    #    tmpfs:
-    #      size: 134217728 # 128*2^20 bytes = 128Mb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -31,3 +27,7 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+
+volumes:
+  pgdata:
+    driver: local

--- a/microservices/matchmaking-service/config/default.json
+++ b/microservices/matchmaking-service/config/default.json
@@ -1,6 +1,6 @@
 {
   "transport": {
-    "url": "",
+    "url": "amqp://localhost",
     "matchmaking_queue": "dev-matchmaking",
     "image_generation_queue": "dev-ig",
     "core_queue": "dev-core",
@@ -18,9 +18,8 @@
     "url": "http://localhost:3001"
   },
   "redis": {
-    "port": 0,
-    "host": "",
-    "prefix": "dev"
+    "port": 6379,
+    "host": "localhost",
+    "prefix": "local-"
   }
 }
-  

--- a/microservices/matchmaking-service/src/scrim/scrim.service.spec.helpers.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.spec.helpers.ts
@@ -9,9 +9,10 @@ export function getMockScrimSettings(
     competitive: boolean,
     observable: boolean,
     checkinTimeout: number,
+    lfs: boolean = false,
 ): ScrimSettings {
     return {
-        teamSize, teamCount, mode, competitive, observable, checkinTimeout,
+        teamSize, teamCount, mode, competitive, observable, lfs, checkinTimeout,
     };
 }
 

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -88,26 +88,22 @@ export class ScrimService {
         numRounds,
         join,
     }: CreateLFSScrimRequest): Promise<Scrim> {
-        for (const j of join) {
-            if (await this.scrimCrudService.playerInAnyScrim(j.playerId)) throw new RpcException(MatchmakingError.PlayerAlreadyInScrim);
-        }
-        if (join.filter(j => j.createGroup).length !== 0 && !this.scrimGroupService.modeAllowsGroups(settings.mode)) throw new RpcException(MatchmakingError.ScrimGroupNotSupportedInMode);
+        if (await this.scrimCrudService.playerInAnyScrim(join.playerId)) throw new RpcException(MatchmakingError.PlayerAlreadyInScrim);
+        if (join.createGroup && !this.scrimGroupService.modeAllowsGroups(settings.mode)) throw new RpcException(MatchmakingError.ScrimGroupNotSupportedInMode);
         
         const players: ScrimPlayer[] = [];
         const teams: ScrimPlayer[][] = [];
         teams[0] = [];
         teams[1] = [];
 
-        for (const j of join) {
-            const player = {
-                id: j.playerId,
-                name: j.playerName,
-                joinedAt: new Date(),
-                leaveAt: add(new Date(), {seconds: j.leaveAfter}),
-            };
-            players.push(player);
-            if (j.team) teams[j.team].push(player);
-        }
+        const player = {
+            id: join.playerId,
+            name: join.playerName,
+            joinedAt: new Date(),
+            leaveAt: add(new Date(), {seconds: join.leaveAfter}),
+        };
+        players.push(player);
+        if (join.team) teams[join.team].push(player);
 
         const scrim = await this.scrimCrudService.createLFSScrim(
             authorId,

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -4,7 +4,6 @@ import type {
     CreateLFSScrimRequest,
     CreateScrimOptions,
     JoinScrimOptions,
-    PopLFSScrimRequest,
     Scrim,
     ScrimPlayer,
 } from "@sprocketbot/common";
@@ -122,7 +121,12 @@ export class ScrimService {
         scrim.submissionId = sId;
         await this.scrimCrudService.setSubmissionId(scrim.id, sId);
         await this.eventsService.publish(EventTopic.ScrimCreated, scrim, scrim.id);
+        
+        // For the same reason, set the scrim in PENDING status
+        scrim.status = ScrimStatus.IN_PROGRESS;
+        await this.scrimCrudService.updateScrimStatus(scrim.id, scrim.status);
 
+        console.log(`Created LFS scrim: ${JSON.stringify(scrim)}`);
         this.analyticsService.send(AnalyticsEndpoint.Analytics, {
             name: "scrimCreated",
             tags: [ ["playerId", `${authorId}`] ],

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -4,6 +4,7 @@ import type {
     CreateLFSScrimRequest,
     CreateScrimOptions,
     JoinScrimOptions,
+    PopLFSScrimRequest,
     Scrim,
     ScrimPlayer,
 } from "@sprocketbot/common";
@@ -116,6 +117,10 @@ export class ScrimService {
             numRounds,
         );
 
+        // Set the submissionId right away for LFS scrims, there is no Pop event
+        const sId = `scrim-${scrim.id}`;
+        scrim.submissionId = sId;
+        await this.scrimCrudService.setSubmissionId(scrim.id, sId);
         await this.eventsService.publish(EventTopic.ScrimCreated, scrim, scrim.id);
 
         this.analyticsService.send(AnalyticsEndpoint.Analytics, {


### PR DESCRIPTION
Adds a new landing page for franchise staff to manage team scrims:

- CRUD ops
- Upload replays

Have verified all behavior locally *aside from submission*, as I don't have replay-parse up and running locally yet. That's the last PR before we go live with this to staging. 