### PR TITLE
[codex] improve replay mismatch error context

### DIFF
--- a/clients/web/src/lib/components/molecules/scrims/AdminSubmissionTable/SubmissionDetailModal.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/AdminSubmissionTable/SubmissionDetailModal.svelte
@@ -18,27 +18,75 @@
         id: number;
     }
 
+    interface ExpectedPlayer {
+        userId: number;
+        name: string;
+    }
+
+    interface ReplayAccountPlayer {
+        name: string;
+        platform: string;
+        id: string;
+        userId: number | null;
+    }
+
+    interface TeamPlayers<TPlayer> {
+        teamIndex: number;
+        players: TPlayer[];
+    }
+
+    interface MismatchDetails {
+        gameIndex: number;
+        expectedParticipants: ExpectedPlayer[];
+        expectedTeams: Array<TeamPlayers<ExpectedPlayer>>;
+        foundTeams: Array<TeamPlayers<ReplayAccountPlayer>>;
+        unexpectedRecognizedPlayers: ExpectedPlayer[];
+        missingExpectedPlayers: ExpectedPlayer[];
+    }
+
+    interface RawDataPayload {
+        unreported?: UnreportedAccount[];
+        verified?: VerifiedPlayer[];
+        mismatch?: MismatchDetails;
+    }
+
     let unreportedAccounts: UnreportedAccount[] = [];
     let verifiedPlayers: VerifiedPlayer[] = [];
