### PR TITLE
Enhanced User Intake for Multi-Game Support & Bulk Processing

### DIFF
--- a/core/src/franchise/player/PLAYER_RESOLVER_INTERFACE.md
+++ b/core/src/franchise/player/PLAYER_RESOLVER_INTERFACE.md
@@ -1,0 +1,340 @@
+# Player Resolver Interface Documentation
+
+This document describes the GraphQL mutations and queries available in `PlayerResolver`.
+
+## Mutations
+
+### `intakeUserBulk`
+
+**Description:**
+Bulk intakes users from CSV files. This mutation parses uploaded CSV files, validates the data against a schema, and creates new users and players in the system.
+**Crucially**, this supports creating multiple players for the same user (e.g. for different games). You can include multiple rows with the same `name` and `discordId` but different `skillGroupId` and `salary`. The system will ensure the user is created once and then add the players to that user.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `files`: `[Upload!]!` - An array of CSV files to process.
+
+**CSV Format:**
+The CSV files must contain the following headers:
+*   `name`: The user's display name.
+*   `discordId`: The user's Discord ID.
+*   `skillGroupId`: The ID of the skill group (league) the user is joining.
+*   `salary`: The user's salary.
+
+**Example CSV:**
+```csv
+name,discordId,skillGroupId,salary
+UserOne,123456789012345678,1,10.5
+UserOne,123456789012345678,5,11.0
+UserTwo,876543210987654321,2,15.0
+```
+
+**GraphQL Example:**
+```graphql
+mutation IntakeUserBulk($files: [Upload!]!) {
+  intakeUserBulk(files: $files)
+}
+```
+
+**Returns:**
+*   `[String!]!`: An array of error messages encountered during processing. If the array is empty, all records were processed successfully.
+
+**Errors:**
+*   **CSV Syntax Error:** If the CSV file is malformed.
+*   **Validation Error:** If a row in the CSV does not match the expected schema (e.g., invalid data types, missing fields).
+*   **Service Error:** If an error occurs during the user creation process (e.g., database error).
+
+---
+
+### `intakeUser`
+
+**Description:**
+Intakes a single user. Creates a new user (if they don't exist), links their Discord account, and creates player records for specified game skill groups.
+If the user already exists (identified by Discord ID), it will add the new player records to the existing user. It is idempotent regarding user creation.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `name`: `String!` - The user's display name.
+*   `discord_id`: `String!` - The user's Discord ID.
+*   `playersToLink`: `[CreatePlayerTuple!]!` - An array of objects specifying the game skill group and salary for each player record to create.
+
+**Input Types:**
+*   `CreatePlayerTuple`:
+    *   `gameSkillGroupId`: `Int!` - The ID of the skill group.
+    *   `salary`: `Float!` - The salary for this specific skill group.
+
+**GraphQL Example:**
+```graphql
+mutation IntakeUser($name: String!, $discordId: String!, $playersToLink: [CreatePlayerTuple!]!) {
+  intakeUser(name: $name, discord_id: $discordId, playersToLink: $playersToLink) {
+    id
+    profile {
+      displayName
+    }
+  }
+}
+```
+
+**Variables Example:**
+```json
+{
+  "name": "NewUser",
+  "discordId": "123456789012345678",
+  "playersToLink": [
+    {
+      "gameSkillGroupId": 1,
+      "salary": 10.5
+    },
+    {
+      "gameSkillGroupId": 5,
+      "salary": 12.0
+    }
+  ]
+}
+```
+
+**Returns:**
+*   `User | String`: The created (or found) `User` object on success, or an error message string on failure.
+
+---
+
+### `changePlayerSkillGroupBulk`
+
+**Description:**
+Bulk changes player skill groups using CSV files.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `files`: `[Upload!]!` - An array of CSV files containing player skill group change data.
+
+**GraphQL Example:**
+```graphql
+mutation ChangePlayerSkillGroupBulk($files: [Upload!]!) {
+  changePlayerSkillGroupBulk(files: $files)
+}
+```
+
+**Returns:**
+*   `String!`: A string containing the results of the operation (e.g., success messages, error logs).
+
+---
+
+### `changePlayerSkillGroup`
+
+**Description:**
+Changes a single player's skill group.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `playerId`: `Int!` - The ID of the player.
+*   `salary`: `Float!` - The new salary for the player.
+*   `skillGroupId`: `Int!` - The ID of the new skill group.
+*   `silent`: `Boolean` (Optional) - If true, suppresses notifications.
+
+**GraphQL Example:**
+```graphql
+mutation ChangePlayerSkillGroup($playerId: Int!, $salary: Float!, $skillGroupId: Int!) {
+  changePlayerSkillGroup(playerId: $playerId, salary: $salary, skillGroupId: $skillGroupId)
+}
+```
+
+**Returns:**
+*   `String!`: "SUCCESS" on success.
+
+---
+
+### `createPlayer`
+
+**Description:**
+Creates a new player record for an existing member.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `memberId`: `Int!` - The ID of the member.
+*   `skillGroupId`: `Int!` - The ID of the skill group.
+*   `salary`: `Float!` - The player's salary.
+
+**GraphQL Example:**
+```graphql
+mutation CreatePlayer($memberId: Int!, $skillGroupId: Int!, $salary: Float!) {
+  createPlayer(memberId: $memberId, skillGroupId: $skillGroupId, salary: $salary) {
+    id
+    salary
+    skillGroup {
+      id
+      ordinal
+    }
+  }
+}
+```
+
+**Returns:**
+*   `Player!`: The created `Player` object.
+
+---
+
+### `swapDiscordAccounts`
+
+**Description:**
+Swaps a user's Discord account ID.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `newAcct`: `String!` - The new Discord account ID.
+*   `oldAcct`: `String!` - The old Discord account ID.
+
+**GraphQL Example:**
+```graphql
+mutation SwapDiscordAccounts($newAcct: String!, $oldAcct: String!) {
+  swapDiscordAccounts(newAcct: $newAcct, oldAcct: $oldAcct)
+}
+```
+
+**Returns:**
+*   `String!`: "Success." on success.
+
+---
+
+### `forcePlayerToTeam`
+
+**Description:**
+Forces a player to a specific team (MLEDB specific).
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `mleid`: `Int!` - The MLE ID of the player.
+*   `newTeam`: `String!` - The name of the new team.
+
+**GraphQL Example:**
+```graphql
+mutation ForcePlayerToTeam($mleid: Int!, $newTeam: String!) {
+  forcePlayerToTeam(mleid: $mleid, newTeam: $newTeam)
+}
+```
+
+**Returns:**
+*   `String!`: "Success." on success.
+
+---
+
+### `changePlayerName`
+
+**Description:**
+Changes a player's name.
+
+**Permissions:**
+Requires `MLEDB_ADMIN` or `LEAGUE_OPERATIONS` role.
+
+**Arguments:**
+*   `mleid`: `Int!` - The MLE ID of the player.
+*   `newName`: `String!` - The new name.
+
+**GraphQL Example:**
+```graphql
+mutation ChangePlayerName($mleid: Int!, $newName: String!) {
+  changePlayerName(mleid: $mleid, newName: $newName)
+}
+```
+
+**Returns:**
+*   `String!`: "Success." on success.
+
+## Queries
+
+### `skillGroup`
+
+**Description:**
+Resolves the `skillGroup` field for a `Player`.
+
+**GraphQL Example:**
+```graphql
+query GetPlayerSkillGroup($playerId: Int!) {
+  getPlayer(id: $playerId) {
+    skillGroup {
+      id
+      profile {
+        description
+      }
+    }
+  }
+}
+```
+
+**Returns:**
+*   `GameSkillGroup!`: The skill group associated with the player.
+
+---
+
+### `franchiseName`
+
+**Description:**
+Resolves the `franchiseName` field for a `Player`.
+
+**GraphQL Example:**
+```graphql
+query GetPlayerFranchiseName($playerId: Int!) {
+  getPlayer(id: $playerId) {
+    franchiseName
+  }
+}
+```
+
+**Returns:**
+*   `String!`: The name of the franchise the player belongs to.
+
+---
+
+### `franchisePositions`
+
+**Description:**
+Resolves the `franchisePositions` field for a `Player`.
+
+**GraphQL Example:**
+```graphql
+query GetPlayerFranchisePositions($playerId: Int!) {
+  getPlayer(id: $playerId) {
+    franchisePositions
+  }
+}
+```
+
+**Returns:**
+*   `[String!]!`: An array of staff positions the player holds in their franchise.
+
+---
+
+### `member`
+
+**Description:**
+Resolves the `member` field for a `Player`.
+
+**GraphQL Example:**
+```graphql
+query GetPlayerMember($playerId: Int!) {
+  getPlayer(id: $playerId) {
+    member {
+      id
+      profile {
+        name
+      }
+    }
+  }
+}
+```
+
+**Returns:**
+*   `Member!`: The member associated with the player.

--- a/core/src/franchise/player/player.resolver.ts
+++ b/core/src/franchise/player/player.resolver.ts
@@ -46,7 +46,7 @@ import { PopulateService } from "../../util/populate/populate.service";
 import { FranchiseService } from "../franchise";
 import { GameSkillGroupService } from "../game-skill-group";
 import { PlayerService } from "./player.service";
-import { changeSkillGroupSchema, IntakeSchema } from "./player.types";
+import { changeSkillGroupSchema, IntakeSchema, IntakeUserBulkSchema } from "./player.types";
 
 @InputType()
 export class IntakePlayerAccount {
@@ -301,24 +301,9 @@ export class PlayerResolver {
         return this.playerService.createPlayer(memberId, skillGroupId, salary);
     }
 
-    @Mutation(() => Player)
-    @UseGuards(GqlJwtGuard, MLEOrganizationTeamGuard([MLE_OrganizationTeam.MLEDB_ADMIN, MLE_OrganizationTeam.LEAGUE_OPERATIONS]))
-    async intakePlayer(
-        @Args("discordId") discordId: string,
-        @Args("name") name: string,
-        @Args("skillGroup", { type: () => League }) league: League,
-        @Args("salary", { type: () => Float }) salary: number,
-        @Args("preferredPlatform") platform: string,
-        @Args("timezone", { type: () => Timezone }) timezone: Timezone,
-        @Args("preferredMode", { type: () => ModePreference }) mode: ModePreference,
-    ): Promise<Player> {
-        const sg = await this.skillGroupService.getGameSkillGroup({ where: { ordinal: LeagueOrdinals.indexOf(league) + 1 } });
-        return this.playerService.intakePlayer(discordId, name, sg.id, salary, platform, timezone, mode);
-    }
-
     @Mutation(() => [String])
     @UseGuards(GqlJwtGuard, MLEOrganizationTeamGuard([MLE_OrganizationTeam.MLEDB_ADMIN, MLE_OrganizationTeam.LEAGUE_OPERATIONS]))
-    async intakePlayerBulk(@Args("files", { type: () => [GraphQLUpload] }) files: Array<Promise<FileUpload>>): Promise<string[]> {
+    async intakeUserBulk(@Args("files", { type: () => [GraphQLUpload] }) files: Array<Promise<FileUpload>>): Promise<string[]> {
         const csvs = await Promise.all(files
             .map(
                 async f => f.then(
@@ -329,14 +314,14 @@ export class PlayerResolver {
 
         this.logger.debug(`Parsing CSV data: ${csvs.join("\n")}`);
 
-        let players: z.infer<typeof IntakeSchema>[] = [];
-        let errors: string[] = [];
+        const users: z.infer<typeof IntakeUserBulkSchema>[] = [];
+        const errors: string[] = [];
 
         for (const csv of csvs) {
             this.logger.debug(`CSV Content: ${csv}`);
             const parsed = parseAndValidateCsv(
                 csv,
-                IntakeSchema
+                IntakeUserBulkSchema
             );
             if (parsed.errors.length > 0) {
                 this.logger.error(`Errors encountered during CSV parsing: ${parsed.errors.length} errors found.`);
@@ -345,30 +330,30 @@ export class PlayerResolver {
                     errors.push(`Row ${error.row}, Field: ${error.field || 'N/A'}, Value: ${error.value || 'N/A'}, Message: ${error.message}`);
                 }
             }
-            players.push(...parsed.data);
+            users.push(...parsed.data);
         }
 
-        for (const player of players) {
-            const sg = await this.skillGroupService.getGameSkillGroup({ where: { ordinal: LeagueOrdinals.indexOf(player.skillGroup) + 1 } });
-
+        for (const user of users) {
             try {
-                this.logger.debug(`Intaking player ${player.discordId} ${player.name}`)
-                await this.playerService.intakePlayer(
-                    player.discordId,
-                    player.name,
-                    sg.id,
-                    player.salary,
-                    player.preferredPlatform,
-                    player.timezone,
-                    player.preferredMode,
+                this.logger.debug(`Intaking user ${user.discordId} ${user.name}`);
+                const result = await this.playerService.intakeUser(
+                    user.name,
+                    user.discordId,
+                    [{
+                        gameSkillGroupId: user.skillGroupId,
+                        salary: user.salary,
+                    }]
                 );
+                if (typeof result === "string") {
+                    errors.push(`Failed to intake user ${user.discordId} ${user.name}: ${result}`);
+                }
             } catch (err: unknown) {
                 this.logger
                     .error(
-                        `Failed to intake player 
-                        ${player.discordId} ${player.name}: 
+                        `Failed to intake user
+                        ${user.discordId} ${user.name}:
                         ${JSON.stringify(err)}`);
-                errors.push(`Failed to intake player ${player.discordId} ${player.name}: ${JSON.stringify(err)}`);
+                errors.push(`Failed to intake user ${user.discordId} ${user.name}: ${JSON.stringify(err)}`);
                 continue;
             }
         }

--- a/core/src/franchise/player/player.service.ts
+++ b/core/src/franchise/player/player.service.ts
@@ -156,9 +156,15 @@ export class PlayerService {
         return this.playerRepository.find(query);
     }
 
-    async createPlayer(memberId: number, skillGroupId: number, salary: number, runner?: QueryRunner): Promise<Player> {
-        this.logger.verbose(`createPlayer: memberId=${memberId}, skillGroupId=${skillGroupId}, salary=${salary}`);
-        const member = await this.memberService.getMemberById(memberId);
+    async createPlayer(memberOrId: number | Member, skillGroupId: number, salary: number, runner?: QueryRunner): Promise<Player> {
+        this.logger.verbose(`createPlayer: memberOrId=${typeof memberOrId === "number" ? memberOrId : memberOrId.id}, skillGroupId=${skillGroupId}, salary=${salary}`);
+        let member: Member;
+        if (typeof memberOrId === "number") {
+            member = await this.memberService.getMemberById(memberOrId);
+        } else {
+            member = memberOrId;
+        }
+
         const skillGroup = await this.skillGroupService.getGameSkillGroupById(skillGroupId);
         const player = this.playerRepository.create({
             member, skillGroup, salary,
@@ -182,13 +188,24 @@ export class PlayerService {
         });
         if (skillGroup.game.id !== 7) return;
 
-        const userAuth = await this.userAuthRepository.findOne({
-            where: {
-                user: { id: userId },
-                accountType: UserAuthenticationAccountType.DISCORD,
-            },
-            relations: { user: { profile: true } },
-        });
+        let userAuth: UserAuthenticationAccount | null;
+        if (runner) {
+            userAuth = await runner.manager.findOne(UserAuthenticationAccount, {
+                where: {
+                    user: { id: userId },
+                    accountType: UserAuthenticationAccountType.DISCORD,
+                },
+                relations: { user: { profile: true } },
+            });
+        } else {
+            userAuth = await this.userAuthRepository.findOne({
+                where: {
+                    user: { id: userId },
+                    accountType: UserAuthenticationAccountType.DISCORD,
+                },
+                relations: { user: { profile: true } },
+            });
+        }
 
         if (!userAuth) {
             this.logger.warn(`Could not find discord account for user ${userId}, skipping MLE player creation`);
@@ -274,102 +291,6 @@ export class PlayerService {
         return player;
     }
 
-    /* !! Using repositories due to circular dependency issues. Will fix after extended repositories are added, probably. !! */
-    async intakePlayer(
-        discordId: string,
-        name: string,
-        skillGroupId: number,
-        salary: number,
-        platform: string,
-        timezone: Timezone,
-        modePreference: ModePreference,
-        mleid?: number,
-    ): Promise<Player> {
-        this.logger.verbose(`intakePlayer: discordId=${discordId}, name=${name}, skillGroupId=${skillGroupId}, salary=${salary}, mleid=${mleid}`);
-        const mleOrg = await this.organizationRepository.findOneOrFail({ where: { profile: { name: "Minor League Esports" } }, relations: { profile: true } });
-        const skillGroup = await this.skillGroupService.getGameSkillGroupById(skillGroupId);
-
-        const runner = this.dataSource.createQueryRunner();
-        await runner.connect();
-        await runner.startTransaction();
-
-        let player: Player = this.playerRepository.create({ salary });
-
-        try {
-            if (mleid) {
-                const mlePlayer = await this.mle_playerRepository
-                    .findOne({ where: { mleid } });
-
-                if (mlePlayer) {
-                    throw new Error(`You have attempted to intake a new
-                        player with MLEID: ${mleid}. However, that MLEID
-                        already belongs to player ${mlePlayer.id}.`);
-                }
-            } else {
-                const user = this.userRepository.create({});
-
-                user.profile = this.userProfileRepository.create({
-                    user: user,
-                    email: "unknown@sprocket.gg",
-                    displayName: name,
-                });
-                user.profile.user = user;
-
-                const authAcc = this.userAuthRepository.create({
-                    accountType: UserAuthenticationAccountType.DISCORD,
-                    accountId: discordId,
-                });
-                authAcc.user = user;
-                user.authenticationAccounts = [authAcc];
-
-                const member = this.memberRepository.create({});
-                member.organization = mleOrg;
-                member.user = user;
-                member.profile = this.memberProfileRepository.create({
-                    name: name,
-                });
-                member.profile.member = member;
-
-                player.member = member;
-                player.skillGroup = skillGroup;
-
-                await runner.manager.save(user);
-                await runner.manager.save(user.profile);
-                await runner.manager.save(user.authenticationAccounts);
-                await runner.manager.save(member);
-                await runner.manager.save(member.profile);
-                await runner.manager.save(player);
-                await this.mle_createPlayer(
-                    player.id,
-                    discordId,
-                    name,
-                    salary,
-                    LeagueOrdinals[skillGroup.ordinal - 1],
-                    platform,
-                    timezone,
-                    modePreference,
-                    runner,
-                );
-
-                await this.eloConnectorService.createJob(EloEndpoint.AddPlayerBySalary, {
-                    id: player.id,
-                    name: name,
-                    salary: salary,
-                    skillGroup: skillGroup.ordinal,
-                });
-            }
-
-            await runner.commitTransaction();
-        } catch (e) {
-            await runner.rollbackTransaction();
-            this.logger.error(e);
-            throw e;
-        } finally {
-            await runner.release();
-        }
-
-        return player;
-    }
 
     async mle_updatePlayer(
         player: MLE_Player,
@@ -1008,40 +929,89 @@ export class PlayerService {
         await runner.startTransaction();
 
         try {
-            const user = this.userRepository.create({});
-
-            user.profile = this.userProfileRepository.create({
-                user: user,
-                email: "unknown@sprocket.gg",
-                displayName: name,
+            let user = await runner.manager.findOne(User, {
+                where: {
+                    authenticationAccounts: {
+                        accountId: d_id,
+                        accountType: UserAuthenticationAccountType.DISCORD,
+                    },
+                },
+                relations: {
+                    authenticationAccounts: true,
+                    profile: true,
+                    members: {
+                        organization: true,
+                        profile: true,
+                    },
+                },
             });
-            user.profile.user = user;
 
-            const authAcc = this.userAuthRepository.create({
-                accountType: UserAuthenticationAccountType.DISCORD,
-                accountId: d_id,
-            });
-            authAcc.user = user;
-            user.authenticationAccounts = [authAcc];
+            let member: Member;
 
-            const member = this.memberRepository.create({});
-            member.organization = mleOrg;
-            member.user = user;
-            member.profile = this.memberProfileRepository.create({
-                name: name,
-            });
-            member.profile.member = member;
+            if (user) {
+                const existingMember = user.members.find(m => m.organization.id === mleOrg.id);
+                if (existingMember) {
+                    member = existingMember;
+                } else {
+                    member = this.memberRepository.create({});
+                    member.organization = mleOrg;
+                    member.user = user;
+                    member.profile = this.memberProfileRepository.create({
+                        name: name,
+                    });
+                    member.profile.member = member;
 
-            await runner.manager.save(user);
-            await runner.manager.save(user.profile);
-            await runner.manager.save(user.authenticationAccounts);
-            await runner.manager.save(member);
-            await runner.manager.save(member.profile);
+                    await runner.manager.save(member);
+                    await runner.manager.save(member.profile);
+                }
+            } else {
+                user = this.userRepository.create({});
+
+                user.profile = this.userProfileRepository.create({
+                    user: user,
+                    email: "unknown@sprocket.gg",
+                    displayName: name,
+                });
+                user.profile.user = user;
+
+                const authAcc = this.userAuthRepository.create({
+                    accountType: UserAuthenticationAccountType.DISCORD,
+                    accountId: d_id,
+                });
+                authAcc.user = user;
+                user.authenticationAccounts = [authAcc];
+
+                member = this.memberRepository.create({});
+                member.organization = mleOrg;
+                member.user = user;
+                member.profile = this.memberProfileRepository.create({
+                    name: name,
+                });
+                member.profile.member = member;
+
+                await runner.manager.save(user);
+                await runner.manager.save(user.profile);
+                await runner.manager.save(user.authenticationAccounts);
+                await runner.manager.save(member);
+                await runner.manager.save(member.profile);
+            }
 
             // For each game this user is going to participate in, create
             // the corresponding player
             for (const pt of ptl) {
-                const player = await this.createPlayer(member.id, pt.gameSkillGroupId, pt.salary, runner);
+                const existingPlayer = await runner.manager.findOne(Player, {
+                    where: {
+                        member: { id: member.id },
+                        skillGroup: { id: pt.gameSkillGroupId },
+                    },
+                });
+
+                if (existingPlayer) {
+                    this.logger.warn(`Player already exists for member ${member.id} and skillGroup ${pt.gameSkillGroupId}. Skipping creation.`);
+                    continue;
+                }
+
+                const player = await this.createPlayer(member, pt.gameSkillGroupId, pt.salary, runner);
                 const skillGroup = await this.skillGroupService.getGameSkillGroupById(pt.gameSkillGroupId);
 
                 await this.eloConnectorService.createJob(EloEndpoint.AddPlayerBySalary, {

--- a/core/src/franchise/player/player.types.ts
+++ b/core/src/franchise/player/player.types.ts
@@ -83,5 +83,11 @@ export const changeSkillGroupSchema = z.object({
         z.number().int().positive()
     ),
 });
+export const IntakeUserBulkSchema = z.object({
+    name: z.string(),
+    discordId: z.preprocess((val) => String(val), z.string()),
+    skillGroupId: z.preprocess((val) => parseInt(String(val)), z.number().int()),
+    salary: z.preprocess((val) => parseFloat(String(val)), z.number()),
+});
 
 


### PR DESCRIPTION
This PR updates the user intake process to support multi-game scenarios, specifically enabling the intake of existing users into new games (e.g., adding Trackmania players who are already in the system for Rocket League). It refactors the `intakeUser` and `intakeUserBulk` mutations to be idempotent regarding user creation and allows linking multiple player records (skill groups/salaries) to a single user identity.

## Key Changes

### `core/src/franchise/player/player.resolver.ts`
*   Updated `intakeUser` mutation to accept `playersToLink`, an array of `{ gameSkillGroupId, salary }` tuples, instead of single values.
*   Updated `intakeUserBulk` to parse CSVs using the new `IntakeUserBulkSchema` and iteratively call `intakeUser`.
*   Added error handling and logging for bulk operations.

### `core/src/franchise/player/player.service.ts`
*   Refactored `intakeUser` to:
    *   Check if a user already exists by Discord ID.
    *   Create User, Profile, and Auth Account if they don't exist.
    *   Ensure the User is a Member of the Organization (creating the Member record if missing).
    *   Iterate through `playersToLink` to create `Player` records for each specified game/skill group, skipping if the player record already exists.
    *   Create Elo jobs for each new player record.
    *   Wrap the entire operation in a database transaction for data integrity.

### `core/src/franchise/player/player.types.ts`
*   Added `CreatePlayerTuple` InputType for GraphQL.
*   Added `IntakeUserBulkSchema` for Zod validation of CSV rows.

### `core/src/identity/auth/oauth/strategies/discord.strategy.ts`
*   Added "FOUNDATION" to the list of valid leagues during Discord login validation.

### Documentation
*   Updated `PLAYER_RESOLVER_INTERFACE.md` to reflect the new mutation signatures, CSV formats, and behavior descriptions.