### PR TITLE
update sprocket db scrim point values per LO change

### DIFF
--- a/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
+++ b/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
@@ -313,7 +313,7 @@ export class RocketLeagueFinalizationService {
         const output = em.create(EligibilityData);
         output.matchParent = matchParent;
         output.player = player;
-        output.points = Math.floor(gameCount * 5 / 3);
+        output.points = 3;
         return output;
     }
 


### PR DESCRIPTION
all these data guys cleaning up after you dev folks 😜

The mledb scrim points were correctly updated to account for LO's change in how scrim points are awarded, but the sprocket db was still awarding 5 points instead of 3.  This may need to be built out more robustly if longer team scrims are implemented in the future and are awarded differing number of points.

Once this is merged, we will backfill 3 scrim points to the `sprocket.eligibility_data` table for all rows that the `mledb.eligibility_data` table lists as being worth 3.  The below query should accomplish that:
```
 --mledb last scrim with 5 points: 2025-11-24 05:10:45.237
 --mledb first scrim with 3 points: 2025-11-24 05:39:41.679

UPDATE sprocket.eligibility_data
SET points = 3
WHERE points = 5
  AND "createdAt" > '2025-11-24 05:15:00.000';
```