### PR TITLE
[codex] improve admin modal readability

### DIFF
--- a/clients/web/src/lib/components/atoms/Modal.svelte
+++ b/clients/web/src/lib/components/atoms/Modal.svelte
@@ -9,7 +9,17 @@
     export let visible: boolean = false;
     export let canClickOutside: boolean =  true;
     export let id: string;
+    export let size: "sm" | "md" | "lg" | "xl" | "full" = "md";
     let mounted: boolean = false;
+
+    $: sizeClass = {
+        sm: "w-[min(92vw,28rem)]",
+        md: "w-[min(94vw,42rem)]",
+        lg: "w-[min(95vw,64rem)]",
+        xl: "w-[min(96vw,84rem)]",
+        full: "w-[98vw] h-[92vh]",
+    }[size];
+
     const close = (): void => {
         visible = false;
     };
@@ -30,14 +40,17 @@
     <input type="checkbox" class="modal-toggle" bind:checked={visible}/>
 
     <div class="modal w-screen h-screen" {id}>
-        <div class="modal-box flex flex-col px-0" use:clickOutside={{callback: handleClickOutside}}>
+        <div
+            class={`modal-box max-w-none max-h-[92vh] flex flex-col px-0 ${sizeClass}`}
+            use:clickOutside={{callback: handleClickOutside}}
+        >
             <div class="close" on:click={close}>
                 <IoMdClose/>
             </div>
 
             <h2 class="px-4 md:px-8">{title ?? ""}</h2>
 
-            <div class="flex-shrink overflow-y-auto overflow-x-auto px-4 md:px-8">
+            <div class="flex-shrink min-w-0 overflow-y-auto overflow-x-hidden px-4 md:px-8">
                 <slot name="body"/>
 
                 {#if $$slots.actions}

--- a/clients/web/src/lib/components/molecules/scrims/AdminSubmissionTable/SubmissionDetailModal.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/AdminSubmissionTable/SubmissionDetailModal.svelte
@@ -164,7 +164,7 @@
 </script>
 
 
-<Modal title="Submission Detail" bind:visible id="submission-detail-modal">
+<Modal title="Submission Detail" bind:visible id="submission-detail-modal" size="xl">
     <div slot="body">
         {#if mismatchDetails}
             <div class="alert bg-warning text-warning-content shadow-lg mb-4">

--- a/clients/web/src/lib/components/organisms/scrims/modals/ManuallyExpireRestrictionModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/ManuallyExpireRestrictionModal.svelte
@@ -26,7 +26,7 @@ const expireRestriction = async () => {
 };
 </script>
 
-<Modal title="Expire Queue Ban Restriction" bind:visible id="expire-restriction-modal">
+<Modal title="Expire Queue Ban Restriction" bind:visible id="expire-restriction-modal" size="lg">
     <section slot="body">
         <div class="form-control w-full">
             <label class="label">

--- a/clients/web/src/lib/components/organisms/scrims/modals/PlayerManagementModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/PlayerManagementModal.svelte
@@ -34,7 +34,7 @@
     }
 </script>
 
-<Modal title="Player Ban Tool" bind:visible id="ban-player-modal">
+<Modal title="Player Ban Tool" bind:visible id="ban-player-modal" size="lg">
     <form on:submit|preventDefault={createBan} slot="body">
         <h4 class='text-lg font-bold'>Selected Player: {player.name}</h4>
 

--- a/clients/web/src/lib/components/organisms/scrims/modals/ScrimManagementModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/ScrimManagementModal.svelte
@@ -21,7 +21,7 @@
   let canClickOutside = true;
 </script>
 
-<Modal title="Manage Scrim" id="manage-scrim-modal" bind:visible {canClickOutside}>
+<Modal title="Manage Scrim" id="manage-scrim-modal" bind:visible {canClickOutside} size="xl">
   <section slot="body">
     {#if targetScrim?.playerCount > 0}
       <Collapse title="Players">
@@ -29,7 +29,12 @@
       </Collapse>
     {/if}
     <Collapse title="Actions" open >
-      <ScrimManagementActions bind:targetScrim on:uploading={e => canClickOutside = !e.detail} />
+      <ScrimManagementActions
+        bind:targetScrim
+        on:uploading={e => {
+            canClickOutside = !e.detail;
+        }}
+      />
     </Collapse>
   </section>
 </Modal>


### PR DESCRIPTION
## Summary
Improves readability of admin modals by adding configurable modal sizing and applying wider modal sizes to the admin-heavy flows.

## What changed
- Added a `size` prop to the shared modal component (`sm|md|lg|xl|full`) with responsive width classes.
- Removed narrow default constraints by setting explicit width classes and `max-w-none`.
- Updated modal body overflow behavior to avoid unnecessary horizontal container scrolling.
- Applied wider sizes to admin-facing modals:
  - Submission Detail (`xl`)
  - Scrim Management (`xl`)
  - Player Ban (`lg`)
  - Expire Restriction (`lg`)
- Minor event handler formatting cleanup in `ScrimManagementModal.svelte` for lint compliance.

## Validation
- `npm run dev` in `clients/web` starts successfully (Vite ready on `http://localhost:3000/`).
- `eslint` on touched modal files reports warnings only (no errors).
