### PR TITLE
Report card assets for Evidence

### DIFF
--- a/common/src/service-connectors/core/core.types.ts
+++ b/common/src/service-connectors/core/core.types.ts
@@ -32,6 +32,7 @@ export enum CoreEndpoint {
     GetGameModeById = "GetGameModeById",
     GetGameByGameMode = "GetGameByGameMode",
     GetNicknameByDiscordUser = "GetNicknameByDiscordUser",
+    UpsertReportCardAsset = "UpsertReportCardAsset",
 }
 
 export const CoreSchemas = {
@@ -146,6 +147,10 @@ export const CoreSchemas = {
     [CoreEndpoint.GetNicknameByDiscordUser]: {
         input: Schemas.GetNicknameByDiscordUser_Request,
         output: Schemas.GetNicknameByDiscordUser_Response,
+    },
+    [CoreEndpoint.UpsertReportCardAsset]: {
+        input: Schemas.UpsertReportCardAsset_Request,
+        output: Schemas.UpsertReportCardAsset_Response,
     },
 };
 

--- a/common/src/service-connectors/core/schemas/UpsertReportCardAsset.schema.ts
+++ b/common/src/service-connectors/core/schemas/UpsertReportCardAsset.schema.ts
@@ -1,0 +1,24 @@
+import {z} from "zod";
+
+export enum ReportCardAssetType {
+    SCRIM = "SCRIM",
+    MATCH = "MATCH",
+}
+
+export const UpsertReportCardAsset_Request = z.object({
+    type: z.nativeEnum(ReportCardAssetType),
+    organizationId: z.number(),
+    sprocketId: z.number(),
+    legacyId: z.number(),
+    minioKey: z.string(),
+    scrimUuid: z.string().uuid().optional(),
+    userIds: z.array(z.number()).default([]),
+    franchiseIds: z.array(z.number()).default([]),
+});
+
+export const UpsertReportCardAsset_Response = z.object({
+    success: z.boolean(),
+});
+
+export type UpsertReportCardAssetRequest = z.infer<typeof UpsertReportCardAsset_Request>;
+export type UpsertReportCardAssetResponse = z.infer<typeof UpsertReportCardAsset_Response>;

--- a/common/src/service-connectors/core/schemas/index.ts
+++ b/common/src/service-connectors/core/schemas/index.ts
@@ -26,3 +26,4 @@ export * from "./GetTransactionsDiscordWebhook.schema";
 export * from "./GetUserByAuthAccount.schema";
 export * from "./GetUsersLastScrim.schema";
 export * from "./MemberRestriction.schema";
+export * from "./UpsertReportCardAsset.schema";

--- a/core/migrations/1770434634193-ReportCardAssets.ts
+++ b/core/migrations/1770434634193-ReportCardAssets.ts
@@ -1,0 +1,27 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ReportCardAssets1770434634193 implements MigrationInterface {
+    name = "ReportCardAssets1770434634193";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TYPE \"sprocket\".\"report_card_asset_type_enum\" AS ENUM('SCRIM', 'MATCH')",
+        );
+        await queryRunner.query(
+            "CREATE TABLE \"sprocket\".\"report_card_asset\" (\"id\" SERIAL NOT NULL, \"createdAt\" TIMESTAMP NOT NULL DEFAULT now(), \"updatedAt\" TIMESTAMP NOT NULL DEFAULT now(), \"deletedAt\" TIMESTAMP, \"type\" \"sprocket\".\"report_card_asset_type_enum\" NOT NULL, \"sprocketId\" integer NOT NULL, \"legacyId\" integer NOT NULL, \"organizationId\" integer NOT NULL, \"minioKey\" character varying NOT NULL, \"scrimUuid\" uuid, \"userIds\" integer array NOT NULL DEFAULT '{}'::integer[], \"franchiseIds\" integer array NOT NULL DEFAULT '{}'::integer[], CONSTRAINT \"PK_3c6d0b7412b7edca6ad0e3ab4d6\" PRIMARY KEY (\"id\"))",
+        );
+        await queryRunner.query(
+            "CREATE UNIQUE INDEX \"report_card_asset_type_sprocket_id_unique\" ON \"sprocket\".\"report_card_asset\" (\"type\", \"sprocketId\")",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "DROP INDEX \"sprocket\".\"report_card_asset_type_sprocket_id_unique\"",
+        );
+        await queryRunner.query("DROP TABLE \"sprocket\".\"report_card_asset\"");
+        await queryRunner.query(
+            "DROP TYPE \"sprocket\".\"report_card_asset_type_enum\"",
+        );
+    }
+}

