### PR TITLE
[codex] re-enable network-frame replay parsing

### DIFF
--- a/microservices/replay-parse-service/src/main.py
+++ b/microservices/replay-parse-service/src/main.py
@@ -151,9 +151,9 @@ class ParseReplay(BaseTask):
 
         self.analytics.timer_split_parse()
 
+        parser_metadata = parser.get_result_metadata()
         result = {
-            "parser": 'carball',
-            "analysisMode": "summary-only",
+            **parser_metadata,
             "parserVersion": PARSER_VERSION,
             "outputPath": parsed_object_path,
             "data": parsed_data,

--- a/microservices/replay-parse-service/src/parser.py
+++ b/microservices/replay-parse-service/src/parser.py
@@ -35,12 +35,22 @@ if PARSER not in VALID_PARSERS:
     raise Exception(f"Unknown parser {PARSER}. Please specify one of: {', '.join(VALID_PARSERS)}")
 
 
-def parse(path: str, on_progress: Callable[[str], None] = None):
-    # Default to the metadata-only parser contract to avoid depending on network frames.
-    print("Parsing with carball summary-only parser.")
-    return _parse_carball_summary(path, on_progress)
+def get_result_metadata() -> dict:
     if PARSER == "carball":
-        return _parse_carball_summary(path, on_progress)
+        return {
+            "parser": "carball",
+            "analysisMode": "full-analysis",
+        }
+
+    return {
+        "parser": "ballchasing",
+        "analysisMode": "full-analysis",
+    }
+
+
+def parse(path: str, on_progress: Callable[[str], None] = None):
+    if PARSER == "carball":
+        return _parse_carball_full_analysis(path, on_progress)
     if PARSER == "ballchasing":
         return _parse_ballchasing(path, on_progress)
     if PARSER == "ballchasing-with-carball-shadow":

--- a/microservices/replay-parse-service/tests/test_parser_id_normalization.py
+++ b/microservices/replay-parse-service/tests/test_parser_id_normalization.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import unittest
+from types import ModuleType
 from pathlib import Path
+from unittest.mock import patch
 
 
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
@@ -11,6 +13,28 @@ os.environ.setdefault("CONFIG_DIR", str(SERVICE_ROOT / "config"))
 os.environ.setdefault("ENV", "default")
 os.chdir(SRC_ROOT)
 sys.path.insert(0, str(SRC_ROOT))
+
+if "carball" not in sys.modules:
+    sys.modules["carball"] = ModuleType("carball")
+
+if "ballchasing" not in sys.modules:
+    ballchasing = ModuleType("ballchasing")
+
+    class _Api:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    ballchasing.Api = _Api
+    sys.modules["ballchasing"] = ballchasing
+
+if "requests" not in sys.modules:
+    requests = ModuleType("requests")
+
+    class _Response:
+        pass
+
+    requests.Response = _Response
+    sys.modules["requests"] = requests
 
 import parser as replay_parser  # noqa: E402
 
@@ -75,6 +99,50 @@ class ParserIdNormalizationTests(unittest.TestCase):
         )
 
         self.assertEqual(result, "PlayerHandle")
+
+    def test_parse_uses_carball_full_analysis_when_configured(self):
+        with patch.object(replay_parser, "PARSER", "carball"), \
+                patch.object(replay_parser, "_parse_carball_full_analysis", return_value={"mode": "full"}) as parse_full, \
+                patch.object(replay_parser, "_parse_ballchasing") as parse_ballchasing, \
+                patch.object(replay_parser, "_parse_dual_with_shadow") as parse_shadow:
+            result = replay_parser.parse("/tmp/example.replay")
+
+        self.assertEqual(result, {"mode": "full"})
+        parse_full.assert_called_once_with("/tmp/example.replay", None)
+        parse_ballchasing.assert_not_called()
+        parse_shadow.assert_not_called()
+
+    def test_parse_uses_ballchasing_shadow_primary_when_configured(self):
+        with patch.object(replay_parser, "PARSER", "ballchasing-with-carball-shadow"), \
+                patch.object(replay_parser, "_parse_dual_with_shadow", return_value={"mode": "shadow"}) as parse_shadow, \
+                patch.object(replay_parser, "_parse_carball_full_analysis") as parse_full, \
+                patch.object(replay_parser, "_parse_ballchasing") as parse_ballchasing:
+            result = replay_parser.parse("/tmp/example.replay")
+
+        self.assertEqual(result, {"mode": "shadow"})
+        parse_shadow.assert_called_once_with("/tmp/example.replay", None)
+        parse_full.assert_not_called()
+        parse_ballchasing.assert_not_called()
+
+    def test_result_metadata_matches_carball_full_analysis_mode(self):
+        with patch.object(replay_parser, "PARSER", "carball"):
+            self.assertEqual(
+                replay_parser.get_result_metadata(),
+                {
+                    "parser": "carball",
+                    "analysisMode": "full-analysis",
+                },
+            )
+
+    def test_result_metadata_maps_shadow_mode_to_ballchasing(self):
+        with patch.object(replay_parser, "PARSER", "ballchasing-with-carball-shadow"):
+            self.assertEqual(
+                replay_parser.get_result_metadata(),
+                {
+                    "parser": "ballchasing",
+                    "analysisMode": "full-analysis",
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change restores replay parse service behavior at the RPS layer now that the underlying libraries can parse network frames again.

The regression was that the parse entrypoint in the replay parse service had been hardwired to the temporary carball header-only path. Even when the service config said to use `carball` or `ballchasing-with-carball-shadow`, the task always returned a summary-only carball payload and labeled it as such. In practice that meant the service no longer performed full replay analysis through the configured parser path, so downstream consumers were getting degraded data even though the parser libraries had recovered.

The fix removes that unconditional summary-only short-circuit and restores normal parser dispatch based on the configured parser mode. When the parser is configured as `carball`, the replay parse service now uses the full analysis path again, which relies on network-frame parsing as before. I also added a small metadata helper so the Celery task result reports the actual primary parser and `full-analysis` mode instead of always claiming `carball` and `summary-only` regardless of what ran.

To reduce the risk of this regressing again, the replay parse service tests now cover both parser selection and result metadata. The test harness also stubs optional parser dependencies when they are not installed locally, so these unit tests still validate dispatch behavior in a lean environment.

Validation for this change was done with:

- `microservices/replay-parse-service/.venv/bin/python -m unittest microservices/replay-parse-service/tests/test_parser_id_normalization.py`
