### PR TITLE
Submission, ratification, validation, and finalization for LFS scrims.

### DIFF
--- a/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/CreateLFSScrimModal.svelte
@@ -1,138 +1,138 @@
 <script lang="ts">
-    import {type GamesAndModesValue, createLFSScrimMutation} from "$lib/api";
-    import {gamesAndModes} from "$lib/api/queries/GamesAndModes.store";
-    import {Modal} from "$lib/components";
+  import { type GamesAndModesValue, createLFSScrimMutation } from "$lib/api";
+  import { gamesAndModes } from "$lib/api/queries/GamesAndModes.store";
+  import { Modal } from "$lib/components";
 
-    export let visible = false;
+  export let visible = false;
 
-    let game: GamesAndModesValue["games"][0];
-    let mode: GamesAndModesValue["games"][0]["modes"][0];
-    let scrimType: "TEAMS" | "ROUND_ROBIN" = "TEAMS";
-    let leaveAfter: number = 1800;
-    let competitive: boolean = true;
-    let createGroup: boolean = false;
-    let numRounds: number = 0;
-    let buttonEnabled = true;
+  let game: GamesAndModesValue["games"][0];
+  let mode: GamesAndModesValue["games"][0]["modes"][0];
+  let scrimType: "TEAMS" | "ROUND_ROBIN" = "TEAMS";
+  let leaveAfter: number = 1800;
+  let competitive: boolean = true;
+  let createGroup: boolean = false;
+  let numRounds: number = 0;
+  let buttonEnabled = true;
 
