### PR TITLE
infra: add stack map (env → Pulumi stacks + deploy order) (#667)

### DIFF
--- a/infra/ci/README.md
+++ b/infra/ci/README.md
@@ -1,0 +1,17 @@
+# Infra CI metadata
+
+## `stack-map.yaml`
+
+Single machine-readable contract for **which Pulumi stacks apply to which logical environment** (`dev`, `staging`, `prod`) and in **what order** Swarm-facing layers should run (`layer_1` → `layer_2` → `platform`).
+
+- **Prod** entries match [`.github/workflows/infra-pulumi.yml`](../../.github/workflows/infra-pulumi.yml) PR preview matrix today.
+- **Dev / staging** list candidate stack names (`dev`, `staging`) with TODO comments until ops confirms they exist ([issue #667](https://github.com/SprocketBot/sprocket/issues/667)).
+- **Foundation** (`infra/foundation`) is listed separately; it is not part of the Swarm `deploy_order`.
+
+### Who updates this
+
+Maintainers who add or rename Pulumi stacks. After `pulumi stack ls` in each project, update this file and keep CI matrices in sync (or teach workflows to read this file).
+
+### Future consumption
+
+GitHub Actions or `scripts/infra` can parse this YAML with `yq`, a tiny Node script, or similar—out of scope for the initial file landing; see milestone notes in issue #667.

--- a/infra/ci/stack-map.yaml
+++ b/infra/ci/stack-map.yaml
@@ -1,0 +1,48 @@
+# Machine-readable map: logical environment → Pulumi projects, stack names, deploy order.
+# Consumed by future CI/CD workflows (see infra/ci/README.md). No secrets.
+# Source of truth for prod Swarm preview matrix today: .github/workflows/infra-pulumi.yml
+# Issue: https://github.com/SprocketBot/sprocket/issues/667
+
+version: 1
+
+environments:
+  dev:
+    description: "Shared pre-prod Swarm — dev isolation (planned; not in CI matrix yet)"
+    deploy_order:
+      # TODO(667): Confirm with ops — stacks may not exist yet; do not automate against these until verified.
+      - project: layer_1
+        stack: dev
+      - project: layer_2
+        stack: dev
+      - project: platform
+        stack: dev
+
+  staging:
+    description: "Same droplet as dev in current plan; different stack isolation (planned)"
+    deploy_order:
+      # TODO(667): Confirm with ops. Note: infra/platform/old_pulumi/ had historical dev/staging/main stacks;
+      # active Swarm platform stack in CI today is prod (see prod environment below).
+      - project: layer_1
+        stack: staging
+      - project: layer_2
+        stack: staging
+      - project: platform
+        stack: staging
+
+  prod:
+    description: "Production Swarm — matches infra-pulumi.yml PR preview matrix"
+    deploy_order:
+      # layer_* stack names match project folder names; platform uses stack prod.
+      - { project: layer_1, stack: layer_1 }
+      - { project: layer_2, stack: layer_2 }
+      - { project: platform, stack: prod }
+
+foundation:
+  note: "Provisioned separately (droplet/bootstrap); not part of Swarm deploy_order above"
+  stacks:
+    dev_staging_node:
+      project: foundation
+      stack: dev-staging
+    prod_node:
+      project: foundation
+      stack: prod

--- a/infra/docs-output/CICD_STRATEGY.md
+++ b/infra/docs-output/CICD_STRATEGY.md
@@ -318,6 +318,8 @@ To make this stable:
 
 You should also standardize per-stack commands so CI does not guess.
 
+Stack names and order are defined in `infra/ci/stack-map.yaml`.
+
 For example:
 
 - `infra/layer_1`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #667](https://github.com/SprocketBot/sprocket/issues/667): a machine-readable Pulumi stack map for `dev` / `staging` / `prod`, plus short documentation and a CI/CD strategy cross-link.

## Changes

- **`infra/ci/stack-map.yaml`** — `version: 1`; `deploy_order` is `layer_1` → `layer_2` → `platform`. **Prod** matches `.github/workflows/infra-pulumi.yml` PR preview matrix (`layer_1` / `layer_2` / `prod`). **Foundation** documents `dev-staging` and `prod` from `infra/foundation/Pulumi.*.yaml`. **Dev/staging** use candidate stack names `dev` / `staging` with `# TODO(667)` comments until ops confirms.
- **`infra/ci/README.md`** — purpose, ownership, link to #667, note on future `yq`/script consumption.
- **`infra/docs-output/CICD_STRATEGY.md`** — one sentence pointing at `infra/ci/stack-map.yaml`.

## Validation

- Parsed `infra/ci/stack-map.yaml` with Python `yaml.safe_load` (OK).

## Out of scope (per issue)

- GitHub Actions not wired to read this file yet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dabe74c-c181-445c-9f3e-61ba8cc51993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dabe74c-c181-445c-9f3e-61ba8cc51993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

