### PR TITLE
[codex] improve carball parser parity

### DIFF
--- a/common/src/converters/carball-converter.service.ts
+++ b/common/src/converters/carball-converter.service.ts
@@ -9,52 +9,43 @@ import type {
     CarballTeam,
 } from "../celery/types/schemas/stats";
 
+type TeamTotals = {goals: number; shots: number;};
+
 export class CarballConverterService {
 
-    /**
-   * Converts CarballResponse to BallchasingResponse format
-   * This allows the rest of the codebase to work with a consistent format
-   */
     convertToBallchasingFormat(
         carball: CarballResponse,
         outputPath: string,
     ): BallchasingResponse {
-        const metadata = carball.gameMetadata ?? carball.game_metadata ?? {};
+        const metadata = this.asRecord(carball.gameMetadata ?? carball.game_metadata);
         const teams = carball.teams ?? [];
         const players = carball.players ?? [];
         const goalCounts = this.buildGoalCountLookup(metadata);
         const {blue: bluePlayers, orange: orangePlayers} = this.groupPlayersByTeam(players, teams);
         const blueTeam = this.findTeamByColor(teams, "blue") ?? {players: bluePlayers};
         const orangeTeam = this.findTeamByColor(teams, "orange") ?? {players: orangePlayers};
-        const metadataScore = (metadata as any).score ?? {};
+        const metadataScore = this.asRecord(this.getField(metadata, "score"));
         const blueGoals = this.getTeamGoals(bluePlayers, blueTeam, goalCounts, metadataScore, "blue");
         const orangeGoals = this.getTeamGoals(orangePlayers, orangeTeam, goalCounts, metadataScore, "orange");
         const blueTotals = this.getTeamTotals(bluePlayers, blueGoals);
         const orangeTotals = this.getTeamTotals(orangePlayers, orangeGoals);
-
-        // Use the full output path so fallback identifiers stay deterministic and low-collision.
         const replayId = this.buildReplayId(outputPath);
+        const playlist = this.getField(metadata, "playlist");
+        const matchType = this.getField(metadata, "match_type", "matchType");
+        const overtimeSeconds = this.toNumber(this.getField(metadata, "overtime_seconds", "overtimeSeconds"));
 
-        // Convert to ballchasing format
-        const ballchasingResponse: BallchasingResponse = {
-            // Required fields - use stubs for ballchasing-specific fields
+        return {
             id: replayId,
             link: `file://${outputPath}`,
             status: "ok" as const,
-            title: metadata.name ?? metadata.id ?? "Carball Parsed Replay",
-            date: this.getValidDate(metadata.time),
+            title: this.getOptionalString(this.getField(metadata, "name", "id")) ?? "Carball Parsed Replay",
+            date: this.getValidDate(this.getField(metadata, "time")),
             date_has_timezone: false,
             created: new Date().toISOString(),
             visibility: "private",
-
-            // Rocket League metadata
-            rocket_league_id: this.getOptionalString(metadata.id) ?? replayId,
-            season: 0, // Unknown from carball
-            match_guid: this.getOptionalString((metadata as any).match_guid)
-                ?? this.getOptionalString(metadata.id)
-                ?? replayId,
-
-            // Uploader - stub data
+            rocket_league_id: this.getOptionalString(this.getField(metadata, "id")) ?? replayId,
+            season: 0,
+            match_guid: this.getOptionalString(this.getField(metadata, "match_guid", "matchGuid", "id")) ?? replayId,
             recorder: undefined,
             uploader: {
                 name: "Carball Parser",
@@ -62,33 +53,49 @@ export class CarballConverterService {
                 steam_id: "0",
                 profile_url: "",
             },
-
-            // Match info
-            match_type: this.getMatchType(metadata.playlist, metadata.match_type),
-            playlist_id: this.getPlaylistId(metadata.playlist),
-            playlist_name: this.getPlaylistName(metadata.playlist),
-
-            // Map info
-            map_code: metadata.map ?? "unknown",
-            map_name: metadata.map ?? "UNKNOWN",
-
-            // Duration (rounded to integer for database compatibility)
-            duration: Math.round(metadata.length ?? 0),
-            overtime: false, // TODO: Detect from carball data
-            overtime_seconds: undefined,
-
-            // Teams
-            team_size: metadata.team_size ?? Math.max(bluePlayers.length, orangePlayers.length),
+            match_type: this.getMatchType(playlist, matchType),
+            playlist_id: this.getPlaylistId(playlist),
+            playlist_name: this.getPlaylistName(playlist),
+            map_code: this.getOptionalString(this.getField(metadata, "map")) ?? "unknown",
+            map_name: this.getOptionalString(this.getField(metadata, "map")) ?? "UNKNOWN",
+            duration: Math.round(this.toNumber(this.getField(metadata, "length")) ?? 0),
+            overtime: Boolean(overtimeSeconds && overtimeSeconds > 0),
+            overtime_seconds: overtimeSeconds,
+            team_size: this.toNumber(this.getField(metadata, "team_size", "teamSize"))
+                ?? Math.max(bluePlayers.length, orangePlayers.length),
             blue: this.convertTeam(blueTeam, bluePlayers, "blue", orangeTotals, goalCounts),
             orange: this.convertTeam(orangeTeam, orangePlayers, "orange", blueTotals, goalCounts),
         };
-
-        return ballchasingResponse;
     }
 
     private buildReplayId(outputPath: string): string {
         if (!outputPath) return createHash("sha256").update("missing-output-path").digest("hex");
         return createHash("sha256").update(outputPath).digest("hex");
+    }
+
+    private asRecord(value: unknown): Record<string, unknown> {
+        return value && typeof value === "object" ? value as Record<string, unknown> : {};
+    }
+
+    private getField(source: unknown, ...candidates: Array<string | string[]>): unknown {
+        const root = this.asRecord(source);
+
+        for (const candidate of candidates) {
+            const path = Array.isArray(candidate) ? candidate : [candidate];
+            let current: unknown = root;
+
+            for (const segment of path) {
+                if (!current || typeof current !== "object" || !(segment in (current as Record<string, unknown>))) {
+                    current = undefined;
+                    break;
+                }
+                current = (current as Record<string, unknown>)[segment];
+            }
+
+            if (current !== undefined) return current;
+        }
+
+        return undefined;
     }
 
     private getOptionalString(value: unknown): string | undefined {
@@ -101,40 +108,42 @@ export class CarballConverterService {
         team: CarballTeam | {players: CarballPlayer[];},
         players: CarballPlayer[],
         color: "blue" | "orange",
-        opposingTeamTotals: {goals: number; shots: number;},
+        opposingTeamTotals: TeamTotals,
         goalCounts: Map<string, number>,
     ): BallchasingTeam {
-        const teamStats = this.aggregateTeamStats(players, opposingTeamTotals, goalCounts);
+        const convertedPlayers = players.map(player => this.convertPlayer(
+            player,
+            opposingTeamTotals,
+            goalCounts.get(this.getPlayerLookupKey(player.id)) ?? 0,
+        ));
 
         return {
-            name: (team as any).name,
+            name: this.getOptionalString((team as any).name),
             color,
-            stats: teamStats,
-            players: players.map(p => this.convertPlayer(
-                p,
-                opposingTeamTotals,
-                goalCounts.get(this.getPlayerLookupKey(p.id)) ?? 0,
-            )),
+            stats: this.aggregateTeamStats(team, players, convertedPlayers, opposingTeamTotals, goalCounts),
+            players: convertedPlayers,
         };
     }
 
     private convertPlayer(
         player: CarballPlayer,
-        opposingTeamTotals: {goals: number; shots: number;},
+        opposingTeamTotals: TeamTotals,
         derivedGoals: number,
     ): BallchasingPlayer {
-        const playerId = player.id ?? {id: "0", platform: undefined};
-        const platform = (playerId as any).platform ?? (player as any).platform ?? "steam";
-        const startTime = player.first_frame_in_game ?? player.firstFrameInGame ?? 0;
-        const timeInGame = player.time_in_game ?? player.timeInGame ?? 0;
+        const playerId = this.asRecord(player.id);
+        const platform = this.getOptionalString(this.getField(playerId, "platform"))
+            ?? this.getOptionalString(this.getField(player, "platform"))
+            ?? "steam";
+        const startTime = this.toNumber(this.getField(player, "first_frame_in_game", "firstFrameInGame")) ?? 0;
+        const timeInGame = this.toNumber(this.getField(player, "time_in_game", "timeInGame")) ?? 0;
 
         return {
             id: {
-                id: (playerId as any).id ?? "0",
+                id: this.getOptionalString(this.getField(playerId, "id")) ?? "0",
                 platform: this.mapPlatform(platform),
             },
-            name: player.name ?? "Unknown",
-            camera: this.extractCameraSettings(player.camera_settings ?? player.cameraSettings),
+            name: this.getOptionalString(this.getField(player, "name")) ?? "Unknown",
+            camera: this.extractCameraSettings(this.getField(player, "camera_settings", "cameraSettings")),
             car_id: -1,
             car_name: "UNKNOWN",
             start_time: startTime,
@@ -146,53 +155,74 @@ export class CarballConverterService {
 
     private convertPlayerStats(
         player: CarballPlayer,
-        opposingTeamTotals: {goals: number; shots: number;},
+        opposingTeamTotals: TeamTotals,
         derivedGoals: number,
-    ): any {
-        const stats = player.stats as any ?? {};
-        const goals = player.goals ?? derivedGoals;
-        const shots = player.shots ?? 0;
+    ): BallchasingPlayer["stats"] {
+        const stats = this.asRecord(player.stats);
+        const hitCounts = this.asRecord(this.getField(stats, "hit_counts", "hitCounts"));
+        const goals = this.toNumber(this.getField(player, "goals")) ?? derivedGoals;
+        const shots = this.toNumber(this.getField(player, "shots"))
+            ?? this.toNumber(this.getField(hitCounts, "total_shots", "totalShots"))
+            ?? 0;
+        const assists = this.toNumber(this.getField(player, "assists")) ?? 0;
+        const saves = this.toNumber(this.getField(player, "saves"))
+            ?? this.toNumber(this.getField(hitCounts, "total_saves", "totalSaves"))
+            ?? 0;
+        const score = this.toNumber(this.getField(player, "score")) ?? 0;
+        const timeInGame = this.toNumber(this.getField(player, "time_in_game", "timeInGame")) ?? 0;
 
         return {
             core: {
                 mvp: false,
-                // Round all core stats to integers for database compatibility
                 goals: Math.round(goals),
-                saves: Math.round(player.saves ?? 0),
-                score: Math.round(player.score ?? 0),
+                saves: Math.round(saves),
+                score: Math.round(score),
                 shots: Math.round(shots),
-                assists: Math.round(player.assists ?? 0),
+                assists: Math.round(assists),
                 goals_against: Math.round(opposingTeamTotals.goals),
                 shots_against: Math.round(opposingTeamTotals.shots),
-                shooting_percentage: shots > 0 ? goals / shots * 100 : 0,
+                shooting_percentage: this.calculatePercentage(goals, shots),
             },
             demo: {
-                taken: stats.demo_stats?.taken ?? 0,
-                inflicted: stats.demo_stats?.inflicted ?? 0,
+                taken: this.toNumber(this.getField(stats, ["demo_stats", "taken"], ["demoStats", "taken"])) ?? 0,
+                inflicted: this.toNumber(this.getField(stats, ["demo_stats", "inflicted"], ["demoStats", "inflicted"])) ?? 0,
             },
-            boost: this.extractBoostStats(stats.boost),
-            movement: this.extractMovementStats(stats.distance, stats.speed),
-            positioning: this.extractPositioningStats(stats.positional_tendencies, stats.relative_positioning),
+            boost: this.extractBoostStats(this.getField(stats, "boost"), timeInGame),
+            movement: this.extractMovementStats(
+                this.getField(stats, "distance"),
+                this.getField(stats, "speed"),
+                this.getField(stats, "positional_tendencies", "positionalTendencies"),
+                this.getField(stats, "averages"),
+            ),
+            positioning: this.extractPositioningStats(
+                this.getField(stats, "positional_tendencies", "positionalTendencies"),
+                this.getField(stats, "relative_positioning", "relativePositioning"),
+            ),
         };
     }
 
     private aggregateTeamStats(
-        players: CarballPlayer[],
-        opposingTeamTotals: {goals: number; shots: number;},
+        team: CarballTeam | {players: CarballPlayer[];},
+        rawPlayers: CarballPlayer[],
+        players: BallchasingPlayer[],
+        opposingTeamTotals: TeamTotals,
         goalCounts: Map<string, number>,
-    ): any {
-        const totalGoals = players.reduce((sum, p) => (
-            sum + (p.goals ?? goalCounts.get(this.getPlayerLookupKey(p.id)) ?? 0)
+    ): BallchasingTeam["stats"] {
+        const teamStats = this.asRecord((team as any).stats);
+        const teamPossession = this.toNumber(this.getField(teamStats, ["possession", "possession_time"], ["possession", "possessionTime"]));
+        const playerStats = players.map(player => player.stats);
+        const totalGoals = rawPlayers.reduce((sum, player) => (
+            sum + (this.toNumber(this.getField(player, "goals")) ?? goalCounts.get(this.getPlayerLookupKey(player.id)) ?? 0)
         ), 0);
-        const totalSaves = players.reduce((sum, p) => sum + (p.saves ?? 0), 0);
-        const totalScore = players.reduce((sum, p) => sum + (p.score ?? 0), 0);
-        const totalShots = players.reduce((sum, p) => sum + (p.shots ?? 0), 0);
-        const totalAssists = players.reduce((sum, p) => sum + (p.assists ?? 0), 0);
+        const totalSaves = playerStats.reduce((sum, stats) => sum + stats.core.saves, 0);
+        const totalScore = playerStats.reduce((sum, stats) => sum + stats.core.score, 0);
+        const totalShots = playerStats.reduce((sum, stats) => sum + stats.core.shots, 0);
+        const totalAssists = playerStats.reduce((sum, stats) => sum + stats.core.assists, 0);
 
         return {
             ball: {
                 time_in_side: 0,
-                possession_time: 0,
+                possession_time: teamPossession ?? 0,
             },
             core: {
                 goals: totalGoals,
@@ -202,11 +232,52 @@ export class CarballConverterService {
                 assists: totalAssists,
                 goals_against: opposingTeamTotals.goals,
                 shots_against: opposingTeamTotals.shots,
-                shooting_percentage: totalShots > 0 ? totalGoals / totalShots * 100 : 0,
+                shooting_percentage: this.calculatePercentage(totalGoals, totalShots),
             },
-            boost: this.getDefaultBoostStats(),
-            movement: this.getDefaultMovementStats(),
-            positioning: this.getDefaultPositioningStats(),
+            boost: {
+                bpm: this.sumNumbers(playerStats.map(stats => stats.boost.bpm)),
+                bcpm: this.sumNumbers(playerStats.map(stats => stats.boost.bcpm)),
+                avg_amount: this.averageNumbers(playerStats.map(stats => stats.boost.avg_amount)),
+                amount_stolen: this.sumNumbers(playerStats.map(stats => stats.boost.amount_stolen)),
+                amount_overfill: this.sumNumbers(playerStats.map(stats => stats.boost.amount_overfill)),
+                time_boost_0_25: this.sumNumbers(playerStats.map(stats => stats.boost.time_boost_0_25)),
+                time_full_boost: this.sumNumbers(playerStats.map(stats => stats.boost.time_full_boost)),
+                time_zero_boost: this.sumNumbers(playerStats.map(stats => stats.boost.time_zero_boost)),
+                amount_collected: this.sumNumbers(playerStats.map(stats => stats.boost.amount_collected)),
+                count_stolen_big: this.sumNumbers(playerStats.map(stats => stats.boost.count_stolen_big)),
+                time_boost_25_50: this.sumNumbers(playerStats.map(stats => stats.boost.time_boost_25_50)),
+                time_boost_50_75: this.sumNumbers(playerStats.map(stats => stats.boost.time_boost_50_75)),
+                amount_stolen_big: this.sumNumbers(playerStats.map(stats => stats.boost.amount_stolen_big)),
+                time_boost_75_100: this.sumNumbers(playerStats.map(stats => stats.boost.time_boost_75_100)),
+                count_stolen_small: this.sumNumbers(playerStats.map(stats => stats.boost.count_stolen_small)),
+                amount_stolen_small: this.sumNumbers(playerStats.map(stats => stats.boost.amount_stolen_small)),
+                count_collected_big: this.sumNumbers(playerStats.map(stats => stats.boost.count_collected_big)),
+                amount_collected_big: this.sumNumbers(playerStats.map(stats => stats.boost.amount_collected_big)),
+                count_collected_small: this.sumNumbers(playerStats.map(stats => stats.boost.count_collected_small)),
+                amount_collected_small: this.sumNumbers(playerStats.map(stats => stats.boost.amount_collected_small)),
+                amount_overfill_stolen: this.sumNumbers(playerStats.map(stats => stats.boost.amount_overfill_stolen)),
+                amount_used_while_supersonic: this.sumNumbers(playerStats.map(stats => stats.boost.amount_used_while_supersonic)),
+            },
+            movement: {
+                time_ground: this.sumNumbers(playerStats.map(stats => stats.movement.time_ground)),
+                time_low_air: this.sumNumbers(playerStats.map(stats => stats.movement.time_low_air)),
+                time_high_air: this.sumNumbers(playerStats.map(stats => stats.movement.time_high_air)),
+                total_distance: this.sumNumbers(playerStats.map(stats => stats.movement.total_distance)),
+                time_powerslide: this.sumNumbers(playerStats.map(stats => stats.movement.time_powerslide)),
+                time_slow_speed: this.sumNumbers(playerStats.map(stats => stats.movement.time_slow_speed)),
+                count_powerslide: this.sumNumbers(playerStats.map(stats => stats.movement.count_powerslide)),
+                time_boost_speed: this.sumNumbers(playerStats.map(stats => stats.movement.time_boost_speed)),
+                time_supersonic_speed: this.sumNumbers(playerStats.map(stats => stats.movement.time_supersonic_speed)),
+            },
+            positioning: {
+                time_behind_ball: this.sumNumbers(playerStats.map(stats => stats.positioning.time_behind_ball)),
+                time_infront_ball: this.sumNumbers(playerStats.map(stats => stats.positioning.time_infront_ball)),
+                time_neutral_third: this.sumNumbers(playerStats.map(stats => stats.positioning.time_neutral_third)),
+                time_defensive_half: this.sumNumbers(playerStats.map(stats => stats.positioning.time_defensive_half)),
+                time_offensive_half: this.sumNumbers(playerStats.map(stats => stats.positioning.time_offensive_half)),
+                time_defensive_third: this.sumNumbers(playerStats.map(stats => stats.positioning.time_defensive_third)),
+                time_offensive_third: this.sumNumbers(playerStats.map(stats => stats.positioning.time_offensive_third)),
+            },
         };
     }
 
@@ -228,10 +299,10 @@ export class CarballConverterService {
 
     private buildGoalCountLookup(metadata: Record<string, unknown>): Map<string, number> {
         const goalCounts = new Map<string, number>();
-        const goals = ((metadata as any).goals ?? []) as Array<Record<string, unknown>>;
+        const goals = (this.getField(metadata, "goals") as Array<Record<string, unknown>> | undefined) ?? [];
 
         for (const goal of goals) {
-            const playerId = (goal.player_id ?? goal.playerId) as Record<string, unknown> | undefined;
+            const playerId = (this.getField(goal, "player_id", "playerId") as Record<string, unknown> | undefined);
             const key = this.getPlayerLookupKey(playerId);
             if (!key) continue;
             goalCounts.set(key, (goalCounts.get(key) ?? 0) + 1);
@@ -251,7 +322,7 @@ export class CarballConverterService {
         };
 
         for (const player of players) {
-            const isOrange = this.toBooleanish((player as any).isOrange ?? player.is_orange);
+            const isOrange = this.toBooleanish(this.getField(player, "isOrange", "is_orange"));
             if (isOrange === true) grouped.orange.push(player);
             else if (isOrange === false) grouped.blue.push(player);
         }
@@ -261,7 +332,7 @@ export class CarballConverterService {
             if (!color) continue;
 
             const target = color === "orange" ? grouped.orange : grouped.blue;
-            const playerIds = (((team as any).player_ids ?? (team as any).playerIds) ?? []) as Array<Record<string, unknown>>;
+            const playerIds = (this.getField(team, "player_ids", "playerIds") as Array<Record<string, unknown>> | undefined) ?? [];
             for (const playerId of playerIds) {
                 const key = this.getPlayerLookupKey(playerId);
                 if (!key) continue;
@@ -296,42 +367,48 @@ export class CarballConverterService {
         metadataScore: Record<string, unknown>,
         color: "blue" | "orange",
     ): number {
-        const scoreField = color === "blue" ? "team_0_score" : "team_1_score";
         const metadataScoreValue = this.toNumber(
-            (metadataScore as any)[scoreField]
-            ?? (metadataScore as any)[scoreField.replace(/_/g, "")]
-            ?? (metadataScore as any)[color === "blue" ? "team0Score" : "team1Score"],
+            color === "blue"
+                ? this.getField(metadataScore, "team_0_score", "team0Score")
+                : this.getField(metadataScore, "team_1_score", "team1Score"),
         );
-        const teamScore = this.toNumber((team as any).score);
+        const teamScore = this.toNumber(this.getField(team, "score"));
 
         return teamScore
             ?? metadataScoreValue
             ?? players.reduce((sum, player) => (
-                sum + (player.goals ?? goalCounts.get(this.getPlayerLookupKey(player.id)) ?? 0)
+                sum + (this.toNumber(this.getField(player, "goals")) ?? goalCounts.get(this.getPlayerLookupKey(player.id)) ?? 0)
             ), 0);
     }
 
     private getTeamTotals(
         players: CarballPlayer[],
         teamGoals: number,
-    ): {goals: number; shots: number;} {
+    ): TeamTotals {
         return {
             goals: teamGoals,
-            shots: players.reduce((sum, player) => sum + (player.shots ?? 0), 0),
+            shots: players.reduce((sum, player) => (
+                sum
+                + (this.toNumber(this.getField(player, "shots"))
+                ?? this.toNumber(this.getField(player.stats, ["hit_counts", "total_shots"], ["hitCounts", "totalShots"]))
+                ?? 0)
+            ), 0),
         };
     }
 
     private getPlayerLookupKey(playerId: unknown): string {
-        const id = (playerId as any)?.id;
-        return id ? String(id) : "";
+        const id = this.getOptionalString(this.getField(playerId, "id"));
+        if (!id) return "";
+        const platform = this.getOptionalString(this.getField(playerId, "platform"));
+        return platform ? `${platform}:${id}` : id;
     }
 
     private getTeamColor(team: CarballTeam): "blue" | "orange" | null {
-        const explicitColor = (team as any).color;
+        const explicitColor = this.getField(team, "color");
         if (explicitColor === 0 || explicitColor === "0" || explicitColor === "blue") return "blue";
         if (explicitColor === 1 || explicitColor === "1" || explicitColor === "orange") return "orange";
 
-        const isOrange = this.toBooleanish((team as any).is_orange ?? (team as any).isOrange);
+        const isOrange = this.toBooleanish(this.getField(team, "is_orange", "isOrange"));
         if (isOrange === true) return "orange";
         if (isOrange === false) return "blue";
 
@@ -351,180 +428,162 @@ export class CarballConverterService {
     }
 
     private toNumber(value: unknown): number | undefined {
-        if (value === null || value === undefined || value === "") return undefined;
+        if (value === null || value === undefined || value === "" || value === "NaN") return undefined;
         const parsed = Number(value);
         return Number.isFinite(parsed) ? parsed : undefined;
     }
 
-    private getPlaylistId(playlist: number | undefined): string {
-        if (playlist === 6) return "private";
-        return playlist?.toString() ?? "unknown";
+    private calculatePercentage(numerator: number, denominator: number): number {
+        return denominator > 0 ? numerator / denominator * 100 : 0;
     }
 
-    private getMatchType(playlist: number | undefined, matchType: string | undefined): string {
-        if (matchType) return matchType;
-        if (playlist === 6) return "Private";
+    private sumNumbers(values: number[]): number {
+        return values.reduce((sum, value) => sum + value, 0);
+    }
+
+    private averageNumbers(values: number[]): number {
+        if (values.length === 0) return 0;
+        return this.sumNumbers(values) / values.length;
+    }
+
+    private normalizePlaylist(playlist: unknown): string {
+        const numeric = this.toNumber(playlist);
+        if (numeric !== undefined) return String(numeric);
+        return String(playlist ?? "").trim().toUpperCase();
+    }
+
+    private getPlaylistId(playlist: unknown): string {
+        const normalized = this.normalizePlaylist(playlist);
+        if (normalized === "6" || normalized === "CUSTOM_LOBBY" || normalized === "PRIVATE") return "private";
+        return normalized || "unknown";
+    }
+
+    private getMatchType(playlist: unknown, matchType: unknown): string {
+        const explicitMatchType = this.getOptionalString(matchType);
+        if (explicitMatchType) return explicitMatchType;
+        if (this.getPlaylistId(playlist) === "private") return "Private";
         return "unknown";
     }
 
-    private extractCameraSettings(cameraSettings: unknown): any {
-        const settings = cameraSettings as any ?? {};
+    private extractCameraSettings(cameraSettings: unknown): BallchasingPlayer["camera"] {
         return {
-            fov: settings.fov ?? 110,
-            pitch: settings.pitch ?? -3,
-            height: settings.height ?? 100,
-            distance: settings.distance ?? 270,
-            stiffness: settings.stiffness ?? 0.5,
-            swivel_speed: settings.swivel_speed ?? 3,
-            transition_speed: settings.transition_speed ?? 1,
+            fov: this.toNumber(this.getField(cameraSettings, "fov", "fieldOfView")) ?? 110,
+            pitch: this.toNumber(this.getField(cameraSettings, "pitch")) ?? -3,
+            height: this.toNumber(this.getField(cameraSettings, "height")) ?? 100,
+            distance: this.toNumber(this.getField(cameraSettings, "distance")) ?? 270,
+            stiffness: this.toNumber(this.getField(cameraSettings, "stiffness")) ?? 0.5,
+            swivel_speed: this.toNumber(this.getField(cameraSettings, "swivel_speed", "swivelSpeed")) ?? 3,
+            transition_speed: this.toNumber(this.getField(cameraSettings, "transition_speed", "transitionSpeed")) ?? 1,
         };
     }
 
-    private extractBoostStats(boostData: unknown): any {
-        const boost = boostData as any ?? {};
+    private extractBoostStats(boostData: unknown, timeInGame: number): BallchasingPlayer["stats"]["boost"] {
+        const averageBoostLevel = this.toNumber(this.getField(boostData, "avg_amount", "averageBoostLevel")) ?? 0;
+        const amountCollected = this.toNumber(this.getField(boostData, "amount_collected", "amountCollected", "boostUsage")) ?? 0;
+        const perMinute = timeInGame > 0 ? amountCollected / timeInGame * 60 : 0;
+
         return {
-            bpm: boost.bpm ?? 0,
-            bcpm: boost.bcpm ?? 0,
-            avg_amount: boost.avg_amount ?? boost.boost_usage ?? 0,
-            amount_stolen: boost.amount_stolen ?? 0,
-            amount_overfill: boost.amount_overfill ?? 0,
-            time_boost_0_25: boost.time_boost_0_25 ?? 0,
-            time_full_boost: boost.time_full_boost ?? 0,
-            time_zero_boost: boost.time_zero_boost ?? 0,
-            amount_collected: boost.amount_collected ?? boost.wasted_collection ?? 0,
-            count_stolen_big: boost.count_stolen_big ?? 0,
-            time_boost_25_50: boost.time_boost_25_50 ?? 0,
-            time_boost_50_75: boost.time_boost_50_75 ?? 0,
-            amount_stolen_big: boost.amount_stolen_big ?? 0,
-            time_boost_75_100: boost.time_boost_75_100 ?? 0,
-            count_stolen_small: boost.count_stolen_small ?? 0,
+            bpm: this.toNumber(this.getField(boostData, "bpm")) ?? perMinute,
+            bcpm: this.toNumber(this.getField(boostData, "bcpm")) ?? perMinute,
+            avg_amount: averageBoostLevel,
+            amount_stolen: this.toNumber(this.getField(boostData, "amount_stolen", "amountStolen")) ?? 0,
+            amount_overfill: this.toNumber(this.getField(boostData, "amount_overfill", "amountOverfill", "wastedCollection")) ?? 0,
+            time_boost_0_25: this.toNumber(this.getField(boostData, "time_boost_0_25", "timeLowBoost")) ?? 0,
+            time_full_boost: this.toNumber(this.getField(boostData, "time_full_boost", "timeFullBoost")) ?? 0,
+            time_zero_boost: this.toNumber(this.getField(boostData, "time_zero_boost", "timeNoBoost")) ?? 0,
+            amount_collected: amountCollected,
+            count_stolen_big: this.toNumber(this.getField(boostData, "count_stolen_big", "numStolenBoosts")) ?? 0,
+            time_boost_25_50: this.toNumber(this.getField(boostData, "time_boost_25_50")) ?? 0,
+            time_boost_50_75: this.toNumber(this.getField(boostData, "time_boost_50_75")) ?? 0,
+            amount_stolen_big: this.toNumber(this.getField(boostData, "amount_stolen_big")) ?? 0,
+            time_boost_75_100: this.toNumber(this.getField(boostData, "time_boost_75_100")) ?? 0,
+            count_stolen_small: this.toNumber(this.getField(boostData, "count_stolen_small")) ?? 0,
             percent_boost_0_25: 0,
             percent_full_boost: 0,
             percent_zero_boost: 0,
-            amount_stolen_small: boost.amount_stolen_small ?? 0,
-            count_collected_big: boost.count_collected_big ?? 0,
+            amount_stolen_small: this.toNumber(this.getField(boostData, "amount_stolen_small")) ?? 0,
+            count_collected_big: this.toNumber(this.getField(boostData, "count_collected_big")) ?? 0,
             percent_boost_25_50: 0,
             percent_boost_50_75: 0,
-            amount_collected_big: boost.amount_collected_big ?? 0,
+            amount_collected_big: this.toNumber(this.getField(boostData, "amount_collected_big")) ?? 0,
             percent_boost_75_100: 0,
-            count_collected_small: boost.count_collected_small ?? 0,
-            amount_collected_small: boost.amount_collected_small ?? 0,
-            amount_overfill_stolen: boost.amount_overfill_stolen ?? 0,
-            amount_used_while_supersonic: boost.amount_used_while_supersonic ?? 0,
+            count_collected_small: this.toNumber(this.getField(boostData, "count_collected_small")) ?? 0,
+            amount_collected_small: this.toNumber(this.getField(boostData, "amount_collected_small")) ?? 0,
+            amount_overfill_stolen: this.toNumber(this.getField(boostData, "amount_overfill_stolen")) ?? 0,
+            amount_used_while_supersonic: this.toNumber(this.getField(boostData, "amount_used_while_supersonic", "wastedUsage")) ?? 0,
         };
     }
 
-    private extractMovementStats(distanceData: unknown, speedData: unknown): any {
-        const distance = distanceData as any ?? {};
-        const speed = speedData as any ?? {};
+    private extractMovementStats(
+        distanceData: unknown,
+        speedData: unknown,
+        positionalTendencies: unknown,
+        averagesData: unknown,
+    ): BallchasingPlayer["stats"]["movement"] {
+        const rawAvgSpeed = this.toNumber(this.getField(speedData, "avg_speed", "averageSpeed"))
+            ?? this.toNumber(this.getField(averagesData, "averageSpeed", "average_speed"))
+            ?? 0;
+        const avgSpeed = rawAvgSpeed > 3000 ? rawAvgSpeed / 10 : rawAvgSpeed;
+        const totalDistance = this.toNumber(this.getField(distanceData, "total_distance", "totalDistance"))
+            ?? (
+                (this.toNumber(this.getField(distanceData, "ball_hit_forward", "ballHitForward")) ?? 0)
+                + (this.toNumber(this.getField(distanceData, "ball_hit_backward", "ballHitBackward")) ?? 0)
+            );
 
         return {
-            avg_speed: speed.avg_speed ?? 0,
-            time_ground: distance.time_on_ground ?? 0,
-            time_low_air: distance.time_low_in_air ?? 0,
-            time_high_air: distance.time_high_in_air ?? 0,
+            avg_speed: avgSpeed,
+            time_ground: this.toNumber(this.getField(positionalTendencies, "time_on_ground", "timeOnGround")) ?? 0,
+            time_low_air: this.toNumber(this.getField(positionalTendencies, "time_low_in_air", "timeLowInAir")) ?? 0,
+            time_high_air: this.toNumber(this.getField(positionalTendencies, "time_high_in_air", "timeHighInAir")) ?? 0,
             percent_ground: 0,
-            total_distance: distance.ball_hit_forward ?? 0,
+            total_distance: totalDistance,
             percent_low_air: 0,
-            time_powerslide: distance.time_powerslide ?? 0,
-            time_slow_speed: speed.time_at_slow_speed ?? 0,
-            count_powerslide: distance.count_powerslide ?? 0,
+            time_powerslide: this.toNumber(this.getField(distanceData, "time_powerslide", "timePowerslide")) ?? 0,
+            time_slow_speed: this.toNumber(this.getField(speedData, "time_at_slow_speed", "timeAtSlowSpeed")) ?? 0,
+            count_powerslide: this.toNumber(this.getField(distanceData, "count_powerslide", "countPowerslide")) ?? 0,
             percent_high_air: 0,
-            time_boost_speed: speed.time_at_boost_speed ?? 0,
+            time_boost_speed: this.toNumber(this.getField(speedData, "time_at_boost_speed", "timeAtBoostSpeed")) ?? 0,
             percent_slow_speed: 0,
             percent_boost_speed: 0,
             avg_speed_percentage: 0,
-            time_supersonic_speed: speed.time_at_super_sonic ?? 0,
+            time_supersonic_speed: this.toNumber(this.getField(speedData, "time_at_super_sonic", "timeAtSuperSonic")) ?? 0,
             avg_powerslide_duration: 0,
             percent_supersonic_speed: 0,
         };
     }
 
-    private extractPositioningStats(positionalTendencies: unknown, relativePositioning: unknown): any {
-        const positioning = positionalTendencies as any ?? {};
-        const relative = relativePositioning as any ?? {};
-
+    private extractPositioningStats(
+        positionalTendencies: unknown,
+        relativePositioning: unknown,
+    ): BallchasingPlayer["stats"]["positioning"] {
         return {
-            time_most_back: positioning.time_most_back ?? 0,
-            time_behind_ball: positioning.time_behind_ball ?? 0,
+            time_most_back: this.toNumber(this.getField(relativePositioning, "time_behind_center_of_mass", "timeBehindCenterOfMass")) ?? 0,
+            time_behind_ball: this.toNumber(this.getField(positionalTendencies, "time_behind_ball", "timeBehindBall")) ?? 0,
             percent_most_back: 0,
-            time_infront_ball: positioning.time_infront_ball ?? 0,
-            time_most_forward: positioning.time_most_forward ?? 0,
-            time_neutral_third: positioning.time_neutral_third ?? 0,
+            time_infront_ball: this.toNumber(this.getField(positionalTendencies, "time_in_front_ball", "timeInFrontBall")) ?? 0,
+            time_most_forward: this.toNumber(this.getField(relativePositioning, "time_in_front_of_center_of_mass", "timeInFrontOfCenterOfMass")) ?? 0,
+            time_neutral_third: this.toNumber(this.getField(positionalTendencies, "time_neutral_third", "timeInNeutralThird")) ?? 0,
             percent_behind_ball: 0,
-            time_defensive_half: positioning.time_defensive_half ?? 0,
-            time_offensive_half: positioning.time_offensive_half ?? 0,
-            avg_distance_to_ball: relative.avg_distance_to_ball ?? 0,
+            time_defensive_half: this.toNumber(this.getField(positionalTendencies, "time_defensive_half", "timeInDefendingHalf")) ?? 0,
+            time_offensive_half: this.toNumber(this.getField(positionalTendencies, "time_offensive_half", "timeInAttackingHalf")) ?? 0,
+            avg_distance_to_ball: this.toNumber(this.getField(relativePositioning, "avg_distance_to_ball", "avgDistanceToBall")) ?? 0,
             percent_infront_ball: 0,
             percent_most_forward: 0,
-            time_closest_to_ball: positioning.time_closest_to_ball ?? 0,
-            time_defensive_third: positioning.time_defensive_third ?? 0,
-            time_offensive_third: positioning.time_offensive_third ?? 0,
-            avg_distance_to_mates: relative.avg_distance_to_mates ?? 0,
+            time_closest_to_ball: this.toNumber(this.getField(positionalTendencies, "time_closest_to_ball", "timeClosestToBall")) ?? 0,
+            time_defensive_third: this.toNumber(this.getField(positionalTendencies, "time_defensive_third", "timeInDefendingThird")) ?? 0,
+            time_offensive_third: this.toNumber(this.getField(positionalTendencies, "time_offensive_third", "timeInAttackingThird")) ?? 0,
+            avg_distance_to_mates: this.toNumber(this.getField(relativePositioning, "avg_distance_to_mates", "avgDistanceToMates")) ?? 0,
             percent_neutral_third: 0,
             percent_defensive_half: 0,
             percent_offensive_half: 0,
             percent_closest_to_ball: 0,
             percent_defensive_third: 0,
             percent_offensive_third: 0,
-            time_farthest_from_ball: positioning.time_farthest_from_ball ?? 0,
+            time_farthest_from_ball: this.toNumber(this.getField(positionalTendencies, "time_farthest_from_ball", "timeFurthestFromBall")) ?? 0,
             percent_farthest_from_ball: 0,
             avg_distance_to_ball_possession: 0,
             goals_against_while_last_defender: 0,
             avg_distance_to_ball_no_possession: 0,
-        };
-    }
-
-    private getDefaultBoostStats(): any {
-        return {
-            bpm: 0,
-            bcpm: 0,
-            avg_amount: 0,
-            amount_stolen: 0,
-            amount_overfill: 0,
-            time_boost_0_25: 0,
-            time_full_boost: 0,
-            time_zero_boost: 0,
-            amount_collected: 0,
-            count_stolen_big: 0,
-            time_boost_25_50: 0,
-            time_boost_50_75: 0,
-            amount_stolen_big: 0,
-            time_boost_75_100: 0,
-            count_stolen_small: 0,
-            amount_stolen_small: 0,
-            count_collected_big: 0,
-            amount_collected_big: 0,
-            count_collected_small: 0,
-            amount_collected_small: 0,
-            amount_overfill_stolen: 0,
-            amount_used_while_supersonic: 0,
-        };
-    }
-
-    private getDefaultMovementStats(): any {
-        return {
-            time_ground: 0,
-            time_low_air: 0,
-            time_high_air: 0,
-            total_distance: 0,
-            time_powerslide: 0,
-            time_slow_speed: 0,
-            count_powerslide: 0,
-            time_boost_speed: 0,
-            time_supersonic_speed: 0,
-        };
-    }
-
-    private getDefaultPositioningStats(): any {
-        return {
-            time_behind_ball: 0,
-            time_infront_ball: 0,
-            time_neutral_third: 0,
-            time_defensive_half: 0,
-            time_offensive_half: 0,
-            time_defensive_third: 0,
-            time_offensive_third: 0,
         };
     }
 
@@ -536,22 +595,31 @@ export class CarballConverterService {
         return "steam";
     }
 
-    private getPlaylistName(playlist: number | undefined): string {
-        const playlistMap: Record<number, string> = {
-            1: "Duel",
-            2: "Doubles",
-            3: "Standard",
-            4: "Chaos",
-            6: "Private",
-            10: "Ranked Duel",
-            11: "Ranked Doubles",
-            13: "Ranked Standard",
-            27: "Hoops",
-            28: "Rumble",
-            29: "Dropshot",
-            30: "Snow Day",
+    private getPlaylistName(playlist: unknown): string {
+        const normalized = this.normalizePlaylist(playlist);
+        const playlistMap: Record<string, string> = {
+            "1": "Duel",
+            "2": "Doubles",
+            "3": "Standard",
+            "4": "Chaos",
+            "6": "Private",
+            "10": "Ranked Duel",
+            "11": "Ranked Doubles",
+            "13": "Ranked Standard",
+            "27": "Hoops",
+            "28": "Rumble",
+            "29": "Dropshot",
+            "30": "Snow Day",
+            CUSTOM_LOBBY: "Private",
+            PRIVATE: "Private",
+            RANKED_DUEL: "Ranked Duel",
+            RANKED_DOUBLES: "Ranked Doubles",
+            RANKED_STANDARD: "Ranked Standard",
+            DOUBLES: "Doubles",
+            DUEL: "Duel",
+            STANDARD: "Standard",
         };
 
-        return playlistMap[playlist ?? 0] ?? "Unknown";
+        return playlistMap[normalized] ?? "Unknown";
     }
 }

--- a/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.spec.ts
+++ b/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.spec.ts
@@ -1,4 +1,4 @@
-import {Parser} from "@sprocketbot/common";
+import {CarballConverterService, Parser} from "@sprocketbot/common";
 
 import {StatsConverterService} from "./stats-converter.service";
 
@@ -48,6 +48,156 @@ const SUMMARY_ONLY_CARBALL_REPLAY = {
     ],
 };
 
+const FULL_ANALYSIS_CARBALL_REPLAY = {
+    gameMetadata: {
+        id: "full-analysis-replay",
+        name: "Full Analysis Replay",
+        map: "eurostadium_night_p",
+        time: "1710000000",
+        length: 300.2,
+        teamSize: 2,
+        playlist: "CUSTOM_LOBBY",
+        matchGuid: "full-analysis-match-guid",
+        score: {
+            team0Score: 2,
+            team1Score: 1,
+        },
+        goals: [
+            {playerId: {id: "blue-1", platform: "OnlinePlatform_Steam"} },
+            {playerId: {id: "orange-1", platform: "OnlinePlatform_Epic"} },
+            {playerId: {id: "blue-1", platform: "OnlinePlatform_Steam"} },
+        ],
+    },
+    players: [
+        {
+            id: {id: "blue-1", platform: "OnlinePlatform_Steam"},
+            name: "Blue One",
+            goals: 2,
+            shots: 3,
+            assists: 1,
+            saves: 2,
+            score: 620,
+            isOrange: 0,
+            platform: "OnlinePlatform_Steam",
+            firstFrameInGame: 4,
+            timeInGame: 296,
+            cameraSettings: {
+                fieldOfView: 108,
+                pitch: -4,
+                height: 110,
+                distance: 280,
+                stiffness: 0.45,
+                swivelSpeed: 4.5,
+                transitionSpeed: 1.3,
+            },
+            stats: {
+                boost: {
+                    boostUsage: 1200,
+                    averageBoostLevel: 42,
+                    timeLowBoost: 30,
+                    timeNoBoost: 12,
+                    timeFullBoost: 18,
+                },
+                distance: {
+                    ballHitForward: 1400,
+                    ballHitBackward: 250,
+                    timeClosestToBall: 15,
+                    timeFurthestFromBall: 18,
+                },
+                positionalTendencies: {
+                    timeOnGround: 180,
+                    timeLowInAir: 70,
+                    timeHighInAir: 12,
+                    timeBehindBall: 160,
+                    timeInFrontBall: 60,
+                    timeInDefendingHalf: 130,
+                    timeInAttackingHalf: 110,
+                    timeInDefendingThird: 70,
+                    timeInNeutralThird: 65,
+                    timeInAttackingThird: 60,
+                },
+                averages: {
+                    averageSpeed: 15000,
+                },
+                speed: {
+                    timeAtSlowSpeed: 20,
+                    timeAtBoostSpeed: 110,
+                    timeAtSuperSonic: 40,
+                },
+                relativePositioning: {
+                    timeBehindCenterOfMass: 120,
+                    timeInFrontOfCenterOfMass: 90,
+                },
+            },
+        },
+        {
+            id: {id: "blue-2", platform: "OnlinePlatform_Steam"},
+            name: "Blue Two",
+            goals: 0,
+            shots: 1,
+            assists: 0,
+            saves: 1,
+            score: 320,
+            isOrange: 0,
+            platform: "OnlinePlatform_Steam",
+            firstFrameInGame: 4,
+            timeInGame: 296,
+            stats: {},
+        },
+        {
+            id: {id: "orange-1", platform: "OnlinePlatform_Epic"},
+            name: "Orange One",
+            goals: 1,
+            shots: 2,
+            assists: 0,
+            saves: 1,
+            score: 410,
+            isOrange: 1,
+            platform: "OnlinePlatform_Epic",
+            firstFrameInGame: 4,
+            timeInGame: 296,
+            stats: {},
+        },
+        {
+            id: {id: "orange-2", platform: "OnlinePlatform_Epic"},
+            name: "Orange Two",
+            goals: 0,
+            shots: 1,
+            assists: 0,
+            saves: 0,
+            score: 180,
+            isOrange: 1,
+            platform: "OnlinePlatform_Epic",
+            firstFrameInGame: 4,
+            timeInGame: 296,
+            stats: {},
+        },
+    ],
+    teams: [
+        {
+            color: "blue",
+            score: 2,
+            playerIds: [
+                {id: "blue-1", platform: "OnlinePlatform_Steam"},
+                {id: "blue-2", platform: "OnlinePlatform_Steam"},
+            ],
+            stats: {
+                possession: {
+                    possessionTime: 120,
+                },
+            },
+        },
+        {
+            color: "orange",
+            score: 1,
+            playerIds: [
+                {id: "orange-1", platform: "OnlinePlatform_Epic"},
+                {id: "orange-2", platform: "OnlinePlatform_Epic"},
+            ],
+        },
+    ],
+};
+
 describe("StatsConverterService", () => {
     it("converts summary-only carball payloads without frame-derived stats", () => {
         const service = new StatsConverterService();
@@ -73,5 +223,29 @@ describe("StatsConverterService", () => {
             name: "Orange One",
             stats: {goals: 1},
         });
+    });
+
+    it("maps camelCase full-analysis carball fields into ballchasing-compatible stats", () => {
+        const converter = new CarballConverterService();
+
+        const result = converter.convertToBallchasingFormat(
+            FULL_ANALYSIS_CARBALL_REPLAY as any,
+            "dev/v4/full-analysis.json",
+        );
+
+        expect(result.playlist_id).toBe("private");
+        expect(result.playlist_name).toBe("Private");
+        expect(result.match_guid).toBe("full-analysis-match-guid");
+        expect(result.blue.stats.ball.possession_time).toBe(120);
+        expect(result.blue.players[0].id).toEqual({id: "blue-1", platform: "steam"});
+        expect(result.blue.players[0].camera.fov).toBe(108);
+        expect(result.blue.players[0].stats.core.goals).toBe(2);
+        expect(result.blue.players[0].stats.core.shots).toBe(3);
+        expect(result.blue.players[0].stats.boost.avg_amount).toBe(42);
+        expect(result.blue.players[0].stats.boost.amount_collected).toBe(1200);
+        expect(result.blue.players[0].stats.movement.avg_speed).toBe(1500);
+        expect(result.blue.players[0].stats.movement.total_distance).toBe(1650);
+        expect(result.blue.players[0].stats.positioning.time_behind_ball).toBe(160);
+        expect(result.blue.players[0].stats.positioning.time_most_back).toBe(120);
     });
 });

--- a/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.ts
+++ b/microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.ts
@@ -52,7 +52,7 @@ export class StatsConverterService {
                     // Convert carball data to ballchasing format first
                     const ballchasingData = this.carballConverter.convertToBallchasingFormat(
                         data,
-                        `carball-stats-${Math.random()}`,
+                        raw.outputPath,
                     );
 
                     // teams = [blue, orange]


### PR DESCRIPTION
## What changed
Improves parser parity for carball-derived replay data inside Sprocket.

## Why
The replay parse service and downstream consumers were still losing useful data when carball output was normalized into ballchasing shape. That left avoidable gaps versus ballchasing, especially for full-analysis payloads.

## Impact
Carball replay normalization now preserves more metadata and stat fields, handles both camelCase and snake_case payloads, and uses stable output paths instead of random placeholders during stats conversion.

## Root cause
The converter was written around a narrow subset of summary-style fields and defaulted many full-analysis fields to zero or ignored them entirely.

## Validation
- `python3 -m unittest tests.test_parser_id_normalization` in `main/microservices/replay-parse-service`
- Added converter coverage in `microservices/submission-service/src/replay-submission/stats-converter/stats-converter.service.spec.ts`
- Could not run the Jest spec in this workspace because `ts-jest` and other Node test dependencies are not installed locally