### PR TITLE
[codex] fix ghcr service rebuilds

### DIFF
--- a/.github/reusable_workflows/build_container/action.yaml
+++ b/.github/reusable_workflows/build_container/action.yaml
@@ -35,12 +35,12 @@ runs:
       uses: docker/build-push-action@v2
       with:
         build-args: |
-          BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/monorepo-core:${{ inputs.docker_tag }}
+          BASE_IMAGE=ghcr.io/sprocketbot/monorepo-core:${{ inputs.docker_tag }}
         context: ${{ inputs.build_directory }}
         file: ${{ inputs.build_directory }}/Dockerfile
         target: app_image
         push: true
-        tags: ghcr.io/${{ github.repository_owner }}/${{ inputs.docker_image }}:${{ inputs.docker_tag }}
+        tags: ghcr.io/sprocketbot/${{ inputs.docker_image }}:${{ inputs.docker_tag }}
         platforms: linux/amd64
 
     - uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/on-changes.yml
+++ b/.github/workflows/on-changes.yml
@@ -78,11 +78,15 @@ jobs:
           list-files: json
           filters: |
             baseDockerfileHasChanges: ./dockerfiles/node.Dockerfile
+            buildConfigHasChanges:
+              - ./.github/workflows/on-changes.yml
+              - ./.github/reusable_workflows/build_container/**
+              - ./infra/platform/**
             projectHasChanges: ${{ matrix.directory[1] }}/**
             sprocketCommonHasChanges: ./common/**
 
       - name: Build project
-        if: steps.changes.outputs.baseDockerfileHasChanges == 'true' || steps.changes.outputs.projectHasChanges == 'true' || steps.changes.outputs.sprocketCommonHasChanges == 'true'
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.baseDockerfileHasChanges == 'true' || steps.changes.outputs.buildConfigHasChanges == 'true' || steps.changes.outputs.projectHasChanges == 'true' || steps.changes.outputs.sprocketCommonHasChanges == 'true'
         uses: ./.github/reusable_workflows/build_container
         with:
           build_directory: ${{ matrix.directory[1] }}

--- a/infra/platform/Pulumi.prod.yaml
+++ b/infra/platform/Pulumi.prod.yaml
@@ -2,7 +2,7 @@ config:
   platform:docker-username: asaxplayinghorse
   platform:docker-access-token:
     secure: AAABAMOdsN2rA9tzU+BrK4iGPbzcO+kHZQ/7B7WkD7K4Eb+YoCtUiFomsfyvs1nT5cDwXHUPaGyaC0PkSh13MftRN2Y=
-  platform:image-namespace: asaxplayinghorse
+  platform:image-namespace: sprocketbot
   platform:postgres-username: doadmin
   platform:postgres-port: "25060"
   platform:postgres-host: sprocketbot-postgres-d5033d2-do-user-24528890-0.j.db.ondigitalocean.com

--- a/infra/platform/Pulumi.v15-beta.template.yaml
+++ b/infra/platform/Pulumi.v15-beta.template.yaml
@@ -3,7 +3,7 @@ config:
   # This template only pins the v1.5-specific knobs and the non-secret environment identity.
 
   platform:image-tag: personal-gankoji-unbork-cloud-spend
-  platform:image-namespace: asaxplayinghorse
+  platform:image-namespace: sprocketbot
   platform:hostname: sprocket.mlesports.gg
   platform:subdomain: v15
   platform:monolith-mode: "true"

--- a/infra/platform/old_pulumi/Pulumi.dev.yaml
+++ b/infra/platform/old_pulumi/Pulumi.dev.yaml
@@ -6,7 +6,7 @@ config:
   platform:docker-access-token:
     secure: v1:tmRmBUB/1RNiyLVR:vTexaAV98OKtJ9ZHqz4c10oefKO2BjN0Z/1pg0Jc+Qzbju6RBsVlIZaWQCdsfmU/4zdK4w==
   platform:docker-username: actualsovietshark
-  platform:image-namespace: asaxplayinghorse
+  platform:image-namespace: sprocketbot
   platform:image-tag: dev
   platform:legacy-bot-token:
     secure: v1:50PybyrQe0tmzGt1:Hmyo9lZPZWQAKTTYTp+64CefaLxeH3OHTmVscFzJpMNts5WDSyYnGxpDooThk4ORaAjL9ts7sxOCUfkLdSzlJM3CML/gje8L36VhfmzPDVGjse2ygkg=

--- a/infra/platform/old_pulumi/Pulumi.main.yaml
+++ b/infra/platform/old_pulumi/Pulumi.main.yaml
@@ -6,7 +6,7 @@ config:
     secure: v1:vgs40pq1JtHQ2rU2:8ql1WVQw5+QUYOeOwPsOL+Lt13ab2oFJ4uL5QSoFQVHoawIhsqhdz/GWunTO83eEsAEMWg==
   platform:docker-username: actualsovietshark
   platform:hostname: app.sprocket.gg
-  platform:image-namespace: asaxplayinghorse
+  platform:image-namespace: sprocketbot
   platform:image-tag: main
   platform:legacy-bot-token-emilia:
     secure: v1:ckC2DtkQWnGHZxtz:8FEmjOaUBHQC5z7qargKpojdvRtIDqXVRiqDKwA8HRg4k66KrvAZ2cuP1EH5M6UJuagWHCDyuQIMrKis57r0lLbGy+C+XxN3VRvr

--- a/infra/platform/old_pulumi/Pulumi.staging.yaml
+++ b/infra/platform/old_pulumi/Pulumi.staging.yaml
@@ -6,7 +6,7 @@ config:
     secure: v1:R74j5D3k+CNL3yd/:+tq95quvfSU4hCCuJQwgy2ysZqevGqFSfvb08fvBBEY1fmfuio1QJ6vlvt69ceCifgSdcg==
   platform:docker-username: actualsovietshark
   platform:hostname: app.sprocket.gg
-  platform:image-namespace: asaxplayinghorse
+  platform:image-namespace: sprocketbot
   platform:image-tag: staging
   platform:legacy-bot-token:
     secure: v1:xQ9UzYFSV68ZwTZZ:iOXk3G0S8yYcdIp26rlWYCfcGgZSGA5Ffs29rqTXDiQv88LPCzs+GwhpSnkR0cm6vnCtttFBEMhUSNFt3hVTRvPwOiIt+ORBOKlJUorWCji0ZNeBB9E=


### PR DESCRIPTION
This fixes the GHCR migration fallout where the `on-changes` workflow could complete successfully while only publishing `monorepo-core` and none of the service images. In practice, that left the registry partially migrated: the base image was present in GHCR, but unchanged services were never republished there, so the platform still lacked the expected per-service images.

The root cause was twofold. First, the service matrix in the workflow only rebuilt when a given service directory, `common/**`, or the base Dockerfile changed. The GHCR migration and Pulumi refactor touched CI and infrastructure config, not every service directory, so a merge to `main` could skip all service builds. Second, the runtime and build config were not fully aligned on the target GHCR namespace. The base image and deployments were moving toward `sprocketbot`, but the reusable service build action and stack config still contained stale namespace assumptions.

This change makes the registry migration behavior explicit and safe. Manual dispatches now force the full service matrix to rebuild, and CI also treats changes under the workflow, reusable build action, and `infra/platform/**` as image-build-affecting so service images get republished when deployment image configuration changes. The reusable build action now pushes service images to `ghcr.io/sprocketbot/...` and uses the same namespace for the `monorepo-core` base image. The Pulumi stack config files that set `platform:image-namespace` are updated to `sprocketbot` so runtime image resolution matches what CI publishes.

Validation for this change was limited to local git-level checks because GitHub Actions cannot be executed from this environment. I verified the resulting diff directly and ran `git diff --check` to confirm the patch is syntactically clean. The remaining `elo-service` image gap is intentionally not addressed here and will be handled separately.