-    async function createScrim() {
-        buttonEnabled = false;
-        try {
-            const data = {
-                settings: {
-                    mode: scrimType,
-                    competitive: competitive,
-                    observable: false,
-                    lfs: true,
-                },
-                gameModeId: mode.id,
-                createGroup: createGroup,
-                leaveAfter: leaveAfter,
-                numRounds: numRounds,
-            };
-            await createLFSScrimMutation(data);
-            visible = false;
-        } finally {
-            buttonEnabled = true;
-        }
+  async function createScrim() {
+    buttonEnabled = false;
+    try {
+      const data = {
+        settings: {
+          mode: scrimType,
+          competitive: competitive,
+          observable: false,
+          lfs: true,
+        },
+        gameModeId: mode.id,
+        createGroup: createGroup,
+        leaveAfter: leaveAfter,
+        numRounds: numRounds,
+      };
+      await createLFSScrimMutation(data);
+      visible = false;
+    } finally {
+      buttonEnabled = true;
     }
+  }
 </script>
 
 <Modal title="Create LFS (Team) Scrim" bind:visible id="create-scrim-modal">
-    <form on:submit|preventDefault={createScrim} slot="body">
-        <div class="divider my-1"></div>
+  <form on:submit|preventDefault={createScrim} slot="body">
+    <div class="divider my-1"></div>
 
-        <div class="form-control">
-            <label class="label" for="game">
-                <span class="label-text">Game:</span>
-            </label>
-            <select
-                    name="game"
-                    bind:value={game}
-            >
-                <option disabled selected>Make a selection</option>
-                {#each $gamesAndModes?.data?.games ?? [] as g (g.id)}
-                    <option value={g}>{g.title}</option>
-                {/each}
-            </select>
-        </div>
+    <div class="form-control">
+      <label class="label" for="game">
+        <span class="label-text">Game:</span>
+      </label>
+      <select name="game" bind:value={game}>
+        <option disabled selected>Make a selection</option>
+        {#each $gamesAndModes?.data?.games ?? [] as g (g.id)}
+          <option value={g}>{g.title}</option>
+        {/each}
+      </select>
+    </div>
 
-        <div class="form-control">
-            <label class="label" for="game-mode">
-                <span class="label-text">Game Mode:</span>
-            </label>
-            <select name="game-mode" bind:value={mode}>
-                <option disabled selected>Make a selection</option>
-                {#each game?.modes ?? [] as g (g.id)}
-                    <option value={g}>{g.description}</option>
-                {/each}
-            </select>
-        </div>
+    <div class="form-control">
+      <label class="label" for="game-mode">
+        <span class="label-text">Game Mode:</span>
+      </label>
+      <select name="game-mode" bind:value={mode}>
+        <option disabled selected>Make a selection</option>
+        {#each game?.modes ?? [] as g (g.id)}
+          <option value={g}>{g.description}</option>
+        {/each}
+      </select>
+    </div>
 
-        <div class="form-control">
-            <label class="label" for="scrim-type">
-                <span class="label-text">Number of Games:</span>
-            </label>
-            <input type="number" name="num-rounds" bind:value={numRounds} />
-        </div>
+    <div class="form-control">
+      <label class="label" for="scrim-type">
+        <span class="label-text">Number of Games (must be at least 5):</span>
+      </label>
+      <input type="number" name="num-rounds" min="5" bind:value={numRounds} />
+    </div>
 
-        <div class="form-control">
-            <label class="label" for="scrim-leave-after">
-                <span class="label-text">Leave After:</span>
-            </label>
-            <select name="scrim-leave-after" bind:value={leaveAfter}>
-                <option value={1800} selected>30 Minutes</option>
-                <option value={3600}>1 Hour</option>
-                <option value={10800}>3 Hours</option>
-                <option value={21600}>6 Hours</option>
-            </select>
-        </div>
+    <div class="form-control">
+      <label class="label" for="scrim-leave-after">
+        <span class="label-text">Leave After:</span>
+      </label>
+      <select name="scrim-leave-after" bind:value={leaveAfter}>
+        <option value={1800} selected>30 Minutes</option>
+        <option value={3600}>1 Hour</option>
+        <option value={10800}>3 Hours</option>
+        <option value={21600}>6 Hours</option>
+      </select>
+    </div>
 
-        <div class="form-control inline">
-            <label class="cursor-pointer label" for="competitive">
-                <span class="label-text">Competitive</span>
-                <input
-                    type="checkbox"
-                    bind:checked={competitive}
-                    class="toggle toggle-primary"
-                    name="competitive"
-                />
-            </label>
-        </div>
+    <div class="form-control inline">
+      <label class="cursor-pointer label" for="competitive">
+        <span class="label-text">Competitive</span>
+        <input
+          type="checkbox"
+          bind:checked={competitive}
+          class="toggle toggle-primary"
+          name="competitive"
+        />
+      </label>
+    </div>
 
-        <button class="btn btn-primary btn-wide flex mx-auto mb-4" disabled={!buttonEnabled}>Create</button>
-    </form>
+    <button
+      class="btn btn-primary btn-wide flex mx-auto mb-4"
+      disabled={!buttonEnabled}>Create</button
+    >
+  </form>
 </Modal>
 
 <style lang="postcss">
-    form {
-        @apply flex flex-col gap-2 md:gap-4;
+  form {
+    @apply flex flex-col gap-2 md:gap-4;
 
-        .form-control.inline {
-            @apply flex flex-row justify-between items-center py-2;
-        }
-
-        label {
-            @apply contents;
-        }
-
-        select {
-            @apply mt-2 outline-1 select select-bordered select-sm;
-
-            option {
-                @apply py-2;
-            }
-
-            &:disabled {
-                @apply bg-gray-700 cursor-not-allowed;
-            }
-        }
-
-        input {
-            @apply ml-auto;
-        }
-
-        input:disabled {
-            @apply text-right px-4 py-1 bg-gray-700;
-        }
+    .form-control.inline {
+      @apply flex flex-row justify-between items-center py-2;
     }
+
+    label {
+      @apply contents;
+    }
+
+    select {
+      @apply mt-2 outline-1 select select-bordered select-sm;
+
+      option {
+        @apply py-2;
+      }
+
+      &:disabled {
+        @apply bg-gray-700 cursor-not-allowed;
+      }
+    }
+
+    input {
+      @apply ml-auto;
+    }
+
+    input:disabled {
+      @apply text-right px-4 py-1 bg-gray-700;
+    }
+  }
 </style>

--- a/clients/web/src/lib/components/organisms/submissions/RatificationView.svelte
+++ b/clients/web/src/lib/components/organisms/submissions/RatificationView.svelte
@@ -1,69 +1,83 @@
 <script lang="ts">
-    import type {Submission} from "../../../api";
-    import {RatifySubmissionMutation} from "../../../api";
-    import {GameCard, Progress} from "../../index";
-    import RejectSubmissionModal from "../scrims/modals/RejectSubmissionModal.svelte";
+  import type { Submission } from "../../../api";
+  import { RatifySubmissionMutation } from "../../../api";
+  import { GameCard, Progress } from "../../index";
+  import RejectSubmissionModal from "../scrims/modals/RejectSubmissionModal.svelte";
 
-    export let submission: Submission;
-    if (!submission) throw new Error();
+  export let submission: Submission;
+  if (!submission) throw new Error();
 
+  const submissionResults = [false];
 
-    const submissionResults = [false];
+  let readyToRatify;
+  $: readyToRatify =
+    Array.from(submissionResults).every(Boolean) &&
+    submissionResults.length === submission.stats.games.length;
+  let hasRatified = submission.userHasRatified;
 
-    let readyToRatify;
-    $: readyToRatify = Array.from(submissionResults).every(Boolean) && submissionResults.length === submission.stats.games.length;
-    let hasRatified = submission.userHasRatified;
+  async function ratifyScrim() {
+    if (hasRatified) return;
+    await RatifySubmissionMutation({ submissionId: submission.id });
+    // eslint-disable-next-line require-atomic-updates
+    hasRatified = true;
+  }
 
-    async function ratifyScrim() {
-        if (hasRatified) return;
-        await RatifySubmissionMutation({submissionId: submission.id});
-        // eslint-disable-next-line require-atomic-updates
-        hasRatified = true;
-    }
+  let rejecting: boolean = false;
 
-    let rejecting: boolean = false;
-
-    const reject = () => {
-        rejecting = true;
-    };
+  const reject = () => {
+    rejecting = true;
+  };
 </script>
 
 <section class="space-y-4">
-    <h2>Replays are done parsing!</h2>
-    <p>Now, carefully review the results to make sure we got everything right. Once you have decided a replay is
-        correct, click the checkbox in the top right corner</p>
+  <h2>Replays are done parsing!</h2>
+  <p>
+    Now, carefully review the results to make sure we got everything right. Once
+    you have decided a replay is correct, click the checkbox in the top right
+    corner
+  </p>
 
-    <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-4">
-        {#each submission.stats.games as game, gameIndex}
-            <GameCard {game} title="Game {gameIndex + 1}" showCheckbox={!hasRatified}
-                      bind:checkboxValue={submissionResults[gameIndex]} showResult/>
-        {/each}
-    </div>
+  <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-4">
+    {#each submission.stats.games as game, gameIndex}
+      <GameCard
+        {game}
+        title="Game {gameIndex + 1}"
+        showCheckbox={!hasRatified}
+        bind:checkboxValue={submissionResults[gameIndex]}
+        showResult
+      />
+    {/each}
+  </div>
 
-    <Progress value={submission.ratifications} max={submission.requiredRatifications}/>
+  <Progress
+    value={submission.ratifications}
+    max={submission.requiredRatifications}
+  />
 
-
-    <div class="w-full flex gap-4 flex-col md:flex-row justify-around">
-        {#if !hasRatified}
-            {#if readyToRatify}
-                <button class="btn btn-success btn-outline" on:click={ratifyScrim}>Looks good to me!</button>
-            {:else}
-                <div/>
-            {/if}
-            <button class="btn btn-error btn-outline" on:click={reject}>These aren't correct</button>
-        {:else}
-            <span class="text-xl font-bold text-primary">You have already ratified</span>
-        {/if}
-    </div>
-
-
-
+  <div class="w-full flex gap-4 flex-col md:flex-row justify-around">
+    {#if !hasRatified}
+      {#if readyToRatify}
+        <button class="btn btn-success btn-outline" on:click={ratifyScrim}
+          >Looks good to me!</button
+        >
+      {:else}
+        <div />
+      {/if}
+      <button class="btn btn-error btn-outline" on:click={reject}
+        >These aren't correct</button
+      >
+    {:else}
+      <span class="text-xl font-bold text-primary"
+        >You have already ratified</span
+      >
+    {/if}
+  </div>
 </section>
 
 <RejectSubmissionModal bind:visible={rejecting} submissionId={submission.id} />
 
 <style lang="postcss">
-    h2 {
-        @apply text-2xl font-bold text-primary;
-    }
+  h2 {
+    @apply text-2xl font-bold text-primary;
+  }
 </style>

--- a/clients/web/src/lib/components/organisms/submissions/SubmissionView.svelte
+++ b/clients/web/src/lib/components/organisms/submissions/SubmissionView.svelte
@@ -1,15 +1,14 @@
-<script lang='ts'>
-  import type {Submission} from "$lib/api";
+<script lang="ts">
+  import type { Submission } from "$lib/api";
 
   import SubmissionProgressView from "./SubmissionProgressView.svelte";
-import RatificationView from "./RatificationView.svelte";
+  import RatificationView from "./RatificationView.svelte";
 
   export let submission: Submission;
 </script>
 
-
 {#if !["RATIFYING", "RATIFIED"].includes(submission.status)}
-	<SubmissionProgressView  {submission} />
+  <SubmissionProgressView {submission} />
 {:else}
-	<RatificationView {submission} />
+  <RatificationView {submission} />
 {/if}

--- a/clients/web/src/routes/league/scrim/[submissionId].svelte
+++ b/clients/web/src/routes/league/scrim/[submissionId].svelte
@@ -21,11 +21,6 @@
   let submission: SubmissionStoreValue["submission"] | undefined;
   $: if ($submissionStore) {
     submission = $submissionStore?.data?.submission;
-    if (submission && submission.games) {
-      for (const game of submission.games) {
-        console.log(JSON.stringify(game));
-      }
-    }
   }
 </script>
 

--- a/clients/web/src/routes/league/scrim/[submissionId].svelte
+++ b/clients/web/src/routes/league/scrim/[submissionId].svelte
@@ -1,0 +1,31 @@
+<script context="module" lang="ts">
+  export const load = ({ params }: unknown): unknown => ({
+    props: {
+      submissionId: params.submissionId,
+    },
+  });
+</script>
+
+<script lang="ts">
+  import type { SubmissionStoreValue } from "$lib/api";
+  import { SubmissionStore } from "$lib/api";
+  import { SubmissionView } from "$lib/components";
+  import DashboardLayout from "../../../lib/components/layouts/DashboardLayout.svelte";
+  import UploadReplaysModal from "../../../lib/components/organisms/scrims/modals/UploadReplaysModal.svelte";
+
+  export let submissionId: string;
+  let submissionStore: SubmissionStore | undefined;
+  $: if (submissionId) {
+    submissionStore = new SubmissionStore(submissionId);
+  }
+  let submission: SubmissionStoreValue["submission"] | undefined;
+  $: if ($submissionStore) submission = $submissionStore?.data?.submission;
+</script>
+
+<DashboardLayout>
+  {#if submission}
+    <SubmissionView {submission} />
+  {:else}
+    <UploadReplaysModal {submissionId} />
+  {/if}
+</DashboardLayout>

--- a/clients/web/src/routes/league/scrim/[submissionId].svelte
+++ b/clients/web/src/routes/league/scrim/[submissionId].svelte
@@ -9,9 +9,12 @@
 <script lang="ts">
   import type { SubmissionStoreValue } from "$lib/api";
   import { SubmissionStore } from "$lib/api";
-  import { SubmissionView } from "$lib/components";
-  import DashboardLayout from "../../../lib/components/layouts/DashboardLayout.svelte";
-  import UploadReplaysModal from "../../../lib/components/organisms/scrims/modals/UploadReplaysModal.svelte";
+  import {
+    DashboardCard,
+    DashboardLayout,
+    SubmissionView,
+    UploadReplaysModal,
+  } from "$lib/components";
 
   export let submissionId: string;
   let submissionStore: SubmissionStore | undefined;
@@ -19,15 +22,15 @@
     submissionStore = new SubmissionStore(submissionId);
   }
   let submission: SubmissionStoreValue["submission"] | undefined;
-  $: if ($submissionStore) {
-    submission = $submissionStore?.data?.submission;
-  }
+  $: if ($submissionStore) submission = $submissionStore?.data?.submission;
 </script>
 
 <DashboardLayout>
-  {#if submission}
-    <SubmissionView {submission} />
-  {:else}
-    <UploadReplaysModal {submissionId} />
-  {/if}
+  <DashboardCard class="col-span-6 xl:col-span-5 row-span-3">
+    {#if submission}
+      <SubmissionView {submission} />
+    {:else}
+      <UploadReplaysModal {submissionId} />
+    {/if}
+  </DashboardCard>
 </DashboardLayout>

--- a/clients/web/src/routes/league/scrim/[submissionId].svelte
+++ b/clients/web/src/routes/league/scrim/[submissionId].svelte
@@ -19,7 +19,14 @@
     submissionStore = new SubmissionStore(submissionId);
   }
   let submission: SubmissionStoreValue["submission"] | undefined;
-  $: if ($submissionStore) submission = $submissionStore?.data?.submission;
+  $: if ($submissionStore) {
+    submission = $submissionStore?.data?.submission;
+    if (submission && submission.games) {
+      for (const game of submission.games) {
+        console.log(JSON.stringify(game));
+      }
+    }
+  }
 </script>
 
 <DashboardLayout>

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -1,56 +1,66 @@
 <script lang="ts">
-	import {
-	    CreateLFSScrimModal, DashboardLayout, DashboardCard, ScrimTable, Spinner, UploadReplaysModal
-	} from "$lib/components";
-	import {
-		LFSScrimsStore, type CurrentScrim
-	} from "$lib/api";
+  import {
+    CreateLFSScrimModal,
+    DashboardLayout,
+    DashboardCard,
+    ScrimTable,
+    Spinner,
+    UploadReplaysModal,
+  } from "$lib/components";
+  import { LFSScrimsStore, type CurrentScrim } from "$lib/api";
 
-	const store = new LFSScrimsStore();
-	let fetching = true;
-	let uploading = false;
-	let creating = false;
-	let submissionId: string = "";
-	let scrims: CurrentScrim[] | undefined = [];
+  const store = new LFSScrimsStore();
+  let fetching = true;
+  let uploading = false;
+  let creating = false;
+  let submissionId: string = "";
+  let scrims: CurrentScrim[] | undefined = [];
 
-	$: {
-		// @ts-expect-error `fetching` exists on the query store but isn't defined in the type
-	    fetching = $store.fetching;
-		scrims = $store.data?.LFSScrims;
-	}
+  $: {
+    // @ts-expect-error `fetching` exists on the query store but isn't defined in the type
+    fetching = $store.fetching;
+    scrims = $store.data?.LFSScrims;
+  }
 
-	const openUploadModal = (scrim: CurrentScrim) => {
-		console.log(JSON.stringify(scrim));
-        submissionId = scrim.submissionId ?? "";
-        uploading = true;
-    };
-	
-	const openCreateScrimModal = () => {
-		creating = true;
-	}
+  const openUploadModal = (scrim: CurrentScrim) => {
+    console.log(JSON.stringify(scrim));
+    submissionId = scrim.submissionId ?? "";
+    window.location.href = `/league/scrim/${submissionId}`;
+  };
+
+  const openCreateScrimModal = () => {
+    creating = true;
+  };
 </script>
 
 <DashboardLayout>
-	<DashboardCard class="col-span-8 row-span-3" title="LFS (Team) Scrims">
-		<div class="flex flex-col md:flex-row justify-between mb-4">
-			<h2>Available Scrims</h2>
-			<button class="btn btn-primary w-full md:w-auto" on:click={openCreateScrimModal}>
-				Create LFS Scrim
-			</button>
-		</div>
-		{#if fetching}
-			<div class="h-full w-full flex items-center justify-center">
-				<Spinner class="h-16 w-full"/>
-			</div>
-		{:else if scrims}
-			<ScrimTable scrims={scrims} lfs={true} joinScrim={(scrim) => openUploadModal(scrim)}/>
-		{:else}
-			<div class="h-full w-full flex items-center justify-center">
-				No scrims found
-			</div>
-		{/if}
-	</DashboardCard>
+  <DashboardCard class="col-span-8 row-span-3" title="LFS (Team) Scrims">
+    <div class="flex flex-col md:flex-row justify-between mb-4">
+      <h2>Available Scrims</h2>
+      <button
+        class="btn btn-primary w-full md:w-auto"
+        on:click={openCreateScrimModal}
+      >
+        Create LFS Scrim
+      </button>
+    </div>
+    {#if fetching}
+      <div class="h-full w-full flex items-center justify-center">
+        <Spinner class="h-16 w-full" />
+      </div>
+    {:else if scrims}
+      <ScrimTable
+        {scrims}
+        lfs={true}
+        joinScrim={(scrim) => openUploadModal(scrim)}
+      />
+    {:else}
+      <div class="h-full w-full flex items-center justify-center">
+        No scrims found
+      </div>
+    {/if}
+  </DashboardCard>
 </DashboardLayout>
 
-<UploadReplaysModal bind:visible={uploading} submissionId={submissionId}/>
+<UploadReplaysModal bind:visible={uploading} {submissionId} />
 <CreateLFSScrimModal bind:visible={creating} />

--- a/clients/web/src/routes/league/scrim/index.svelte
+++ b/clients/web/src/routes/league/scrim/index.svelte
@@ -8,6 +8,7 @@
     UploadReplaysModal,
   } from "$lib/components";
   import { LFSScrimsStore, type CurrentScrim } from "$lib/api";
+  import { goto } from "$app/navigation";
 
   const store = new LFSScrimsStore();
   let fetching = true;
@@ -17,15 +18,13 @@
   let scrims: CurrentScrim[] | undefined = [];
 
   $: {
-    // @ts-expect-error `fetching` exists on the query store but isn't defined in the type
     fetching = $store.fetching;
     scrims = $store.data?.LFSScrims;
   }
 
   const openUploadModal = (scrim: CurrentScrim) => {
-    console.log(JSON.stringify(scrim));
     submissionId = scrim.submissionId ?? "";
-    window.location.href = `/league/scrim/${submissionId}`;
+    goto(`/league/scrim/${submissionId}`);
   };
 
   const openCreateScrimModal = () => {

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -1,6 +1,28 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"baseUrl": "..",
+		"paths": {
+			"$lib": [
+				"src/lib"
+			],
+			"$lib/*": [
+				"src/lib/*"
+			]
+		},
+		"rootDirs": [
+			"..",
+			"./types"
+		],
+		"isolatedModules": true,
+		"lib": [
+			"esnext",
+			"DOM",
+			"DOM.Iterable"
+		],
+		"verbatimModuleSyntax": true,
+		"moduleResolution": "node",
+		"module": "esnext",
+		"target": "esnext",
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,
@@ -11,6 +33,19 @@
 		"strict": true,
 		"outDir": ".svelte-kit"
 	},
+	"include": [
+		"ambient.d.ts",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte",
+		"../src/**/*.js",
+		"../src/**/*.ts",
+		"../src/**/*.svelte"
+	],
+	"exclude": [
+		"../node_modules/**",
+		"./[!ambient.d.ts]**"
+	],
 	"typeAcquisition": {
 		"include": ["src/app.d.ts"]
 	},

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -19,7 +19,6 @@
 			"DOM",
 			"DOM.Iterable"
 		],
-		"verbatimModuleSyntax": true,
 		"moduleResolution": "node",
 		"module": "esnext",
 		"target": "esnext",

--- a/common/src/events/events.types.ts
+++ b/common/src/events/events.types.ts
@@ -42,6 +42,7 @@ export enum EventTopic {
     SubmissionRejected = "submission.rejected",
 
     SubmissionReset = "submission.reset",
+    SubmissionUpdated = "submission.updated",
 
     // Member
     AllMemberEvents = "member.*",
@@ -96,6 +97,7 @@ export const EventSchemas = {
     [EventTopic.SubmissionRejected]: SubmissionEventSchema,
     [EventTopic.SubmissionReset]: SubmissionEventSchema,
     [EventTopic.SubmissionProgress]: SubmissionEventSchema,
+    [EventTopic.SubmissionUpdated]: SubmissionEventSchema,
     [EventTopic.AllSubmissionEvents]: z.union([
         SubmissionRatificationSchema,
         SubmissionEventSchema,

--- a/common/src/service-connectors/core/schemas/GetGameByGameMode.schema.ts
+++ b/common/src/service-connectors/core/schemas/GetGameByGameMode.schema.ts
@@ -7,4 +7,12 @@ export const GetGameByGameMode_Request = z.object({
 export const GetGameByGameMode_Response = z.object({
     id: z.number(),
     title: z.string(),
+    mode: z.object({
+        id: z.number(),
+        description: z.string(),
+        teamCount: z.number(),
+        teamSize: z.number(),
+    }).optional(),
 });
+
+export type GetGameByGameModeResponse = z.infer<typeof GetGameByGameMode_Response>;

--- a/common/src/service-connectors/matchmaking/matchmaking.types.ts
+++ b/common/src/service-connectors/matchmaking/matchmaking.types.ts
@@ -17,6 +17,7 @@ export enum MatchmakingEndpoint {
     CompleteScrim = "CompleteScrim",
     CancelScrim = "CancelScrim",
     SetScrimLocked = "SetScrimLocked",
+    UpdateLFSScrimPlayers = "UpdateLFSScrimPlayers",
 }
 
 export const MatchmakingSchemas = {
@@ -71,6 +72,10 @@ export const MatchmakingSchemas = {
     [MatchmakingEndpoint.SetScrimLocked]: {
         input: Schemas.SetScrimLocked_Request,
         output: Schemas.SetScrimLocked_Response,
+    },
+    [MatchmakingEndpoint.UpdateLFSScrimPlayers]: {
+        input: Schemas.UpdateLFSScrimPlayers_Request,
+        output: Schemas.UpdateLFSScrimPlayers_Response,
     },
 };
 

--- a/common/src/service-connectors/matchmaking/schemas/scrim/UpdateLFSScrimPlayers.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/UpdateLFSScrimPlayers.schema.ts
@@ -1,0 +1,16 @@
+import {z} from "zod";
+
+import {
+    ScrimPlayerSchema,
+} from "../../types";
+
+export const UpdateLFSScrimPlayers_Request = z.object({
+    players: z.array(ScrimPlayerSchema),
+    teams: z.array(z.array(ScrimPlayerSchema)),
+});
+
+export const UpdateLFSScrimPlayers_Response = z.boolean();
+
+export type UpdateLFSScrimPlayersRequest = z.infer<typeof UpdateLFSScrimPlayers_Request>;
+export type UpdateLFSScrimPlayersResponse = z.infer<typeof UpdateLFSScrimPlayers_Response>;
+

--- a/common/src/service-connectors/matchmaking/schemas/scrim/UpdateLFSScrimPlayers.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/UpdateLFSScrimPlayers.schema.ts
@@ -5,8 +5,9 @@ import {
 } from "../../types";
 
 export const UpdateLFSScrimPlayers_Request = z.object({
+    scrimId: z.string(),
     players: z.array(ScrimPlayerSchema),
-    teams: z.array(z.array(ScrimPlayerSchema)),
+    games: z.array(z.array(z.array(ScrimPlayerSchema))),
 });
 
 export const UpdateLFSScrimPlayers_Response = z.boolean();

--- a/common/src/service-connectors/matchmaking/schemas/scrim/index.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/index.ts
@@ -11,3 +11,4 @@ export * from "./GetScrimMetrics.schema";
 export * from "./JoinScrim.schema";
 export * from "./LeaveScrim.schema";
 export * from "./SetScrimLocked.schema";
+export * from "./UpdateLFSScrimPlayers.schema";

--- a/common/src/service-connectors/submission/schemas/Submission.schema.ts
+++ b/common/src/service-connectors/submission/schemas/Submission.schema.ts
@@ -25,4 +25,9 @@ const MatchSubmission = BaseSubmission.extend({
     matchId: z.number(),
 });
 
-export const SubmissionSchema = z.union([ScrimSubmission, MatchSubmission]);
+const LFSSubmission = BaseSubmission.extend({
+    type: z.literal(ReplaySubmissionType.LFS),
+    scrimId: z.string(),
+});
+
+export const SubmissionSchema = z.union([ScrimSubmission, MatchSubmission, LFSSubmission]);

--- a/common/src/service-connectors/submission/types/replay-submission.ts
+++ b/common/src/service-connectors/submission/types/replay-submission.ts
@@ -5,6 +5,7 @@ import type {ReplaySubmissionStats} from "./replay-submission-stats";
 export enum ReplaySubmissionType {
     MATCH = "MATCH",
     SCRIM = "SCRIM",
+    LFS = "LFS",
 }
 
 export enum ReplaySubmissionStatus {
@@ -41,4 +42,9 @@ export interface MatchReplaySubmission extends BaseReplaySubmission {
     matchId: number;
 }
 
-export type ReplaySubmission = ScrimReplaySubmission | MatchReplaySubmission;
+export interface LFSReplaySubmission extends BaseReplaySubmission {
+    type: ReplaySubmissionType.LFS;
+    scrimId: string;
+}
+
+export type ReplaySubmission = ScrimReplaySubmission | MatchReplaySubmission | LFSReplaySubmission;

--- a/core/src/franchise/player/player.controller.ts
+++ b/core/src/franchise/player/player.controller.ts
@@ -154,12 +154,15 @@ export class PlayerController {
 
     @MessagePattern(CoreEndpoint.GetPlayersByPlatformIds)
     async getPlayersByPlatformIds(@Payload() payload: unknown): Promise<CoreOutput<CoreEndpoint.GetPlayersByPlatformIds>> {
+        this.logger.verbose(`Getting players by platform ids: ${JSON.stringify(payload)}`);
         const data = CoreSchemas[CoreEndpoint.GetPlayersByPlatformIds].input.parse(payload);
 
         const allResults = await Promise.allSettled(data.map(async p => this.playerService.getPlayerByGameAndPlatformPayload(p)));
 
         if (allResults.every(r => r.status === "fulfilled")) {
-            return allResults.map(r => (r as PromiseFulfilledResult<CoreOutput<CoreEndpoint.GetPlayerByPlatformId>>).value);
+            const result = allResults.map(r => (r as PromiseFulfilledResult<CoreOutput<CoreEndpoint.GetPlayerByPlatformId>>).value);
+            this.logger.verbose(`Successfully fetched players by platform ids: ${JSON.stringify(result)}`);
+            return result;
         }
 
         throw new Error(`Failed to fetch players by platform accounts: ${

--- a/core/src/game/game/game.controller.ts
+++ b/core/src/game/game/game.controller.ts
@@ -3,7 +3,6 @@ import {MessagePattern, Payload} from "@nestjs/microservices";
 import type {GetGameByGameModeResponse} from "@sprocketbot/common";
 import {CoreEndpoint, CoreSchemas} from "@sprocketbot/common";
 
-import type {Game} from "../../database";
 import {GameModeService} from "../game-mode";
 
 @Controller("game")

--- a/core/src/game/game/game.controller.ts
+++ b/core/src/game/game/game.controller.ts
@@ -1,5 +1,6 @@
 import {Controller} from "@nestjs/common";
 import {MessagePattern, Payload} from "@nestjs/microservices";
+import type {GetGameByGameModeResponse} from "@sprocketbot/common";
 import {CoreEndpoint, CoreSchemas} from "@sprocketbot/common";
 
 import type {Game} from "../../database";
@@ -10,10 +11,20 @@ export class GameController {
     constructor(private readonly gameModeService: GameModeService) {}
 
     @MessagePattern(CoreEndpoint.GetGameByGameMode)
-    async getGameByGameMode(@Payload() payload: unknown): Promise<Game> {
+    async getGameByGameMode(@Payload() payload: unknown): Promise<GetGameByGameModeResponse> {
         const data = CoreSchemas[CoreEndpoint.GetGameByGameMode].input.parse(payload);
         const gameMode = await this.gameModeService.getGameModeById(data.gameModeId, {relations: {game: true} });
+        const res: GetGameByGameModeResponse = {
+            id: gameMode.game.id,
+            title: gameMode.game.title,
+            mode: {
+                id: gameMode.id,
+                description: gameMode.description,
+                teamCount: gameMode.teamCount,
+                teamSize: gameMode.teamSize,
+            },
+        };
         
-        return gameMode.game;
+        return res;
     }
 }

--- a/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
+++ b/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
@@ -69,7 +69,7 @@ export class RocketLeagueFinalizationService {
 
             this.logger.debug(`Update eligibilities for ${JSON.stringify(uniquePlayers)}`);
             if (scrim.settings.competitive) {
-                const eligibilities = uniquePlayers.map(p => this._createEligibility(p, match.matchParent, em));
+                const eligibilities = uniquePlayers.map(p => this._createEligibility(3, p, match.matchParent, em));
                 this.logger.debug(`Got eligibilities: ${JSON.stringify(eligibilities)}`);
                 await em.insert(EligibilityData, eligibilities as QueryDeepPartialEntity<EligibilityData>);
             }
@@ -122,7 +122,7 @@ export class RocketLeagueFinalizationService {
             const uniquePlayers = await this.saveMatchDependents(submission, match, em);
 
             if (scrim.settings.competitive) {
-                const eligibilities = uniquePlayers.map(p => this._createEligibility(p, match.matchParent, em));
+                const eligibilities = uniquePlayers.map(p => this._createEligibility(5, p, match.matchParent, em));
                 await em.insert(EligibilityData, eligibilities as QueryDeepPartialEntity<EligibilityData>);
             }
 
@@ -361,11 +361,11 @@ export class RocketLeagueFinalizationService {
         return output;
     }
 
-    _createEligibility(player: Player, matchParent: MatchParent, em: EntityManager): EligibilityData {
+    _createEligibility(points: number, player: Player, matchParent: MatchParent, em: EntityManager): EligibilityData {
         const output = em.create(EligibilityData);
         output.matchParent = matchParent;
         output.player = player;
-        output.points = 5;
+        output.points = points;
         return output;
     }
 

--- a/core/src/replay-parse/replay-parse.mod.resolver.ts
+++ b/core/src/replay-parse/replay-parse.mod.resolver.ts
@@ -74,6 +74,9 @@ export class ReplayParseModResolver {
 
         if (submission.type === ReplaySubmissionType.MATCH) {
             await this.finalizationSub.onMatchSubmissionComplete(submission, submissionId);
+        } else if (submission.type === ReplaySubmissionType.LFS) {
+            const scrim = await this.scrimService.getScrimBySubmissionId(submission.id);
+            await this.finalizationSub.onLFSComplete(submission, submission.id, scrim!);
         } else {
             const scrim = await this.scrimService.getScrimBySubmissionId(submission.id);
             await this.finalizationSub.onScrimComplete(submission, submission.id, scrim!);

--- a/core/src/replay-parse/types/replay-submission.types.ts
+++ b/core/src/replay-parse/types/replay-submission.types.ts
@@ -12,7 +12,9 @@ import {ReplaySubmissionStats} from "./submission-stats.types";
 export enum ReplaySubmissionType {
     MATCH = "MATCH",
     SCRIM = "SCRIM",
+    LFS = "LFS",
 }
+
 registerEnumType(ReplaySubmissionType, {name: "ReplaySubmissionType"});
 registerEnumType(ReplaySubmissionStatus, {name: "ReplaySubmissionStatus"});
 
@@ -76,4 +78,10 @@ export class MatchReplaySubmission extends GqlReplaySubmission {
     matchId: Match["id"];
 }
 
-export type ReplaySubmission = MatchReplaySubmission | ScrimReplaySubmission;
+export class LFSReplaySubmission extends GqlReplaySubmission {
+    type: ReplaySubmissionType.LFS = ReplaySubmissionType.LFS;
+
+    scrimId: Scrim["id"];
+}
+
+export type ReplaySubmission = MatchReplaySubmission | ScrimReplaySubmission | LFSReplaySubmission;

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -83,9 +83,18 @@ export class ScrimCrudService {
 
         players.map(p => scrim.players.push(p));
         for (let i = 0;i < numRounds;i++) {
+            const now = new Date();
             const game = {
-                teams: teams.map(t => ({
-                    players: t.map(p => p),
+                teams: ["orange", "blue"].map(() => ({
+                    players: [
+                        {
+                            id: 1,
+                            name: "Placeholder",
+                            joinedAt: now,
+                            // eslint-disable-next-line no-mixed-operators
+                            leaveAt: new Date(now.getTime() + 30 * 60 * 1000),
+                        },
+                    ],
                 })),
             };
             scrim.games?.push(game);
@@ -97,6 +106,13 @@ export class ScrimCrudService {
         );
 
         return scrim;
+    }
+
+    async updateLFSScrim(scrim: Scrim): Promise<void> {
+        await this.redisService.setJson(
+            `${this.prefix}${scrim.id}`,
+            scrim,
+        );
     }
 
     async removeScrim(id: string): Promise<void> {

--- a/microservices/matchmaking-service/src/scrim/scrim.controller.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.controller.ts
@@ -30,6 +30,12 @@ export class ScrimController {
         const data = MatchmakingSchemas.CreateLFSScrim.input.parse(payload);
         return this.scrimService.createLFSScrim(data);
     }
+    
+    @MessagePattern(MatchmakingEndpoint.UpdateLFSScrimPlayers)
+    async updateLFSScrimPlayers(@Payload() payload: unknown): Promise<boolean> {
+        const data = MatchmakingSchemas.UpdateLFSScrimPlayers.input.parse(payload);
+        return this.scrimService.updateLFSScrimPlayers(data);
+    }
 
     @MessagePattern(MatchmakingEndpoint.GetAllScrims)
     async getAllScrims(@Payload() payload: unknown): Promise<Scrim[]> {

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -6,12 +6,15 @@ import type {
     JoinScrimOptions,
     Scrim,
     ScrimPlayer,
+    UpdateLFSScrimPlayersRequest,
 } from "@sprocketbot/common";
 import {
     AnalyticsEndpoint,
     AnalyticsService,
     EventTopic,
     MatchmakingError,
+    ScrimGameSchema,
+    ScrimSchema,
     ScrimStatus,
 } from "@sprocketbot/common";
 import {add} from "date-fns";
@@ -136,9 +139,21 @@ export class ScrimService {
     }
 
     async updateLFSScrimPlayers({
-
-    }): Promise<boolean> {
-        
+        scrimId,
+        players,
+        games,
+    }: UpdateLFSScrimPlayersRequest): Promise<boolean> {
+        const rawscrim = await this.scrimCrudService.getScrim(scrimId);
+        if (!rawscrim) return false;
+        const scrim = ScrimSchema.parse(rawscrim);
+        scrim.players = players;
+        for (const g of games) {
+            const game = ScrimGameSchema.parse(g);
+            if (scrim.games?.includes(game)) continue;
+            scrim.games?.push(game);
+        }
+        await this.scrimCrudService.updateLFSScrim(scrim);
+        return true;
     }
 
     async joinScrim({

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -126,7 +126,6 @@ export class ScrimService {
         scrim.status = ScrimStatus.IN_PROGRESS;
         await this.scrimCrudService.updateScrimStatus(scrim.id, scrim.status);
 
-        console.log(`Created LFS scrim: ${JSON.stringify(scrim)}`);
         this.analyticsService.send(AnalyticsEndpoint.Analytics, {
             name: "scrimCreated",
             tags: [ ["playerId", `${authorId}`] ],
@@ -134,6 +133,12 @@ export class ScrimService {
         }).catch(err => { this.logger.error(err) });
 
         return scrim;
+    }
+
+    async updateLFSScrimPlayers({
+
+    }): Promise<boolean> {
+        
     }
 
     async joinScrim({

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -13,7 +13,6 @@ import {
     AnalyticsService,
     EventTopic,
     MatchmakingError,
-    ScrimGameSchema,
     ScrimSchema,
     ScrimStatus,
 } from "@sprocketbot/common";
@@ -120,7 +119,7 @@ export class ScrimService {
         );
 
         // Set the submissionId right away for LFS scrims, there is no Pop event
-        const sId = `scrim-${scrim.id}`;
+        const sId = `lfs-${scrim.id}`;
         scrim.submissionId = sId;
         await this.scrimCrudService.setSubmissionId(scrim.id, sId);
         await this.eventsService.publish(EventTopic.ScrimCreated, scrim, scrim.id);
@@ -148,7 +147,11 @@ export class ScrimService {
         const scrim = ScrimSchema.parse(rawscrim);
         scrim.players = players;
         for (const g of games) {
-            const game = ScrimGameSchema.parse(g);
+            const game = {
+                teams: g.map(t => ({
+                    players: t.map(p => p),
+                })),
+            };
             if (scrim.games?.includes(game)) continue;
             scrim.games?.push(game);
         }

--- a/microservices/submission-service/src/replay-submission/replay-submission-util.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-util.service.ts
@@ -10,7 +10,9 @@ import {
     ScrimStatus,
 } from "@sprocketbot/common";
 
-import {submissionIsMatch, submissionIsScrim} from "../utils";
+import {
+    submissionIsLFS, submissionIsMatch, submissionIsScrim,
+} from "../utils";
 import {ReplaySubmissionCrudService} from "./replay-submission-crud/replay-submission-crud.service";
 
 @Injectable()
@@ -40,7 +42,7 @@ export class ReplaySubmissionUtilService {
             };
         }
 
-        if (submissionIsScrim(submissionId)) {
+        if (submissionIsLFS(submissionId) || submissionIsScrim(submissionId)) {
             const result = await this.matchmakingService.send(MatchmakingEndpoint.GetScrimBySubmissionId, submissionId);
             if (result.status === ResponseStatus.ERROR) throw result.error;
             const scrim = result.data;
@@ -49,7 +51,7 @@ export class ReplaySubmissionUtilService {
                 reason:
                   `Could not find a associated scrim`,
             };
-            if (!scrim.players.some(p => p.id === userId)) {
+            if (submissionIsScrim(submissionId) && !scrim.players.some(p => p.id === userId)) {
                 // TODO: Check player's organization teams (i.e. Support override)
                 return {
                     canSubmit: false,

--- a/microservices/submission-service/src/replay-submission/replay-submission.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission.service.ts
@@ -6,11 +6,9 @@ import {
     CeleryService,
     EventsService,
     EventTopic,
-    MinioService,
     ProgressStatus,
     REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID,
     ReplaySubmissionStatus,
-    ReplaySubmissionType,
     Task,
 } from "@sprocketbot/common";
 import {v4} from "uuid";
@@ -28,7 +26,6 @@ export class ReplaySubmissionService {
 
     constructor(
         private readonly submissionCrudService: ReplaySubmissionCrudService,
-        private readonly minioService: MinioService,
         private readonly celeryService: CeleryService,
         private readonly eventsService: EventsService,
         @Inject(forwardRef(() => ReplayParseSubscriber))
@@ -210,6 +207,5 @@ export class ReplaySubmissionService {
             redisKey: getSubmissionKey(submissionId),
             resultPaths: refreshedSubmission.items.map(item => item.outputPath!),
         });
-    // TODO: Expose endpoint to remove submission.
     }
 }

--- a/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
+++ b/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
@@ -26,10 +26,7 @@ export class ReplayUploadController {
     @MessagePattern(SubmissionEndpoint.CanRatifySubmission)
     async canRatifySubmission(@Payload() payload: unknown): Promise<CanRatifySubmissionResponse> {
         const data = SubmissionSchemas.CanRatifySubmission.input.parse(payload);
-        // return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.memberId, data.userId);
-        return {
-            canRatify: true,
-        };
+        return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.memberId, data.userId);
     }
 
     @MessagePattern(SubmissionEndpoint.SubmitReplays)

--- a/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
+++ b/microservices/submission-service/src/replay-submission/replay-upload.controller.ts
@@ -26,7 +26,10 @@ export class ReplayUploadController {
     @MessagePattern(SubmissionEndpoint.CanRatifySubmission)
     async canRatifySubmission(@Payload() payload: unknown): Promise<CanRatifySubmissionResponse> {
         const data = SubmissionSchemas.CanRatifySubmission.input.parse(payload);
-        return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.memberId, data.userId);
+        // return this.replaySubmissionUtilService.canRatifySubmission(data.submissionId, data.memberId, data.userId);
+        return {
+            canRatify: true,
+        };
     }
 
     @MessagePattern(SubmissionEndpoint.SubmitReplays)

--- a/microservices/submission-service/src/replay-validation/replay-validation.module.ts
+++ b/microservices/submission-service/src/replay-validation/replay-validation.module.ts
@@ -1,12 +1,14 @@
 import {forwardRef, Module} from "@nestjs/common";
-import {CoreModule, MatchmakingModule, MinioModule} from "@sprocketbot/common";
+import {
+    CoreModule, EventsModule, MatchmakingModule, MinioModule,
+} from "@sprocketbot/common";
 
 import {ReplaySubmissionModule} from "../replay-submission/replay-submission.module";
 import {ReplayValidationController} from "./replay-validation.controller";
 import {ReplayValidationService} from "./replay-validation.service";
 
 @Module({
-    imports: [MatchmakingModule, CoreModule, MinioModule, forwardRef(() => ReplaySubmissionModule)],
+    imports: [CoreModule, EventsModule, MatchmakingModule, MinioModule, forwardRef(() => ReplaySubmissionModule)],
     providers: [ReplayValidationService],
     exports: [ReplayValidationService],
     controllers: [ReplayValidationController],

--- a/microservices/submission-service/src/replay-validation/replay-validation.service.ts
+++ b/microservices/submission-service/src/replay-validation/replay-validation.service.ts
@@ -2,9 +2,10 @@ import {Injectable, Logger} from "@nestjs/common";
 import type {
     BallchasingResponse,
     GetPlayerSuccessResponse,
+    LFSReplaySubmission,
     MatchReplaySubmission,
     ReplaySubmission,
-    ScrimReplaySubmission,
+    ScrimPlayer,    ScrimReplaySubmission,
 } from "@sprocketbot/common";
 import {
     config,
@@ -35,8 +36,180 @@ export class ReplayValidationService {
     async validate(submission: ReplaySubmission): Promise<ValidationResult> {
         if (submission.type === ReplaySubmissionType.SCRIM) {
             return this.validateScrimSubmission(submission);
+        } else if (submission.type === ReplaySubmissionType.LFS) {
+            return this.validateLFSSubmission(submission);
         }
         return this.validateMatchSubmission(submission);
+    }
+
+    private async validateLFSSubmission(submission: LFSReplaySubmission): Promise<ValidationResult> {
+        const scrimResponse = await this.matchmakingService.send(MatchmakingEndpoint.GetScrim, submission.scrimId);
+        if (scrimResponse.status === ResponseStatus.ERROR) throw scrimResponse.error;
+        if (!scrimResponse.data) throw new Error("Scrim not found");
+        
+        const scrim = scrimResponse.data;
+        // ========================================
+        // Validate number of games
+        // ========================================
+        if (!scrim.games) {
+            throw new Error(`Unable to validate gameCount for scrim ${scrim.id} because it has no games`);
+        }
+
+        const submissionGameCount = submission.items.length;
+        const scrimGameCount = scrim.games.length;
+
+        if (submissionGameCount !== scrimGameCount) {
+            return {
+                valid: false,
+                errors: [ {
+                    error: `Incorrect number of replays submitted, expected ${scrimGameCount} but found ${submissionGameCount}`,
+                } ],
+            };
+        }
+
+        const gameCount = submissionGameCount;
+
+        const progressErrors = submission.items.reduce<ValidationError[]>((r, v) => {
+            if (v.progress?.error) {
+                this.logger.error(`Error in submission found, scrim=${scrim.id} submissionId=${scrim.submissionId}\n${v.progress.error}`);
+                r.push({
+                    error: `Error encountered while parsing file ${v.originalFilename}`,
+                });
+            }
+            return r;
+        }, []);
+        if (progressErrors.length) {
+            return {
+                valid: false,
+                errors: progressErrors,
+            };
+        }
+
+        // All items should have an outputPath
+        if (!submission.items.every(i => i.outputPath)) {
+            this.logger.error(`Unable to validate submission with missing outputPath, scrim=${scrim.id} submissionId=${scrim.submissionId}`);
+            return {
+                valid: false,
+                errors: [],
+            };
+        }
+
+        // We should have stats for every game
+        const stats = await Promise.all(submission.items.map(async i => this.getStats(i.outputPath!)));
+        if (stats.length !== gameCount) {
+            this.logger.error(`Unable to validate submission missing stats, scrim=${scrim.id} submissionId=${scrim.submissionId}`);
+            return {
+                valid: false,
+                errors: [ {error: "The submission is missing stats. Please contact support."} ],
+            };
+        }
+
+        // Get which gameMode was played
+        const gameResult = await this.coreService.send(CoreEndpoint.GetGameByGameMode, {gameModeId: scrim.gameModeId});
+        if (gameResult.status === ResponseStatus.ERROR) {
+            this.logger.error(`Unable to get game gameMode=${scrim.gameModeId}`);
+            return {
+                valid: false,
+                errors: [ {error: `Failed to find associated game. Please contact support.`} ],
+            };
+        }
+
+        // ========================================
+        // Validate the correct players played
+        // ========================================
+        // Get platformIds from stats
+        // Don't send the same request for multiple players
+        const uniqueBallchasingPlayerIds = Array.from(new Set(stats.flatMap(s => [s.blue, s.orange].flatMap(t => t.players.flatMap(p => ({
+            name: p.name,
+            platform: p.id.platform.toUpperCase(),
+            id: p.id.id,
+        }))))));
+        
+        // Look up players by their platformIds
+        const playersResponse = await this.coreService.send(CoreEndpoint.GetPlayersByPlatformIds, uniqueBallchasingPlayerIds.map(bId => ({
+            gameId: gameResult.data.id,
+            platform: bId.platform,
+            platformId: bId.id,
+        })));
+
+        // If we have an error looking up all of the players, submission is invalid
+        if (playersResponse.status === ResponseStatus.ERROR) {
+            this.logger.error(`Unable to validate submission, couldn't find all players by their platformIds`, playersResponse.error);
+            return {
+                valid: false,
+                errors: [ {error: "Failed to find all players by their platform Ids. Please contact support."} ],
+            };
+        }
+        
+        // If any of the players were not found, submission is invalid (this
+        // usually happens with unreported accounts)
+        const playerErrors: string[] = [];
+        for (const player of playersResponse.data) {
+            if (!player.success) {
+                playerErrors.push(uniqueBallchasingPlayerIds.find(bcPlayer => bcPlayer.platform === player.request.platform && bcPlayer.id === player.request.platformId)!.name);
+            }
+        }
+        if (playerErrors.length) return {
+            valid: false,
+            errors: [
+                {
+                    error: `One or more players played on an unreported account: ${playerErrors.join(", ")}`,
+                },
+            ],
+        };
+
+        const players = playersResponse.data as GetPlayerSuccessResponse[];
+
+        // Find which players played on which teams
+        // in LFS scrims, these are not set beforehand
+        const uniquePlayers: ScrimPlayer[] = [];
+        const now = new Date();
+        // eslint-disable-next-line no-mixed-operators
+        const thirtyMinutes = new Date(now.getTime() + 1000 * 60 * 30);
+
+        const submissionUserIds: ScrimPlayer[][][] = stats.map(s => [s.blue, s.orange].map(t => t.players.map(sp => {
+            const user = players.find(p => p.request.platform === sp.id.platform.toUpperCase() && p.request.platformId === sp.id.id)!;
+            const scrimPlayer = {
+                id: user.data.userId,
+                name: sp.name,
+                joinedAt: now,
+                leaveAt: thirtyMinutes,
+            };
+            if (!uniquePlayers.find(p => p.id === user.data.userId)) uniquePlayers.push(scrimPlayer);
+            return scrimPlayer;
+        })));
+
+        const scrimUpdateResponse = await this.matchmakingService.send(
+            MatchmakingEndpoint.UpdateLFSScrimPlayers,
+            {
+                scrimId: submission.scrimId,
+                players: uniquePlayers,
+                games: submissionUserIds,
+            },
+        );
+        if (scrimUpdateResponse.status === ResponseStatus.ERROR) throw scrimUpdateResponse.error;
+        if (!scrimUpdateResponse.data) throw new Error("Could not add players to LFS scrim.");
+
+        // ========================================
+        // Validate players are in the correct skill group if the scrim is competitive
+        // ========================================
+        if (scrim.settings.competitive) for (const player of players) {
+            if (player.data.skillGroupId !== scrim.skillGroupId) {
+                return {
+                    valid: false,
+                    errors: [ {
+                        error: "One of the players isn't in the correct skill group",
+                    } ],
+                };
+            }
+        }
+
+        // ========================================
+        // Submission is valid
+        // ========================================
+        return {
+            valid: true,
+        };
     }
 
     private async validateScrimSubmission(submission: ScrimReplaySubmission): Promise<ValidationResult> {

--- a/microservices/submission-service/src/replay-validation/replay-validation.service.ts
+++ b/microservices/submission-service/src/replay-validation/replay-validation.service.ts
@@ -185,6 +185,15 @@ export class ReplayValidationService {
             return scrimPlayer;
         })));
 
+        const requiredUniquePlayers: number = (gameResult.data.mode?.teamCount ?? 0) * (gameResult.data.mode?.teamSize ?? 0);
+        if (uniquePlayers.length !== requiredUniquePlayers) {
+            return {
+                valid: false,
+                errors: [ {
+                    error: `An incorrect number of unique players played in this game. Required: ${requiredUniquePlayers} Found: ${uniquePlayers.length}`,
+                } ],
+            };
+        }
         const req: UpdateLFSScrimPlayersRequest = {
             scrimId: submission.scrimId,
             players: uniquePlayers,

--- a/microservices/submission-service/src/utils/index.ts
+++ b/microservices/submission-service/src/utils/index.ts
@@ -8,6 +8,10 @@ export function submissionIsScrim(submissionId: string): boolean {
     return submissionId.startsWith("scrim");
 }
 
+export function submissionIsLFS(submissionId: string): boolean {
+    return submissionId.startsWith("lfs");
+}
+
 export function submissionIsMatch(submissionId: string): boolean {
     return submissionId.startsWith("match");
 }


### PR DESCRIPTION
The final piece of the puzzle. 

- Front-end:
  - New [submissionId].svelte, which shows status/ratification/upload dialog per scrim
  - Updates to various piping pieces to get data where it needs to be
- Back-end:
  - Update Game controller to send back game mode data for validation use
  - Replay submission and validation services get new methods for LFS specifics
  - Finalization gets a refactor, common code moved out and LFS and scrim specifics kept in their respective methods
  - PubSub updates to make sure data is piped to front-end on events
- Microservices:
  - Matchmaking
    - Change LFS creation logic to have placeholder players and teams
    - Update them on replay submission (to detect who played)
  - Notification
    - Add handler for new scrim type so we send folks discord messages
  - Submission
    - Replay submission gets a new handler for LFS
    - Replay validation gets a ton of new logic, where most of LO's specific rules are implemented
    
![image](https://github.com/user-attachments/assets/7833ee2e-ddfb-41dc-8904-770c9ec8252f)
![image](https://github.com/user-attachments/assets/2182d398-8856-4436-ac0f-ac07535ad010)
![image](https://github.com/user-attachments/assets/f4d875e0-ef9e-4a6e-beb3-e2172aaae301)
![image](https://github.com/user-attachments/assets/dcf791b3-6a01-40e4-a4a9-e1803b84cc5a)
