### PR TITLE
franchise.service.ts:

### DIFF
--- a/core/src/franchise/franchise/franchise.service.ts
+++ b/core/src/franchise/franchise/franchise.service.ts
@@ -70,7 +70,7 @@ export class FranchiseService {
 
         // Check if this is a non-playing staff member (FP = Free Agent Pool, FA = Free Agent)
         if (team.name === "FP" || team.name === "FA") {
-            return this.getFranchisesFromStaffAssignments(playerId, memberId);
+            return this.getFranchisesFromStaffAssignments(playerId, userId);
         }
 
         // Regular player - try to get their playing franchise
@@ -107,8 +107,8 @@ export class FranchiseService {
             ];
         } catch (error) {
             // FALLBACK: If we can't find their franchise by team name, check staff assignments
-            console.error(`Failed to find franchise for team "${team.name}" (player ${playerId}, member ${memberId}). Checking staff assignments as fallback:`, error instanceof Error ? error.message : error);
-            return this.getFranchisesFromStaffAssignments(playerId, memberId);
+            console.error(`Failed to find franchise for team "${team.name}" (player ${playerId}, member ${userId}). Checking staff assignments as fallback:`, error instanceof Error ? error.message : error);
+            return this.getFranchisesFromStaffAssignments(playerId, userId);
         }
     }
 

--- a/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.ts
+++ b/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.ts
@@ -27,7 +27,7 @@ export class StatsConverterService {
                     const orangeResult = orangeWon ? "WIN" : blueWon ? "LOSS" : "DRAW";
                     const teams = [
                         {
-                            won: blueResult,
+                            result: blueResult,
                             score: blueGoals,
                             stats: {goals: blueGoals},
                             players: data.blue.players.map(p => ({
@@ -36,7 +36,7 @@ export class StatsConverterService {
                             })),
                         },
                         {
-                            won: orangeResult,
+                            result: orangeResult,
                             score: orangeGoals,
                             stats: {goals: orangeGoals},
                             players: data.orange.players.map(p => ({
@@ -64,7 +64,7 @@ export class StatsConverterService {
                     const orangeResult = orangeWon ? "WIN" : blueWon ? "LOSS" : "DRAW";
                     const teams = [
                         {
-                            won: blueResult,
+                            result: blueResult,
                             score: blueGoals,
                             stats: {goals: blueGoals},
                             players: ballchasingData.blue.players.map(p => ({
@@ -73,7 +73,7 @@ export class StatsConverterService {
                             })),
                         },
                         {
-                            won: orangeResult,
+                            result: orangeResult,
                             score: orangeGoals,
                             stats: {goals: orangeGoals},
                             players: ballchasingData.orange.players.map(p => ({


### PR DESCRIPTION
-Undefined memberId variable being passed to methods -Fixed by using userId parameter instead -This was causing crashes for free agent players accessing franchise information

 stats-converter.service.ts:30

-Field name mismatch: using won instead of result -The converter was creating {won: "WIN"} but GraphQL schema and frontend expect {result: "WIN"} -This caused the GraphQL Boolean type error the staff was seeing