### PR TITLE
fix: use rawPlayer.stats.core directly for shots and goals against

### DIFF
--- a/core/src/replay-parse/finalization/rocket-league/better-finalization.service.spec.ts
+++ b/core/src/replay-parse/finalization/rocket-league/better-finalization.service.spec.ts
@@ -3,7 +3,7 @@ import type {TestingModule} from "@nestjs/testing";
 import {Test} from "@nestjs/testing";
 import {getDataSourceToken} from "@nestjs/typeorm";
 import type {BallchasingResponse} from "@sprocketbot/common";
-import {ProgressStatus} from "@sprocketbot/common";
+import {CarballConverterService, ProgressStatus} from "@sprocketbot/common";
 import type {EntityManager} from "typeorm";
 import {DataSource} from "typeorm";
 
@@ -20,11 +20,13 @@ import type {MatchReplaySubmission} from "../../types";
 import {BallchasingConverterService} from "../ballchasing-converter/ballchasing-converter.service";
 import {MATCH_SUBMISSION_FIXTURE_RATIFYING} from "./fixtures/MatchSubmission.fixture";
 import {RocketLeagueFinalizationService} from "./rocket-league-finalization.service";
+import {GameMode} from "../../../database/game/game_mode/game_mode.model";
+import type {BallchasingPlayer} from "@sprocketbot/common";
 
 describe("BetterFinalizationService", () => {
     let service: RocketLeagueFinalizationService;
     let playerService: PlayerService;
-
+    let sprocketRatingService: SprocketRatingService;
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -42,12 +44,8 @@ describe("BetterFinalizationService", () => {
                         getFranchisesForMatch: jest.fn(),
                     },
                 },
-                {
-                    provide: SprocketRatingService,
-                    useValue: {
-                        calcSprocketRating: jest.fn(),
-                    },
-                },
+                
+                    SprocketRatingService,
                 {
                     provide: MledbPlayerService,
                     useValue: {
@@ -91,11 +89,18 @@ describe("BetterFinalizationService", () => {
                         createQueryRunner: jest.fn(),
                     },
                 },
+                {
+                    provide: CarballConverterService,
+                    useValue:{
+                        createRound: jest.fn()
+                    }
+                }
             ],
         }).compile();
 
         service = module.get<RocketLeagueFinalizationService>(RocketLeagueFinalizationService);
         playerService = module.get<PlayerService>(PlayerService);
+        sprocketRatingService = module.get(SprocketRatingService);
     });
 
     it("should be defined", () => {
@@ -114,6 +119,33 @@ describe("BetterFinalizationService", () => {
         });
     });
 
+
+    describe("_getSprocketRating", () => {
+        it("Should return correct sprocket rating using rawPlayer.stats.core values directly", () => {
+            const mockPlayer = {
+                stats: {
+                    core: {
+                        goals: 9.0 / 5.0,
+                        assists: 8.0 / 5.0,
+                        shots: 28.0 / 5.0,
+                        saves: 5.0 / 5.0,
+                        goals_against: 7.0 / 5.0,
+                        shots_against: 24.0 / 5.0,
+                    },
+                },
+            } as unknown as BallchasingPlayer;
+
+            const mockGameMode = {
+                teamSize: 2,
+            } as unknown as GameMode;
+
+            const result = service._getSprocketRating(mockPlayer, mockGameMode);
+
+            expect(Math.round(result.opi * 10.0) / 10.0).toStrictEqual(85.1);
+            expect(Math.round(result.dpi * 10.0) / 10.0).toStrictEqual(77.1);
+            expect(Math.round(result.gpi * 10.0) / 10.0).toStrictEqual(81.1);
+        });
+    });
     describe("saveMatch", () => {
         it("Should throw an error if the submission contains incomplete values", async () => {
             const mockedValue = {

--- a/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
+++ b/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
@@ -568,7 +568,12 @@ export class RocketLeagueFinalizationService {
         gameMode: GameMode,
     ): SprocketRating {
         const sprocketRatingInput: SprocketRatingInput = {
-            ...rawPlayer.stats.core,
+            goals: rawPlayer.stats.core.goals,
+            assists: rawPlayer.stats.core.assists,
+            shots: rawPlayer.stats.core.shots,
+            saves: rawPlayer.stats.core.saves,
+            goals_against: rawPlayer.stats.core.goals_against,
+            shots_against: rawPlayer.stats.core.shots_against,
             team_size: gameMode.teamSize,
         };
         return this.sprocketRatingService.calcSprocketRating(sprocketRatingInput);


### PR DESCRIPTION

*** Untested as I was unable to setup docker/env locally in a complete enough manner. Changes are supported by:

Confirmation that rawPlayer.core.stats does have shots and goals against in the dev requests  thread.
Referencing the MLEDB calculation of sprocket rating, specifically how shots_against and goals_against are accessed.

Changed _getSprocketRating to get shots_against and goals_against from rawPlayer.core.stats rather than the .reduce() calculation done previously. Former implementation was leading to mismatch between MLEDB and sprocket calculations and was overall redundant.