### PR TITLE
Connection pool management for seed module

### DIFF
--- a/core/src/db/seed.module.ts
+++ b/core/src/db/seed.module.ts
@@ -11,56 +11,51 @@ import { PolicySeed } from './policy/policy.seed';
 import { SkillGroupEntitySeed } from './skill_group/skill_group.seed';
 import { authz } from 'src/authz.def';
 @Module({
-  imports: [
-    DbModule,
-    authz,
-    ...BaseSprocketModules.filter((mod) => mod !== RedisModule),
-  ],
-  providers: [
-    GameEntitySeed,
-    GameModeEntitySeed,
-    PolicySeed,
-    SkillGroupEntitySeed,
-  ],
+	imports: [DbModule, authz, ...BaseSprocketModules.filter((mod) => mod !== RedisModule)],
+	providers: [GameEntitySeed, GameModeEntitySeed, PolicySeed, SkillGroupEntitySeed]
 })
 class SeedModule {}
 
 async function execSeeds() {
-  process.env.PG_CACHE = 'false'; // never use the cache during seeding
-  const ctx = await NestFactory.createApplicationContext(SeedModule);
+	process.env.PG_CACHE = 'false'; // never use the cache during seeding
+	const ctx = await NestFactory.createApplicationContext(SeedModule);
 
-  const log = new Logger(execSeeds.name);
+	const log = new Logger(execSeeds.name);
 
-  const datasource: DataSource = ctx.get(getDataSourceToken());
+	const datasource: DataSource = ctx.get(getDataSourceToken());
 
-  const providers: Array<{ new (): any }> = Reflect.getMetadata(
-    'providers',
-    SeedModule,
-  );
+	const providers: Array<{ new (): any }> = Reflect.getMetadata('providers', SeedModule);
 
-  for (const provider of providers) {
-    const isSeeder = Reflect.getMetadata('seeder', provider);
-    if (!isSeeder) continue;
+	for (const provider of providers) {
+		const isSeeder = Reflect.getMetadata('seeder', provider);
+		if (!isSeeder) continue;
 
-    const seeder: Seeder = ctx.get(provider);
+		const seeder: Seeder = ctx.get(provider);
+		const masterQueryRunner = datasource.createQueryRunner('master');
 
-    await datasource
-      .transaction(async (em) => {
-        log.log(`Beginning ${provider.name}`);
-        await seeder.seed(em);
-      })
-      .then(() => log.log(`Executed ${provider.name}`))
-      .catch(async (e) => {
-        log.error(`Failed to execute ${provider.name}`, e);
-        await datasource.destroy();
-        await ctx.close();
-        process.exit(1);
-      });
-  }
+		await masterQueryRunner.connect();
 
-  await ctx.close();
+		await masterQueryRunner.manager
+			.transaction(async (em) => {
+				log.log(`Beginning ${provider.name}`);
+				await seeder.seed(em);
+			})
+			.then(() => {
+				log.log(`Executed ${provider.name}`);
+				masterQueryRunner.release();
+			})
+			.catch(async (e) => {
+				log.error(`Failed to execute ${provider.name}`, e);
+				await masterQueryRunner.release();
+				await datasource.destroy();
+				await ctx.close();
+				process.exit(1);
+			});
+	}
 
-  process.exit(0);
+	await ctx.close();
+
+	process.exit(0);
 }
 
 // @ts-expect-error Bun allows top level await


### PR DESCRIPTION
creating a master queryRunner for each provider, so it has its own connection pool. releasing the connection once the work has been executed
This is to avoid timeout exceptions and query runners being inadvertently closed prior to all seeds being ran

changes are on line 34+, the rest is whitespace