### PR TITLE
Use summary-only replay parsing by default

### DIFF
--- a/common/src/celery/types/schemas/parse-replay.schema.ts
+++ b/common/src/celery/types/schemas/parse-replay.schema.ts
@@ -16,12 +16,14 @@ export enum Parser {
 export const ParseReplay_Response = z.discriminatedUnion("parser", [
     z.object({
         parser: z.literal("ballchasing"),
+        analysisMode: z.enum(["summary-only", "full-analysis"]).optional(),
         parserVersion: z.union([z.string().transform(v => parseFloat(v)), z.number()]),
         outputPath: z.string(),
         data: BallchasingResponseSchema,
     }),
     z.object({
         parser: z.literal("carball"),
+        analysisMode: z.enum(["summary-only", "full-analysis"]).optional(),
         parserVersion: z.union([z.string().transform(v => parseFloat(v)), z.number()]),
         outputPath: z.string(),
         data: CarballResponseSchema,

--- a/common/src/celery/types/schemas/stats/carball/carball.schema.ts
+++ b/common/src/celery/types/schemas/stats/carball/carball.schema.ts
@@ -10,18 +10,28 @@ const safeNumber = () => z.preprocess(val => {
     return isNaN(num) ? undefined : num;
 }, z.number().optional());
 
+const safeString = () => z.preprocess(val => {
+    if (val === null || val === undefined || val === "") return undefined;
+    return typeof val === "number" || typeof val === "bigint" ? String(val) : val;
+}, z.string().optional());
+
 // Game metadata schema - using proper types to match BallchasingResponse expectations
 // Numeric fields safely convert strings to numbers, handling invalid values as undefined
 export const CarballGameMetadataSchema = z.object({
     id: z.string().optional(),
+    name: z.string().optional(),
     map: z.string().optional(),
-    time: z.string().optional(),
+    time: safeString(),
     frames: safeNumber(),
     length: safeNumber(),
+    match_guid: z.string().optional(),
     server_name: z.string().optional(),
+    game_server_id: z.string().optional(),
     match_type: z.string().optional(),
     team_size: safeNumber(),
     playlist: safeNumber(),
+    unknown_playlist: safeNumber(),
+    is_invalid_analysis: z.coerce.boolean().optional(),
 }).passthrough(); // Allow additional fields we haven't explicitly defined
 
 export type CarballGameMetadata = z.infer<typeof CarballGameMetadataSchema>;

--- a/common/src/converters/carball-converter.service.ts
+++ b/common/src/converters/carball-converter.service.ts
@@ -19,55 +19,18 @@ export class CarballConverterService {
         carball: CarballResponse,
         outputPath: string,
     ): BallchasingResponse {
-
-        // Extract metadata (supports both camelCase and snake_case)
         const metadata = carball.gameMetadata ?? carball.game_metadata ?? {};
-        const gameStats = carball.gameStats ?? carball.game_stats ?? {};
-
-        // Helper to validate and return a valid ISO date string
-        const getValidDate = (dateValue: string | undefined): string => {
-            if (!dateValue) return new Date().toISOString();
-            const testDate = new Date(dateValue);
-            return isNaN(testDate.getTime()) ? new Date().toISOString() : dateValue;
-        };
-
-        // Separate teams into blue and orange
         const teams = carball.teams ?? [];
         const players = carball.players ?? [];
-
-        console.log(`[CarballConverter] Total players: ${players.length}`);
-        console.log(`[CarballConverter] Total teams: ${teams.length}`);
-
-        // Identify blue and orange teams based on player color
-        // Carball returns isOrange (camelCase), not is_orange (snake_case)
-        const bluePlayers = players.filter(p => {
-            const isOrange = (p as any).isOrange ?? p.is_orange ?? 0;
-            return isOrange === 0;
-        });
-        const orangePlayers = players.filter(p => {
-            const isOrange = (p as any).isOrange ?? p.is_orange ?? 1;
-            return isOrange === 1;
-        });
-
-        console.log(`[CarballConverter] Blue players: ${bluePlayers.length}, Orange players: ${orangePlayers.length}`);
-
-        // Find team objects if they exist
-        const blueTeam = teams.find(t => t.color === 0) ?? {players: bluePlayers};
-        const orangeTeam = teams.find(t => t.color === 1) ?? {players: orangePlayers};
-
-        // Calculate team scores from player data
-        const blueScore = bluePlayers.reduce((sum, p) => sum + (p.score ?? 0), 0);
-        const orangeScore = orangePlayers.reduce((sum, p) => sum + (p.score ?? 0), 0);
-
-        // Calculate team totals for goals and shots (needed for goals_against/shots_against)
-        const blueTotals = {
-            goals: bluePlayers.reduce((sum, p) => sum + (p.goals ?? 0), 0),
-            shots: bluePlayers.reduce((sum, p) => sum + (p.shots ?? 0), 0),
-        };
-        const orangeTotals = {
-            goals: orangePlayers.reduce((sum, p) => sum + (p.goals ?? 0), 0),
-            shots: orangePlayers.reduce((sum, p) => sum + (p.shots ?? 0), 0),
-        };
+        const goalCounts = this.buildGoalCountLookup(metadata);
+        const {blue: bluePlayers, orange: orangePlayers} = this.groupPlayersByTeam(players, teams);
+        const blueTeam = this.findTeamByColor(teams, "blue") ?? {players: bluePlayers};
+        const orangeTeam = this.findTeamByColor(teams, "orange") ?? {players: orangePlayers};
+        const metadataScore = (metadata as any).score ?? {};
+        const blueGoals = this.getTeamGoals(bluePlayers, blueTeam, goalCounts, metadataScore, "blue");
+        const orangeGoals = this.getTeamGoals(orangePlayers, orangeTeam, goalCounts, metadataScore, "orange");
+        const blueTotals = this.getTeamTotals(bluePlayers, blueGoals);
+        const orangeTotals = this.getTeamTotals(orangePlayers, orangeGoals);
 
         // Generate stub ID from output path or random UUID
         const replayId = outputPath.split("/").pop()
@@ -79,8 +42,8 @@ export class CarballConverterService {
             id: replayId,
             link: `file://${outputPath}`,
             status: "ok" as const,
-            title: metadata.id ?? "Carball Parsed Replay",
-            date: getValidDate(metadata.time),
+            title: metadata.name ?? metadata.id ?? "Carball Parsed Replay",
+            date: this.getValidDate(metadata.time),
             date_has_timezone: false,
             created: new Date().toISOString(),
             visibility: "private",
@@ -88,7 +51,7 @@ export class CarballConverterService {
             // Rocket League metadata
             rocket_league_id: metadata.id ?? replayId,
             season: 0, // Unknown from carball
-            match_guid: metadata.id ?? replayId,
+            match_guid: (metadata as any).match_guid ?? metadata.id ?? replayId,
 
             // Uploader - stub data
             recorder: undefined,
@@ -100,8 +63,8 @@ export class CarballConverterService {
             },
 
             // Match info
-            match_type: metadata.match_type ?? metadata.playlist?.toString() ?? "unknown",
-            playlist_id: metadata.playlist?.toString() ?? "unknown",
+            match_type: this.getMatchType(metadata.playlist, metadata.match_type),
+            playlist_id: this.getPlaylistId(metadata.playlist),
             playlist_name: this.getPlaylistName(metadata.playlist),
 
             // Map info
@@ -115,8 +78,8 @@ export class CarballConverterService {
 
             // Teams
             team_size: metadata.team_size ?? Math.max(bluePlayers.length, orangePlayers.length),
-            blue: this.convertTeam(blueTeam, bluePlayers, "blue", orangeTotals),
-            orange: this.convertTeam(orangeTeam, orangePlayers, "orange", blueTotals),
+            blue: this.convertTeam(blueTeam, bluePlayers, "blue", orangeTotals, goalCounts),
+            orange: this.convertTeam(orangeTeam, orangePlayers, "orange", blueTotals, goalCounts),
         };
 
         return ballchasingResponse;
@@ -127,24 +90,31 @@ export class CarballConverterService {
         players: CarballPlayer[],
         color: "blue" | "orange",
         opposingTeamTotals: {goals: number; shots: number;},
+        goalCounts: Map<string, number>,
     ): BallchasingTeam {
-    // Aggregate team stats from player stats
-        const teamStats = this.aggregateTeamStats(players);
+        const teamStats = this.aggregateTeamStats(players, opposingTeamTotals, goalCounts);
 
         return {
             name: (team as any).name,
             color,
             stats: teamStats,
-            players: players.map(p => this.convertPlayer(p, opposingTeamTotals)),
+            players: players.map(p => this.convertPlayer(
+                p,
+                opposingTeamTotals,
+                goalCounts.get(this.getPlayerLookupKey(p.id)) ?? 0,
+            )),
         };
     }
 
     private convertPlayer(
         player: CarballPlayer,
         opposingTeamTotals: {goals: number; shots: number;},
+        derivedGoals: number,
     ): BallchasingPlayer {
         const playerId = player.id ?? {id: "0", platform: undefined};
         const platform = (playerId as any).platform ?? (player as any).platform ?? "steam";
+        const startTime = player.first_frame_in_game ?? player.firstFrameInGame ?? 0;
+        const timeInGame = player.time_in_game ?? player.timeInGame ?? 0;
 
         return {
             id: {
@@ -152,35 +122,37 @@ export class CarballConverterService {
                 platform: this.mapPlatform(platform),
             },
             name: player.name ?? "Unknown",
-            camera: this.extractCameraSettings(player.camera_settings),
+            camera: this.extractCameraSettings(player.camera_settings ?? player.cameraSettings),
             car_id: -1,
             car_name: "UNKNOWN",
-            start_time: player.first_frame_in_game ?? 0,
-            end_time: (player.first_frame_in_game ?? 0) + (player.time_in_game ?? 0),
+            start_time: startTime,
+            end_time: startTime + timeInGame,
             steering_sensitivity: 1.0,
-            stats: this.convertPlayerStats(player, opposingTeamTotals),
+            stats: this.convertPlayerStats(player, opposingTeamTotals, derivedGoals),
         };
     }
 
     private convertPlayerStats(
         player: CarballPlayer,
         opposingTeamTotals: {goals: number; shots: number;},
+        derivedGoals: number,
     ): any {
-    // Extract stats from carball player stats object
         const stats = player.stats as any ?? {};
+        const goals = player.goals ?? derivedGoals;
+        const shots = player.shots ?? 0;
 
         return {
             core: {
                 mvp: false,
                 // Round all core stats to integers for database compatibility
-                goals: Math.round(player.goals ?? 0),
+                goals: Math.round(goals),
                 saves: Math.round(player.saves ?? 0),
                 score: Math.round(player.score ?? 0),
-                shots: Math.round(player.shots ?? 0),
+                shots: Math.round(shots),
                 assists: Math.round(player.assists ?? 0),
                 goals_against: Math.round(opposingTeamTotals.goals),
                 shots_against: Math.round(opposingTeamTotals.shots),
-                shooting_percentage: 0,
+                shooting_percentage: shots > 0 ? goals / shots * 100 : 0,
             },
             demo: {
                 taken: stats.demo_stats?.taken ?? 0,
@@ -192,9 +164,14 @@ export class CarballConverterService {
         };
     }
 
-    private aggregateTeamStats(players: CarballPlayer[]): any {
-    // Aggregate player stats to team level
-        const totalGoals = players.reduce((sum, p) => sum + (p.goals ?? 0), 0);
+    private aggregateTeamStats(
+        players: CarballPlayer[],
+        opposingTeamTotals: {goals: number; shots: number;},
+        goalCounts: Map<string, number>,
+    ): any {
+        const totalGoals = players.reduce((sum, p) => (
+            sum + (p.goals ?? goalCounts.get(this.getPlayerLookupKey(p.id)) ?? 0)
+        ), 0);
         const totalSaves = players.reduce((sum, p) => sum + (p.saves ?? 0), 0);
         const totalScore = players.reduce((sum, p) => sum + (p.score ?? 0), 0);
         const totalShots = players.reduce((sum, p) => sum + (p.shots ?? 0), 0);
@@ -211,14 +188,172 @@ export class CarballConverterService {
                 score: totalScore,
                 shots: totalShots,
                 assists: totalAssists,
-                goals_against: 0,
-                shots_against: 0,
+                goals_against: opposingTeamTotals.goals,
+                shots_against: opposingTeamTotals.shots,
                 shooting_percentage: totalShots > 0 ? totalGoals / totalShots * 100 : 0,
             },
             boost: this.getDefaultBoostStats(),
             movement: this.getDefaultMovementStats(),
             positioning: this.getDefaultPositioningStats(),
         };
+    }
+
+    private getValidDate(dateValue: unknown): string {
+        if (dateValue === null || dateValue === undefined || dateValue === "") {
+            return new Date().toISOString();
+        }
+
+        if (typeof dateValue === "number" || /^\d+$/.test(String(dateValue))) {
+            const rawValue = Number(dateValue);
+            const timestamp = rawValue > 1_000_000_000_000 ? rawValue : rawValue * 1000;
+            const parsed = new Date(timestamp);
+            return isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+        }
+
+        const parsed = new Date(String(dateValue));
+        return isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+    }
+
+    private buildGoalCountLookup(metadata: Record<string, unknown>): Map<string, number> {
+        const goalCounts = new Map<string, number>();
+        const goals = ((metadata as any).goals ?? []) as Array<Record<string, unknown>>;
+
+        for (const goal of goals) {
+            const playerId = (goal.player_id ?? goal.playerId) as Record<string, unknown> | undefined;
+            const key = this.getPlayerLookupKey(playerId);
+            if (!key) continue;
+            goalCounts.set(key, (goalCounts.get(key) ?? 0) + 1);
+        }
+
+        return goalCounts;
+    }
+
+    private groupPlayersByTeam(
+        players: CarballPlayer[],
+        teams: CarballTeam[],
+    ): {blue: CarballPlayer[]; orange: CarballPlayer[];} {
+        const playerByKey = new Map(players.map(player => [this.getPlayerLookupKey(player.id), player]));
+        const grouped = {
+            blue: [] as CarballPlayer[],
+            orange: [] as CarballPlayer[],
+        };
+
+        for (const player of players) {
+            const isOrange = this.toBooleanish((player as any).isOrange ?? player.is_orange);
+            if (isOrange === true) grouped.orange.push(player);
+            else if (isOrange === false) grouped.blue.push(player);
+        }
+
+        for (const team of teams) {
+            const color = this.getTeamColor(team);
+            if (!color) continue;
+
+            const target = color === "orange" ? grouped.orange : grouped.blue;
+            const playerIds = (((team as any).player_ids ?? (team as any).playerIds) ?? []) as Array<Record<string, unknown>>;
+            for (const playerId of playerIds) {
+                const key = this.getPlayerLookupKey(playerId);
+                if (!key) continue;
+                const player = playerByKey.get(key);
+                if (player && !target.some(existing => this.getPlayerLookupKey(existing.id) === key)) {
+                    target.push(player);
+                }
+            }
+        }
+
+        for (const player of players) {
+            const key = this.getPlayerLookupKey(player.id);
+            if (
+                !grouped.blue.some(existing => this.getPlayerLookupKey(existing.id) === key)
+                && !grouped.orange.some(existing => this.getPlayerLookupKey(existing.id) === key)
+            ) {
+                grouped.blue.push(player);
+            }
+        }
+
+        return grouped;
+    }
+
+    private findTeamByColor(teams: CarballTeam[], color: "blue" | "orange"): CarballTeam | undefined {
+        return teams.find(team => this.getTeamColor(team) === color);
+    }
+
+    private getTeamGoals(
+        players: CarballPlayer[],
+        team: CarballTeam | {players: CarballPlayer[];},
+        goalCounts: Map<string, number>,
+        metadataScore: Record<string, unknown>,
+        color: "blue" | "orange",
+    ): number {
+        const scoreField = color === "blue" ? "team_0_score" : "team_1_score";
+        const metadataScoreValue = this.toNumber(
+            (metadataScore as any)[scoreField]
+            ?? (metadataScore as any)[scoreField.replace(/_/g, "")]
+            ?? (metadataScore as any)[color === "blue" ? "team0Score" : "team1Score"],
+        );
+        const teamScore = this.toNumber((team as any).score);
+
+        return teamScore
+            ?? metadataScoreValue
+            ?? players.reduce((sum, player) => (
+                sum + (player.goals ?? goalCounts.get(this.getPlayerLookupKey(player.id)) ?? 0)
+            ), 0);
+    }
+
+    private getTeamTotals(
+        players: CarballPlayer[],
+        teamGoals: number,
+    ): {goals: number; shots: number;} {
+        return {
+            goals: teamGoals,
+            shots: players.reduce((sum, player) => sum + (player.shots ?? 0), 0),
+        };
+    }
+
+    private getPlayerLookupKey(playerId: unknown): string {
+        const id = (playerId as any)?.id;
+        const platform = (playerId as any)?.platform ?? (playerId as any)?.system_id ?? "unknown";
+        return id ? `${String(platform).toLowerCase()}:${String(id)}` : "";
+    }
+
+    private getTeamColor(team: CarballTeam): "blue" | "orange" | null {
+        const explicitColor = (team as any).color;
+        if (explicitColor === 0 || explicitColor === "0" || explicitColor === "blue") return "blue";
+        if (explicitColor === 1 || explicitColor === "1" || explicitColor === "orange") return "orange";
+
+        const isOrange = this.toBooleanish((team as any).is_orange ?? (team as any).isOrange);
+        if (isOrange === true) return "orange";
+        if (isOrange === false) return "blue";
+
+        return null;
+    }
+
+    private toBooleanish(value: unknown): boolean | null {
+        if (value === null || value === undefined) return null;
+        if (typeof value === "boolean") return value;
+        if (typeof value === "number") return value !== 0;
+        if (typeof value === "string") {
+            const normalized = value.toLowerCase();
+            if (normalized === "true" || normalized === "1") return true;
+            if (normalized === "false" || normalized === "0") return false;
+        }
+        return null;
+    }
+
+    private toNumber(value: unknown): number | undefined {
+        if (value === null || value === undefined || value === "") return undefined;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    private getPlaylistId(playlist: number | undefined): string {
+        if (playlist === 6) return "private";
+        return playlist?.toString() ?? "unknown";
+    }
+
+    private getMatchType(playlist: number | undefined, matchType: string | undefined): string {
+        if (matchType) return matchType;
+        if (playlist === 6) return "Private";
+        return "unknown";
     }
 
     private extractCameraSettings(cameraSettings: unknown): any {
@@ -396,7 +531,7 @@ export class CarballConverterService {
             2: "Doubles",
             3: "Standard",
             4: "Chaos",
-            6: "Rocket Labs",
+            6: "Private",
             10: "Ranked Duel",
             11: "Ranked Doubles",
             13: "Ranked Standard",

--- a/core/src/replay-parse/finalization/rocket-league/better-finalization.service.spec.ts
+++ b/core/src/replay-parse/finalization/rocket-league/better-finalization.service.spec.ts
@@ -22,11 +22,59 @@ import {MATCH_SUBMISSION_FIXTURE_RATIFYING} from "./fixtures/MatchSubmission.fix
 import {RocketLeagueFinalizationService} from "./rocket-league-finalization.service";
 import {GameMode} from "../../../database/game/game_mode/game_mode.model";
 import type {BallchasingPlayer} from "@sprocketbot/common";
+import {ReplaySubmissionType} from "../../types";
+
+const SUMMARY_ONLY_CARBALL_REPLAY = {
+    game_metadata: {
+        id: "summary-only-replay",
+        name: "Summary Only Replay",
+        map: "dfh_stadium",
+        time: "1710000000",
+        length: 300,
+        team_size: 2,
+        playlist: 6,
+        match_guid: "summary-match-guid",
+        score: {
+            team_0_score: 2,
+            team_1_score: 1,
+        },
+        goals: [
+            {player_id: {id: "blue-1", platform: "steam"} },
+            {player_id: {id: "orange-1", platform: "epic"} },
+            {player_id: {id: "blue-1", platform: "steam"} },
+        ],
+    },
+    players: [
+        {id: {id: "blue-1", platform: "steam"}, name: "Blue One", is_orange: 0},
+        {id: {id: "blue-2", platform: "steam"}, name: "Blue Two", is_orange: 0},
+        {id: {id: "orange-1", platform: "epic"}, name: "Orange One", is_orange: 1},
+        {id: {id: "orange-2", platform: "epic"}, name: "Orange Two", is_orange: 1},
+    ],
+    teams: [
+        {
+            is_orange: false,
+            score: 2,
+            player_ids: [
+                {id: "blue-1", platform: "steam"},
+                {id: "blue-2", platform: "steam"},
+            ],
+        },
+        {
+            is_orange: true,
+            score: 1,
+            player_ids: [
+                {id: "orange-1", platform: "epic"},
+                {id: "orange-2", platform: "epic"},
+            ],
+        },
+    ],
+};
 
 describe("BetterFinalizationService", () => {
     let service: RocketLeagueFinalizationService;
     let playerService: PlayerService;
     let sprocketRatingService: SprocketRatingService;
+    let ballchasingConverter: BallchasingConverterService;
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -91,16 +139,15 @@ describe("BetterFinalizationService", () => {
                 },
                 {
                     provide: CarballConverterService,
-                    useValue:{
-                        createRound: jest.fn()
-                    }
-                }
+                    useValue: new CarballConverterService(),
+                },
             ],
         }).compile();
 
         service = module.get<RocketLeagueFinalizationService>(RocketLeagueFinalizationService);
         playerService = module.get<PlayerService>(PlayerService);
         sprocketRatingService = module.get(SprocketRatingService);
+        ballchasingConverter = module.get(BallchasingConverterService);
     });
 
     it("should be defined", () => {
@@ -181,6 +228,57 @@ describe("BetterFinalizationService", () => {
                     {} as unknown as EntityManager,
                 )
                 .catch((e: Error) => e.message.toString())).resolves.toContain(filename);
+        });
+
+        it("Should finalize degraded summary-only carball payloads without frame stats", async () => {
+            const playerLookups = [
+                {id: 1, member: {userId: 11} },
+                {id: 2, member: {userId: 12} },
+                {id: 3, member: {userId: 13} },
+                {id: 4, member: {userId: 14} },
+            ];
+            jest.spyOn(playerService, "getPlayer")
+                .mockResolvedValueOnce(playerLookups[0] as any)
+                .mockResolvedValueOnce(playerLookups[1] as any)
+                .mockResolvedValueOnce(playerLookups[2] as any)
+                .mockResolvedValueOnce(playerLookups[3] as any);
+            jest.spyOn(ballchasingConverter, "createRound").mockReturnValue({round: "stats"} as any);
+
+            const submission = {
+                id: "submission-1",
+                type: ReplaySubmissionType.SCRIM,
+                items: [
+                    {
+                        originalFilename: "summary-only.replay",
+                        outputPath: "dev/v4/summary-only.json",
+                        progress: {
+                            status: ProgressStatus.Complete,
+                            result: {
+                                parser: "carball",
+                                parserVersion: 4,
+                                analysisMode: "summary-only",
+                                outputPath: "dev/v4/summary-only.json",
+                                data: SUMMARY_ONLY_CARBALL_REPLAY,
+                            },
+                        },
+                    },
+                ],
+            } as unknown as MatchReplaySubmission;
+            const em = {
+                create: jest.fn(() => ({})),
+                insert: jest.fn().mockResolvedValue(undefined),
+            } as unknown as EntityManager;
+            const match = {
+                id: 42,
+                gameMode: {teamSize: 2},
+                rounds: [],
+            } as unknown as Match;
+
+            const players = await service.saveMatchDependents(submission, match, false, em);
+
+            expect(players).toHaveLength(4);
+            expect(ballchasingConverter.createRound).toHaveBeenCalledTimes(1);
+            expect((em.insert as jest.Mock).mock.calls).toHaveLength(4);
         });
     });
 });

--- a/microservices/replay-parse-service/src/main.py
+++ b/microservices/replay-parse-service/src/main.py
@@ -17,7 +17,7 @@ from kombu import Producer, Connection
 # Celery pipeline for starting jobs (broker) and returning results (backend)
 app = celery.Celery(config_source=celeryconfig)
 
-PARSER_VERSION = "3"
+PARSER_VERSION = "4"
 
 ANALYTICS_QUEUE = config["transport"]["analytics_queue"]
 PARSED_OBJECT_PREFIX = f"{config['minio']['parsed_object_prefix']}/v{PARSER_VERSION}"
@@ -153,6 +153,7 @@ class ParseReplay(BaseTask):
 
         result = {
             "parser": 'carball',
+            "analysisMode": "summary-only",
             "parserVersion": PARSER_VERSION,
             "outputPath": parsed_object_path,
             "data": parsed_data,

--- a/microservices/replay-parse-service/src/parser.py
+++ b/microservices/replay-parse-service/src/parser.py
@@ -35,11 +35,11 @@ if PARSER not in VALID_PARSERS:
 
 
 def parse(path: str, on_progress: Callable[[str], None] = None):
-    # For now, only parse with carball ever
-    print("Parsing with carball parser.")
-    return _parse_carball(path, on_progress)
+    # Default to the metadata-only parser contract to avoid depending on network frames.
+    print("Parsing with carball summary-only parser.")
+    return _parse_carball_summary(path, on_progress)
     if PARSER == "carball":
-        return _parse_carball(path, on_progress)
+        return _parse_carball_summary(path, on_progress)
     if PARSER == "ballchasing":
         return _parse_ballchasing(path, on_progress)
     if PARSER == "ballchasing-with-carball-shadow":
@@ -77,7 +77,7 @@ def _parse_dual_with_shadow(path: str, on_progress: Callable[[str], None] = None
         try:
             # Create a silent progress callback for shadow parsing
             shadow_progress = lambda msg: print(f"Carball shadow: {msg}")
-            carball_result = _parse_carball(path, shadow_progress)
+            carball_result = _parse_carball_summary(path, shadow_progress)
             carball_duration = time.time() - carball_start
             print(f"Carball shadow parsing completed in {carball_duration:.2f}s")
         except Exception as e:
@@ -227,7 +227,58 @@ def _log_parser_comparison(path: str, ballchasing_data: dict, carball_data: dict
 #
 ###############################
 
-def _parse_carball(path: str, on_progress: Callable[[str], None] = None) -> dict:
+def _coerce_to_jsonable(value):
+    if isinstance(value, dict):
+        return value
+
+    if hasattr(value, "DESCRIPTOR"):
+        from google.protobuf.json_format import MessageToDict
+
+        return MessageToDict(
+            value,
+            preserving_proto_field_name=True,
+        )
+
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return json.loads(json.dumps(value, default=lambda obj: getattr(obj, "__dict__", str(obj))))
+
+
+def _parse_carball_summary(path: str, on_progress: Callable[[str], None] = None) -> dict:
+    """
+    Parses replay metadata using carball's summary-only API.
+
+    This path intentionally avoids full frame analysis so replay format drift in
+    network frames does not break metadata consumers.
+    """
+    print(f"Parsing {path} with carball summary-only path")
+
+    summarize_replay_file = getattr(carball, "summarize_replay_file", None)
+    if summarize_replay_file is None:
+        raise Exception(
+            "Installed sprocket-rl-parser does not expose carball.summarize_replay_file(...). "
+            "Upgrade the parser package to a version with the summary-only API."
+        )
+
+    try:
+        if on_progress:
+            on_progress("Summarizing replay header...")
+
+        summary = summarize_replay_file(path)
+        output = _coerce_to_jsonable(summary)
+        print(f"Carball summary keys: {list(output.keys()) if isinstance(output, dict) else type(output)}")
+        return output
+    except Exception as e:
+        logging.error(f"Carball summary parsing failed for {path}: {str(e)}")
+        raise Exception(f"Failed to summarize replay with carball: {str(e)}")
+
+
+def _parse_carball_full_analysis(path: str, on_progress: Callable[[str], None] = None) -> dict:
     """
     Parses a Rocket League replay located at a given local path using carball
 
@@ -270,7 +321,13 @@ def _parse_carball(path: str, on_progress: Callable[[str], None] = None) -> dict
         return output
     except Exception as e:
         logging.error(f"Carball parsing failed for {path}: {str(e)}")
-        raise Exception(f"Failed to parse replay with carball: {str(e)}")
+        error_message = str(e)
+        if "network_frames" in error_message:
+            error_message = (
+                f"{error_message}. Full analysis requires parsed network frames. "
+                "Use carball.summarize_replay_file(...) for metadata-only flows."
+            )
+        raise Exception(f"Failed to parse replay with carball: {error_message}")
 
 
 

--- a/microservices/replay-parse-service/src/run_parse.py
+++ b/microservices/replay-parse-service/src/run_parse.py
@@ -30,8 +30,9 @@ def main():
         print(f"Keys in result: {list(result.keys())}")
         
         # Print some basic stats to verify
-        if 'gameMetadata' in result:
-            print(f"Game Metadata: {result['gameMetadata']}")
+        metadata = result.get("gameMetadata") or result.get("game_metadata")
+        if metadata:
+            print(f"Game Metadata: {metadata}")
             
     except Exception as e:
         print(f"Error parsing replay: {e}")

--- a/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.spec.ts
+++ b/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.spec.ts
@@ -1,0 +1,77 @@
+import {Parser} from "@sprocketbot/common";
+
+import {StatsConverterService} from "./stats-converter.service";
+
+const SUMMARY_ONLY_CARBALL_REPLAY = {
+    game_metadata: {
+        id: "summary-only-replay",
+        name: "Summary Only Replay",
+        map: "dfh_stadium",
+        time: "1710000000",
+        length: 300,
+        team_size: 2,
+        playlist: 6,
+        match_guid: "summary-match-guid",
+        score: {
+            team_0_score: 2,
+            team_1_score: 1,
+        },
+        goals: [
+            {player_id: {id: "blue-1", platform: "steam"} },
+            {player_id: {id: "orange-1", platform: "epic"} },
+            {player_id: {id: "blue-1", platform: "steam"} },
+        ],
+    },
+    players: [
+        {id: {id: "blue-1", platform: "steam"}, name: "Blue One", is_orange: 0},
+        {id: {id: "blue-2", platform: "steam"}, name: "Blue Two", is_orange: 0},
+        {id: {id: "orange-1", platform: "epic"}, name: "Orange One", is_orange: 1},
+        {id: {id: "orange-2", platform: "epic"}, name: "Orange Two", is_orange: 1},
+    ],
+    teams: [
+        {
+            is_orange: false,
+            score: 2,
+            player_ids: [
+                {id: "blue-1", platform: "steam"},
+                {id: "blue-2", platform: "steam"},
+            ],
+        },
+        {
+            is_orange: true,
+            score: 1,
+            player_ids: [
+                {id: "orange-1", platform: "epic"},
+                {id: "orange-2", platform: "epic"},
+            ],
+        },
+    ],
+};
+
+describe("StatsConverterService", () => {
+    it("converts summary-only carball payloads without frame-derived stats", () => {
+        const service = new StatsConverterService();
+
+        const result = service.convertStats([
+            {
+                parser: Parser.CARBALL,
+                analysisMode: "summary-only",
+                parserVersion: 4,
+                outputPath: "dev/v4/summary-only.json",
+                data: SUMMARY_ONLY_CARBALL_REPLAY,
+            } as any,
+        ]);
+
+        expect(result.games).toHaveLength(1);
+        expect(result.games[0].teams[0].score).toBe(2);
+        expect(result.games[0].teams[0].players[0]).toEqual({
+            name: "Blue One",
+            stats: {goals: 2},
+        });
+        expect(result.games[0].teams[1].score).toBe(1);
+        expect(result.games[0].teams[1].players[0]).toEqual({
+            name: "Orange One",
+            stats: {goals: 1},
+        });
+    });
+});


### PR DESCRIPTION
## Summary
  - switch replay parsing to the new summary-only `sprocket-rl-parser` path by default
  - keep full analysis as an explicit helper only, with clearer missing-`network_frames` guidance
  - make the shared carball-to-ballchasing adapter tolerate header/summary-only payloads
  - allow validation and finalization flows to operate in degraded mode when frame-derived stats are unavailable
  - add coverage for summary-only submission stats conversion and degraded finalization behavior

## Details
  - `microservices/replay-parse-service` now calls `carball.summarize_replay_file(...)` instead of the old full decompile/analyze path during normal parsing
  - parse results now carry `analysisMode: "summary-only"` and use a new parsed cache version
  - the carball schema and converter now accept summary/header metadata like:
    - `game_metadata.score`
    - `game_metadata.goals`
    - `match_guid`
    - timestamp values without requiring frame-derived stats
  - converter fallback behavior now derives:
    - team membership from `is_orange` or `team.player_ids`
    - team/player goals from metadata goals when per-player stats are absent
    - safe zero/default values for advanced stat buckets that are unavailable in summary mode
  - the old full-analysis helper remains available as an explicit escape hatch, but its error message now directs callers toward the summary path when `network_frames` are missing

## Tests
  - added a submission-service spec proving summary-only carball payloads still produce submission stats
  - added core finalization coverage for degraded summary-only carball payloads
  - ran:
    - `npx jest --config jest.config.js src/replay-submission/stats-converter/stats-converter.service.spec.ts --runInBand`
    - `npm run build` in `common`
    - `npm run build` in `core`
    - `npm run build` in `microservices/submission-service`
    - `python3 -m py_compile microservices/replay-parse-service/src/parser.py microservices/replay-parse-service/src/main.py microservices/replay-parse-service/src/run_parse.py`

## Notes
  - the added core degraded-finalization spec could not be executed in the current local Jest environment because the package bootstrap fails before tests run
  - advanced replay stats will now be sparse/defaulted in summary-only mode rather than blocking finalization