+    let mismatchDetails: MismatchDetails | null = null;
+
+    const parseRawData = (input?: string): RawDataPayload | null => {
+        if (!input) return null;
+        const match = input.match(/RawData: (\{.*\})/);
+        if (!match) return null;
+        try {
+            return JSON.parse(match[1]) as RawDataPayload;
+        } catch (e) {
+            console.error(e);
+            return null;
+        }
+    };
+
+    const applyRawData = (data: RawDataPayload | null): boolean => {
+        if (!data) return false;
+        if (data.unreported) unreportedAccounts = data.unreported;
+        if (data.verified) verifiedPlayers = data.verified;
+        if (data.mismatch) mismatchDetails = data.mismatch;
+        return true;
+    };
 
     // Parse error messages for unreported accounts
     $: {
         unreportedAccounts = [];
         verifiedPlayers = [];
+        mismatchDetails = null;
         let found = false;
 
         if (submission.items) {
             for (const item of submission.items) {
                 if (item.progress?.error) {
-                    const match = item.progress.error.match(/RawData: (\{.*\})/);
-                    if (match) {
-                        try {
-                            const data = JSON.parse(match[1]);
-                            if (data.unreported) unreportedAccounts = data.unreported;
-                            if (data.verified) verifiedPlayers = data.verified;
-                            found = true;
-                            break;
-                        } catch (e) { console.error(e) }
+                    if (applyRawData(parseRawData(item.progress.error))) {
+                        found = true;
+                        break;
                     }
                 }
             }
@@ -46,14 +94,8 @@
 
         if (!found && submission.rejections) {
             for (const rejection of submission.rejections) {
-                const match = rejection.reason.match(/RawData: (\{.*\})/);
-                if (match) {
-                    try {
-                        const data = JSON.parse(match[1]);
-                        if (data.unreported) unreportedAccounts = data.unreported;
-                        if (data.verified) verifiedPlayers = data.verified;
-                        break;
-                    } catch (e) { console.error(e) }
+                if (applyRawData(parseRawData(rejection.reason))) {
+                    break;
                 }
             }
         }
@@ -63,6 +105,25 @@
     let linkUserId: number | undefined;
     let linkOrgId: number = 2;
     let linkTracker: string = "TRN";
+
+    // Generate TRN URL based on platform and ID
+    const getTrnUrl = (platform: string, platformId: string): string => {
+        const normalizedPlatform = platform.toUpperCase();
+        switch (normalizedPlatform) {
+            case "STEAM":
+                return `https://rocketleague.tracker.network/rocket-league/profile/steam/${platformId}/overview`;
+            case "EPIC":
+                return `https://rocketleague.tracker.network/rocket-league/profile/epic/${platformId}/overview`;
+            case "PS4":
+            case "PSN":
+                return `https://rocketleague.tracker.network/rocket-league/profile/psn/${platformId}/overview`;
+            case "XBOX":
+            case "XBL":
+                return `https://rocketleague.tracker.network/rocket-league/profile/xbl/${platformId}/overview`;
+            default:
+                return "";
+        }
+    };
 
     const startLink = (acc: UnreportedAccount) => {
         linkingAccount = acc;
@@ -100,30 +161,77 @@
         visible = false;
         activeSubmissionsStore.invalidate();
     };
-
-    // Generate TRN URL based on platform and ID
-    const getTrnUrl = (platform: string, platformId: string): string => {
-        const normalizedPlatform = platform.toUpperCase();
-        switch (normalizedPlatform) {
-            case "STEAM":
-                return `https://rocketleague.tracker.network/rocket-league/profile/steam/${platformId}/overview`;
-            case "EPIC":
-                return `https://rocketleague.tracker.network/rocket-league/profile/epic/${platformId}/overview`;
-            case "PS4":
-            case "PSN":
-                return `https://rocketleague.tracker.network/rocket-league/profile/psn/${platformId}/overview`;
-            case "XBOX":
-            case "XBL":
-                return `https://rocketleague.tracker.network/rocket-league/profile/xbl/${platformId}/overview`;
-            default:
-                return "";
-        }
-    };
 </script>
 
 
 <Modal title="Submission Detail" bind:visible id="submission-detail-modal">
     <div slot="body">
+        {#if mismatchDetails}
+            <div class="alert bg-warning text-warning-content shadow-lg mb-4">
+                <div class="w-full">
+                    <h3 class="font-bold text-base-100">Mismatched Players Detected</h3>
+                    <p class="text-sm mt-1">Replay game #{Number(mismatchDetails.gameIndex) + 1} does not match expected scrim participants.</p>
+
+                    {#if mismatchDetails.unexpectedRecognizedPlayers.length > 0}
+                        <p class="text-sm mt-2"><span class="font-semibold">Unexpected recognized players:</span> {mismatchDetails.unexpectedRecognizedPlayers.map(p => `${p.name} (${p.userId})`).join(", ")}</p>
+                    {/if}
+                    {#if mismatchDetails.missingExpectedPlayers.length > 0}
+                        <p class="text-sm mt-1"><span class="font-semibold">Missing expected players:</span> {mismatchDetails.missingExpectedPlayers.map(p => `${p.name} (${p.userId})`).join(", ")}</p>
+                    {/if}
+
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-3">
+                        <div class="overflow-x-auto">
+                            <h4 class="font-semibold mb-2">Expected Teams</h4>
+                            <table class="table table-compact w-full bg-base-100 text-base-content rounded-lg">
+                                <thead>
+                                    <tr>
+                                        <th class="bg-base-200">Team</th>
+                                        <th class="bg-base-200">Expected Players</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {#each mismatchDetails.expectedTeams as team}
+                                        <tr>
+                                            <td>Team {Number(team.teamIndex) + 1}</td>
+                                            <td>{team.players.map(p => `${p.name} (${p.userId})`).join(", ")}</td>
+                                        </tr>
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <h4 class="font-semibold mb-2">Found Replay Accounts</h4>
+                            <table class="table table-compact w-full bg-base-100 text-base-content rounded-lg">
+                                <thead>
+                                    <tr>
+                                        <th class="bg-base-200">Team</th>
+                                        <th class="bg-base-200">Account</th>
+                                        <th class="bg-base-200">Platform</th>
+                                        <th class="bg-base-200">Account ID</th>
+                                        <th class="bg-base-200">Recognized User</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {#each mismatchDetails.foundTeams as team}
+                                        {#each team.players as player}
+                                            <tr>
+                                                <td>Team {Number(team.teamIndex) + 1}</td>
+                                                <td>{player.name}</td>
+                                                <td>{player.platform}</td>
+                                                <td class="break-all max-w-xs">{player.id}</td>
+                                                <td>{player.userId ?? "Unknown"}</td>
+                                            </tr>
+                                        {/each}
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {/if}
+
         {#if unreportedAccounts.length > 0}
             <div class="alert bg-warning text-warning-content shadow-lg mb-4">
                 <div class="w-full">

--- a/microservices/submission-service/src/replay-submission/replay-submission-crud/replay-submission-crud.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission-crud/replay-submission-crud.service.ts
@@ -269,7 +269,7 @@ export class ReplaySubmissionCrudService {
             // This prevents issues where staff with multiple franchises (e.g., "FP" + real franchise)
             // would use the wrong franchise and block other staff from ratifying
             let franchise: FranchiseInfo;
-            if (submission.franchiseValidation?.homeFranchiseId || submission.franchiseValidation?.awayFranchiseId) {
+            if (submission.franchiseValidation.homeFranchiseId || submission.franchiseValidation.awayFranchiseId) {
                 const matchFranchiseIds = [
                     submission.franchiseValidation.homeFranchiseId,
                     submission.franchiseValidation.awayFranchiseId,


### PR DESCRIPTION
## Summary
This change improves replay rejection diagnostics when a scrim submission contains recognized accounts that do not belong to the scheduled scrim participants. Previously, the system returned a generic `Mismatched player` error with no actionable context for players or admins.

## User Impact
When a mismatch happens, users and admins can now see exactly what went wrong:
- Which game in the submission mismatched.
- Which recognized users were unexpected.
- Which expected users were missing.
- Expected team rosters for the scrim game.
- Accounts actually found in replay data (platform, account id, mapped user id when recognized).

This reduces support back-and-forth and allows faster correction (for example, account linking issues or wrong replay uploads).

## Root Cause
The validation path compared normalized user-id team matchups against expected scrim matchups and failed with a single opaque error string (`Mismatched player`) when no expected matchup matched the replay data. The relevant expected-vs-found context existed in memory at validation time but was not included in rejection reasons or UI output.

## Fix
### Backend validation (`submission-service`)
- Added structured mismatch payload generation in replay validation:
  - `expectedParticipants`
  - `expectedTeams`
  - `foundTeams`
  - `unexpectedRecognizedPlayers`
  - `missingExpectedPlayers`
- Replaced the generic mismatch message with a context-rich error string including `RawData: { ... }`.
- Added explicit warning logs for mismatch failures with the same structured payload for operational debugging.

### Admin UI
- Extended submission detail modal parsing to handle `RawData.mismatch`.
- Added a dedicated mismatch section that renders expected vs found team/account data, plus missing/unexpected recognized users.

### Player UI
- Extended rejected submission view to parse mismatch `RawData` and render mismatch details inline.
- Cleaned the displayed rejection reason by stripping embedded `RawData` JSON from the top-level message text while still rendering details below.

## Validation
- `npm run dev` in `clients/web` starts successfully (Vite served on `http://localhost:3000/`).
- `npx eslint clients/web/src/lib/components/molecules/scrims/AdminSubmissionTable/SubmissionDetailModal.svelte clients/web/src/routes/league/submit/[submissionId].svelte`
  - No errors on changed player/admin views.
  - Existing a11y warnings remain in `SubmissionDetailModal.svelte` (pre-existing label association warnings).
- `npx eslint microservices/submission-service/src/replay-validation/replay-validation.service.ts`
  - Reports pre-existing lint errors in this file (unused import/member-ordering/no-unsafe-*), not introduced by this PR's functional changes.

## Notes
- Includes one incidental lint-related change in `replay-submission-crud.service.ts` per maintainer request to keep it in this branch.
