### PR TITLE
Pin Node 20 and Pulumi 3.229 for infra CI and docs (#668)

### DIFF
--- a/.github/reusable_workflows/pulumi_up/action.yaml
+++ b/.github/reusable_workflows/pulumi_up/action.yaml
@@ -35,9 +35,14 @@ inputs:
     required: false
 
   node-version:
-    description: 'Node.js version used for infra commands'
+    description: 'Node.js major used for infra commands (align with infra/README.md Tool versions)'
     required: false
-    default: '16'
+    default: '20'
+
+  pulumi-version:
+    description: 'Pulumi CLI version (semver without v prefix; align with infra/README.md Tool versions)'
+    required: false
+    default: '3.229.0'
 
   install-command:
     description: 'Command used to install infra dependencies'
@@ -56,7 +61,7 @@ runs:
     - name: Install Pulumi CLI
       shell: bash
       run: |
-        curl -fsSL https://get.pulumi.com | sh
+        curl -fsSL https://get.pulumi.com | sh -s -- --version "${{ inputs.pulumi-version }}"
         echo "${HOME}/.pulumi/bin" >> "${GITHUB_PATH}"
 
     - name: Connect Tailscale

--- a/.github/workflows/infra-foundation-preview.yml
+++ b/.github/workflows/infra-foundation-preview.yml
@@ -9,7 +9,7 @@
 # Repository variable (Settings → Secrets and variables → Actions → Variables), optional:
 #   PULUMI_FOUNDATION_STACK — Pulumi stack name for dev/pre-prod foundation (defaults to dev-staging if unset).
 #
-# Node: uses 20.x here because @pulumi/pulumi in this package requires Node >=20 (root .nvmrc is 16 for other jobs).
+# Node: 20.x is the repo-standard infra toolchain (see infra/README.md "Tool versions"; root .nvmrc stays 16 for legacy app builds).
 #
 # This job does NOT use DOCKER_HOST, SSH to Swarm, or Tailscale — foundation talks only to the DigitalOcean API.
 
@@ -46,7 +46,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          # @pulumi/pulumi in infra/foundation declares engines.node >=20; root .nvmrc is still 16 for legacy app builds.
           node-version: '20'
           cache: npm
           cache-dependency-path: infra/foundation/package-lock.json
@@ -54,7 +53,8 @@ jobs:
       - name: Install Pulumi CLI
         shell: bash
         run: |
-          curl -fsSL https://get.pulumi.com | sh
+          # Keep version aligned with .github/reusable_workflows/pulumi_up/action.yaml and infra/README.md
+          curl -fsSL https://get.pulumi.com | sh -s -- --version 3.229.0
           echo "${HOME}/.pulumi/bin" >> "${GITHUB_PATH}"
 
       - name: Log in to Pulumi backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ If you are making changes, optimize for both goals when possible.
 
 Infra has been migrated into this monorepo from the former standalone `sprocket-infra` repo. Prefer paths under `infra/` over older docs that still reference the external location.
 
+Pinned **Node** and **Pulumi CLI** versions for infra (local + CI) live in [`infra/README.md`](infra/README.md) under **Tool versions**.
+
 ---
 
 ## Canonical Starting Points

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,3 +1,10 @@
+## Tool versions
+
+| Tool | Version | Notes |
+|------|---------|--------|
+| **Node.js** | **20.x** | Use for all Pulumi runs (`npm run infra:install`, GitHub Actions, local preview/up). Matches `@pulumi/pulumi` expectations. The repo root [`.nvmrc`](../.nvmrc) remains **16** for legacy application builds; switch with `nvm install 20 && nvm use 20` (or `fnm use 20`) before infra work. You may see an `npm` `EBADENGINE` warning from transitive packages (for example `minio`); it is benign for our usage. |
+| **Pulumi CLI** | **3.229.0** | Pin CI installs to this version; locally run `pulumi version` after [install](https://www.pulumi.com/docs/install/) and upgrade to match if needed. CI uses `curl -fsSL https://get.pulumi.com \| sh -s -- --version 3.229.0`. |
+
 ## Infrastructure Monorepo Layout
 
 This directory contains the Pulumi infrastructure code migrated from the former `sprocket-infra` repository.
@@ -79,7 +86,8 @@ export PULUMI_REMOTE_DOCKER_HOST=sprocket-prod
 From a clean shell session:
 
 ```bash
-nvm use
+nvm install 20
+nvm use 20
 npm run infra:install
 
 export PULUMI_BACKEND_URL='s3://[your bucket]/pulumi?endpoint=[your endpoint]'

--- a/infra/foundation/package.json
+++ b/infra/foundation/package.json
@@ -1,5 +1,8 @@
 {
   "name": "foundation",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@pulumi/digitalocean": "^4.61.0",
     "@pulumi/pulumi": "^3.0.0"

--- a/infra/global/package.json
+++ b/infra/global/package.json
@@ -8,6 +8,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@influxdata/influxdb-client": "^1.25.0",
     "@influxdata/influxdb-client-apis": "^1.25.0",

--- a/infra/layer_1/package.json
+++ b/infra/layer_1/package.json
@@ -1,5 +1,8 @@
 {
     "name": "layer_1",
+    "engines": {
+        "node": ">=20"
+    },
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/infra/layer_2/package.json
+++ b/infra/layer_2/package.json
@@ -1,5 +1,8 @@
 {
     "name": "layer_2",
+    "engines": {
+        "node": ">=20"
+    },
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/infra/platform/package.json
+++ b/infra/platform/package.json
@@ -1,5 +1,8 @@
 {
     "name": "platform",
+    "engines": {
+        "node": ">=20"
+    },
     "devDependencies": {
         "@types/node": "^14"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #668.

## Summary

- **Document** canonical infra toolchain in `infra/README.md` (**Tool versions**): Node **20.x** (infra standard; root `.nvmrc` stays 16 for legacy app builds) and Pulumi CLI **3.229.0**.
- **CI:** `pulumi_up` composite action now defaults `node-version` to **20** (was 16) and installs Pulumi via `sh -s -- --version 3.229.0` so it matches docs and foundation preview.
- **`infra-foundation-preview.yml`:** same Pulumi install pin; comments aligned with the README.
- **`AGENTS.md`:** one-line link to the infra README tool section.
- **Optional engines:** `engines.node: ">=20"` on `infra/global`, `infra/foundation`, `infra/layer_1`, `infra/layer_2`, `infra/platform` package.json files.

## Verification

- `nvm use 20` + `npm run infra:install` completed successfully (with expected transitive `EBADENGINE` warnings noted in README).
- Pulumi install one-liner tested locally: `curl -fsSL https://get.pulumi.com | sh -s -- --version 3.229.0` → `pulumi version` reports `v3.229.0`.

## Notes

- Pulumi version **3.229.0** was the current stable release at implementation time; bump the default in `pulumi_up` + README + foundation workflow together when upgrading.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7950ab0-23b5-4f6f-be67-23b4cadb553f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7950ab0-23b5-4f6f-be67-23b4cadb553f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