--- a/core/src/app.module.ts
+++ b/core/src/app.module.ts
@@ -17,6 +17,7 @@ import {ImageGenerationModule} from "./image-generation";
 import {MledbInterfaceModule} from "./mledb";
 import {NotificationModule} from "./notification/notification.module";
 import {OrganizationModule} from "./organization";
+import {ReportCardModule} from "./report-card/report-card.module";
 import {ReplayParseModule} from "./replay-parse";
 import {SchedulingModule} from "./scheduling";
 import {ScrimModule} from "./scrim";
@@ -92,6 +93,7 @@ import {UtilModule} from "./util/util.module";
         EloModule,
         SubmissionModule,
         NotificationModule,
+        ReportCardModule,
     ],
 })
 export class AppModule implements NestModule {

--- a/core/src/database/database.module.ts
+++ b/core/src/database/database.module.ts
@@ -12,6 +12,7 @@ import {ImageGenModule} from "./image-gen/image-gen.module";
 import {MledbModule} from "./mledb/mledb.module";
 import {MledbBridgeModule} from "./mledb-bridge/mledb_bridge.module";
 import {OrganizationModule} from "./organization/organization.module";
+import {ReportCardDbModule} from "./report-card/report-card.module";
 import {SchedulingModule} from "./scheduling/scheduling.module";
 import {WebhookModule} from "./webhook/webhook.module";
 
@@ -27,6 +28,7 @@ const modules = [
     MledbModule,
     ImageGenModule,
     MledbBridgeModule,
+    ReportCardDbModule,
     WebhookModule,
     TypeOrmModule.forRoot({
         type: "postgres",

--- a/core/src/database/report-card/report-card.module.ts
+++ b/core/src/database/report-card/report-card.module.ts
@@ -1,0 +1,14 @@
+import {Module} from "@nestjs/common";
+import {TypeOrmModule} from "@nestjs/typeorm";
+
+import {ReportCardAsset} from "./report_card_asset.model";
+
+export const reportCardEntities = [ReportCardAsset];
+
+const ormModule = TypeOrmModule.forFeature(reportCardEntities);
+
+@Module({
+    imports: [ormModule],
+    exports: [ormModule],
+})
+export class ReportCardDbModule {}

--- a/core/src/database/report-card/report_card_asset.model.ts
+++ b/core/src/database/report-card/report_card_asset.model.ts
@@ -1,0 +1,42 @@
+import {Field, Int, ObjectType} from "@nestjs/graphql";
+import {ReportCardAssetType} from "@sprocketbot/common";
+import {Column, Entity, Index} from "typeorm";
+
+import {BaseModel} from "../base-model";
+
+@Index("report_card_asset_type_sprocket_id_unique", ["type", "sprocketId"], {unique: true})
+@Entity({schema: "sprocket"})
+@ObjectType()
+export class ReportCardAsset extends BaseModel {
+    @Column({type: "enum", enum: ReportCardAssetType})
+    @Field(() => String)
+  type: ReportCardAssetType;
+
+    @Column({type: "int"})
+    @Field(() => Int)
+  sprocketId: number;
+
+    @Column({type: "int"})
+    @Field(() => Int)
+  legacyId: number;
+
+    @Column({type: "int"})
+    @Field(() => Int)
+  organizationId: number;
+
+    @Column({type: "varchar"})
+    @Field(() => String)
+  minioKey: string;
+
+    @Column({type: "uuid", nullable: true})
+    @Field(() => String, {nullable: true})
+  scrimUuid?: string | null;
+
+    @Column({type: "int", array: true, default: () => "'{}'"})
+    @Field(() => [Int])
+  userIds: number[];
+
+    @Column({type: "int", array: true, default: () => "'{}'"})
+    @Field(() => [Int])
+  franchiseIds: number[];
+}

--- a/core/src/report-card/report-card.controller.ts
+++ b/core/src/report-card/report-card.controller.ts
@@ -1,0 +1,21 @@
+import {Controller} from "@nestjs/common";
+import {MessagePattern, Payload} from "@nestjs/microservices";
+import {
+    CoreEndpoint,
+    CoreSchemas,
+    type CoreOutput,
+} from "@sprocketbot/common";
+
+import {ReportCardService} from "./report-card.service";
+
+@Controller()
+export class ReportCardController {
+    constructor(private readonly reportCardService: ReportCardService) {}
+
+    @MessagePattern(CoreEndpoint.UpsertReportCardAsset)
+    async upsertReportCardAsset(@Payload() payload: unknown): Promise<CoreOutput<CoreEndpoint.UpsertReportCardAsset>> {
+        const data = CoreSchemas.UpsertReportCardAsset.input.parse(payload);
+        const success = await this.reportCardService.upsertAsset(data);
+        return {success};
+    }
+}

--- a/core/src/report-card/report-card.module.ts
+++ b/core/src/report-card/report-card.module.ts
@@ -1,0 +1,14 @@
+import {Module} from "@nestjs/common";
+import {TypeOrmModule} from "@nestjs/typeorm";
+
+import {ReportCardAsset} from "../database/report-card/report_card_asset.model";
+import {ReportCardController} from "./report-card.controller";
+import {ReportCardService} from "./report-card.service";
+
+@Module({
+    imports: [TypeOrmModule.forFeature([ReportCardAsset])],
+    providers: [ReportCardService],
+    controllers: [ReportCardController],
+    exports: [ReportCardService],
+})
+export class ReportCardModule {}

--- a/core/src/report-card/report-card.service.ts
+++ b/core/src/report-card/report-card.service.ts
@@ -1,0 +1,51 @@
+import {Injectable} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import type {UpsertReportCardAssetRequest} from "@sprocketbot/common";
+import {Repository} from "typeorm";
+
+import {ReportCardAsset} from "../database/report-card/report_card_asset.model";
+
+@Injectable()
+export class ReportCardService {
+    constructor(
+        @InjectRepository(ReportCardAsset)
+        private readonly reportCardRepo: Repository<ReportCardAsset>,
+    ) {}
+
+    async upsertAsset(input: UpsertReportCardAssetRequest): Promise<boolean> {
+        const userIds = Array.from(new Set(input.userIds ?? []));
+        const franchiseIds = Array.from(new Set(input.franchiseIds ?? []));
+
+        const existing = await this.reportCardRepo.findOne({
+            where: {
+                type: input.type,
+                sprocketId: input.sprocketId,
+            },
+        });
+
+        if (existing) {
+            existing.legacyId = input.legacyId;
+            existing.organizationId = input.organizationId;
+            existing.minioKey = input.minioKey;
+            existing.scrimUuid = input.scrimUuid ?? null;
+            existing.userIds = userIds;
+            existing.franchiseIds = franchiseIds;
+            await this.reportCardRepo.save(existing);
+            return true;
+        }
+
+        const asset = this.reportCardRepo.create({
+            type: input.type,
+            sprocketId: input.sprocketId,
+            legacyId: input.legacyId,
+            organizationId: input.organizationId,
+            minioKey: input.minioKey,
+            scrimUuid: input.scrimUuid ?? null,
+            userIds,
+            franchiseIds,
+        });
+
+        await this.reportCardRepo.save(asset);
+        return true;
+    }
+}

--- a/reports/report-cards-evidence-design.md
+++ b/reports/report-cards-evidence-design.md
@@ -1,0 +1,120 @@
+# Evidence Report Cards: Design Summary
+
+## Goal
+Expose scrim and match report cards via Evidence with public access. Users should be able to browse report cards by player and/or team. Scrims include **all** scrims. Matches include **one report card per series**.
+
+## High-Level Flow
+1. **Report cards are generated** today on `ScrimSaved` and `MatchSaved` events via `CoreEndpoint.GenerateReportCard`.
+2. **Notification service persists a report-card asset record** after generation (new Core endpoint).
+3. **Datasets** query the new `report_card_asset` table and enrich with Sprocket + MLEDB context.
+4. **Evidence pages** filter and display report cards with public image URLs.
+
+## Storage Model (Sprocket DB)
+New table: `sprocket.report_card_asset`
+- `id` (serial PK)
+- `type` (`SCRIM` | `MATCH`)
+- `sprocketId` (scrim_id or match_id)
+- `legacyId` (mledb scrim/series id)
+- `organizationId`
+- `minioKey` (object key in public bucket; e.g., `series_report_cards/.../outputs/<id>.png`)
+- `scrimUuid` (nullable, scrim UUID from matchmaking)
+- `userIds` (int[]; populated for scrims)
+- `franchiseIds` (int[]; populated for matches)
+- `createdAt/updatedAt/deletedAt`
+
+Uniqueness: `(type, sprocketId)`
+
+## Core API
+New Core endpoint:
+- `UpsertReportCardAsset`
+  - Input: `{ type, organizationId, sprocketId, legacyId, minioKey, scrimUuid?, userIds[], franchiseIds[] }`
+  - Output: `{ success: boolean }`
+
+Core service upserts on `(type, sprocketId)` to avoid duplicates if events are replayed.
+
+## Notification Service Integration
+- `ScrimSaved` flow:
+  - generate report card
+  - call `UpsertReportCardAsset` with:
+    - `type = SCRIM`
+    - `sprocketId = scrim.databaseIds.id`
+    - `legacyId = scrim.databaseIds.legacyId`
+    - `scrimUuid = scrim.id`
+    - `userIds = scrim.players[].id`
+- `MatchSaved` flow:
+  - generate report card
+  - call `UpsertReportCardAsset` with:
+    - `type = MATCH`
+    - `sprocketId = databaseIds.id`
+    - `legacyId = databaseIds.legacyId`
+    - `franchiseIds = [homeFranchiseId, awayFranchiseId]`
+
+## Public Bucket
+Report card images are stored in the existing image generation bucket. Infra will make this bucket publicly accessible (or expose via CDN). Evidence will build `report_card_url` as:
+
+```
+https://sprocket-image-gen-main-1.nyc3.digitaloceanspaces.com/<minioKey>
+```
+
+The datasets default to this URL but allow overrides via the Postgres setting
+`app.report_cards_base_url` for environment-specific configuration.
+
+## Datasets (sprocketbot/datasets)
+Two public datasets (one row per report-card *player* for filtering):
+
+### `report_cards/scrim_report_cards`
+- Source: `sprocket.report_card_asset` where `type='SCRIM'`
+- Enrichment:
+  - `sprocket.member` + `sprocket.member_profile` for player name
+  - `mledb.scrim` + `mledb.series` for league/mode/type
+- Output columns:
+  - report_card_id, scrim_id, legacy_scrim_id, scrim_uuid
+  - organization_id, generated_at
+  - user_id, player_name
+  - league, scrim_mode, scrim_type
+  - report_card_url
+
+### `report_cards/match_report_cards`
+- Source: `sprocket.report_card_asset` where `type='MATCH'`
+- Enrichment:
+  - `mledb.series` + `mledb.fixture` for home/away teams, league, mode
+  - `mledb.series_replay` + `mledb.player_stats_core` + `mledb.player` for players
+- Output columns:
+  - report_card_id, match_id, legacy_series_id
+  - organization_id, generated_at
+  - home_team, away_team, league, game_mode
+  - player_name
+  - report_card_url
+
+## Evidence Pages
+New pages:
+- `/report_cards/scrims`
+- `/report_cards/matches`
+
+Each page:
+- Dropdown filters for player + league + mode (and team for matches)
+- Query groups by report_card_id to avoid duplicates
+- Grid of cards that links to the full PNG
+
+## Backfill (Optional)
+Once the table is live, a one-time backfill can be run by:
+- selecting all existing scrim/match report card images in the bucket
+- resolving their legacy ids
+- upserting into `report_card_asset`
+
+This is optional; new cards will be indexed automatically.
+
+## Future Enhancement: Match Report Cards with Sprocket User IDs
+Right now match report cards use MLEDB player names because the generation event does not include a reliable list of Sprocket user IDs for the series. To add Sprocket user IDs at generation time:
+- After `MatchSaved`, resolve the MLEDB players for the series:
+  - `mledb.series_replay` → `mledb.player_stats_core` → `mledb.player`
+- Map each MLEDB player to Sprocket players:
+  - `mledb_bridge.player_to_player` (mledPlayerId → sprocketPlayerId)
+  - `sprocket.player` → `sprocket.member` → `sprocket.member.userId`
+- Deduplicate the resulting Sprocket user IDs and include them in `UpsertReportCardAsset` for `MATCH` assets.
+
+This can be added later without changing the datasets, since the dataset can pull from either the `userIds` array or the existing MLEDB-derived player name list.
+
+## Summary of Infra Changes
+- Make the image generation bucket public (or front it with a public CDN).
+- Ensure the public URL prefix matches the datasets’ `report_card_url` construction.


### PR DESCRIPTION
Adds report card asset tracking + upsert endpoint, persists assets on scrim/match report card generation, and includes design summary for Evidence integration.