### PR TITLE
ci: build bill of materials artifact on merge to main (#671)

### DIFF
--- a/.github/reusable_workflows/build_container/action.yaml
+++ b/.github/reusable_workflows/build_container/action.yaml
@@ -18,6 +18,18 @@ inputs:
     description: 'Whether to push the built image to GHCR'
     required: false
     default: 'true'
+  immutable_sha:
+    description: 'When set (full git SHA), also push ghcr.io/.../image:sha-<SHA> for immutable promotion references.'
+    required: false
+    default: ''
+
+outputs:
+  digest:
+    description: 'Image digest (sha256:...) after push; empty when push is disabled.'
+    value: ${{ steps.docker_build.outputs.digest }}
+  image_name:
+    description: 'Short image/service name (docker_image input).'
+    value: ${{ inputs.docker_image }}
 
 runs:
   using: 'composite'
@@ -36,7 +48,26 @@ runs:
     - name: Check out the repo
       uses: actions/checkout@v6
 
+    - name: Compute image tags
+      id: image_tags
+      shell: bash
+      run: |
+        REGISTRY="ghcr.io/sprocketbot"
+        IMG="${{ inputs.docker_image }}"
+        TAG="${{ inputs.docker_tag }}"
+        TAGS="${REGISTRY}/${IMG}:${TAG}"
+        IMMUTABLE="${{ inputs.immutable_sha }}"
+        if [ -n "${IMMUTABLE}" ]; then
+          TAGS="${TAGS}"$'\n'"${REGISTRY}/${IMG}:sha-${IMMUTABLE}"
+        fi
+        {
+          echo 'tags<<EOF'
+          echo "${TAGS}"
+          echo 'EOF'
+        } >> "${GITHUB_OUTPUT}"
+
     - name: Build And Push Image
+      id: docker_build
       uses: docker/build-push-action@v7
       with:
         build-args: |
@@ -45,7 +76,7 @@ runs:
         file: ${{ inputs.build_directory }}/Dockerfile
         target: app_image
         push: ${{ inputs.push_image == 'true' }}
-        tags: ghcr.io/sprocketbot/${{ inputs.docker_image }}:${{ inputs.docker_tag }}
+        tags: ${{ steps.image_tags.outputs.tags }}
         platforms: linux/amd64
 
     - uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/on-changes.yml
+++ b/.github/workflows/on-changes.yml
@@ -48,16 +48,65 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Compute core image tags
+        id: core_tags
+        shell: bash
+        run: |
+          REGISTRY="ghcr.io/sprocketbot/monorepo-core"
+          BRANCH="${{ steps.extract_branch.outputs.branch }}"
+          TAGS="${REGISTRY}:${BRANCH}"
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="${TAGS}"$'\n'"${REGISTRY}:sha-${{ github.sha }}"
+          fi
+          {
+            echo 'tags<<EOF'
+            echo "${TAGS}"
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Build and export
+        id: docker_core
         uses: docker/build-push-action@v7
         with:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
           context: .
           file: ./dockerfiles/node.Dockerfile
-          tags: ghcr.io/sprocketbot/monorepo-core:${{ steps.extract_branch.outputs.branch }}
+          tags: ${{ steps.core_tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           platforms: linux/amd64
+
+      # Bill of materials fragment (main only). Promotion workflows will merge these in merge-bom.
+      - name: Write BOM fragment (monorepo-core)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        shell: bash
+        run: |
+          mkdir -p bom
+          DIGEST="${{ steps.docker_core.outputs.digest }}"
+          if [ -n "${DIGEST}" ]; then
+            jq -n \
+              --arg name monorepo-core \
+              --arg branch "${{ steps.extract_branch.outputs.branch }}" \
+              --arg sha "${{ github.sha }}" \
+              --arg digest "${DIGEST}" \
+              '{name: $name, tags: [$branch, ("sha-" + $sha)], digest: $digest}' \
+              > bom/monorepo-core.json
+          else
+            jq -n \
+              --arg name monorepo-core \
+              --arg branch "${{ steps.extract_branch.outputs.branch }}" \
+              --arg sha "${{ github.sha }}" \
+              '{name: $name, tags: [$branch, ("sha-" + $sha)], digest: null}' \
+              > bom/monorepo-core.json
+          fi
+
+      - name: Upload BOM fragment (monorepo-core)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bom-fragment-monorepo-core
+          path: bom/monorepo-core.json
+          retention-days: 14
 
   build_microservices:
     name: 'Build Node Services'
@@ -109,6 +158,7 @@ jobs:
             sprocketCommonHasChanges: ./common/**
 
       - name: Build project
+        id: build_project
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.baseDockerfileHasChanges == 'true' || steps.changes.outputs.buildConfigHasChanges == 'true' || steps.changes.outputs.projectHasChanges == 'true' || steps.changes.outputs.sprocketCommonHasChanges == 'true'
         uses: ./.github/reusable_workflows/build_container
         with:
@@ -117,3 +167,77 @@ jobs:
           docker_tag: ${{steps.extract_branch.outputs.branch}}
           discord_webhook: ${{ secrets.discord_webhook }}
           push_image: ${{ github.event_name != 'pull_request' }}
+          immutable_sha: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || '' }}
+
+      # Per-service BOM fragment (main pushes only, same conditions as build). merge-bom assembles the full manifest.
+      - name: Write BOM fragment (service)
+        if: >
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          (steps.changes.outputs.baseDockerfileHasChanges == 'true' || steps.changes.outputs.buildConfigHasChanges == 'true' ||
+          steps.changes.outputs.projectHasChanges == 'true' || steps.changes.outputs.sprocketCommonHasChanges == 'true')
+        shell: bash
+        env:
+          SERVICE_NAME: ${{ matrix.directory[0] }}
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          GIT_SHA: ${{ github.sha }}
+          DIGEST: ${{ steps.build_project.outputs.digest }}
+        run: |
+          mkdir -p bom
+          OUT="bom/${SERVICE_NAME}.json"
+          if [ -n "${DIGEST}" ]; then
+            jq -n \
+              --arg name "${SERVICE_NAME}" \
+              --arg branch "${BRANCH}" \
+              --arg sha "${GIT_SHA}" \
+              --arg digest "${DIGEST}" \
+              '{name: $name, tags: [$branch, ("sha-" + $sha)], digest: $digest}' \
+              > "${OUT}"
+          else
+            jq -n \
+              --arg name "${SERVICE_NAME}" \
+              --arg branch "${BRANCH}" \
+              --arg sha "${GIT_SHA}" \
+              '{name: $name, tags: [$branch, ("sha-" + $sha)], digest: null}' \
+              > "${OUT}"
+          fi
+
+      - name: Upload BOM fragment (service)
+        if: >
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          (steps.changes.outputs.baseDockerfileHasChanges == 'true' || steps.changes.outputs.buildConfigHasChanges == 'true' ||
+          steps.changes.outputs.projectHasChanges == 'true' || steps.changes.outputs.sprocketCommonHasChanges == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: bom-fragment-${{ matrix.directory[0] }}
+          path: bom/${{ matrix.directory[0] }}.json
+          retention-days: 14
+
+  merge_bom:
+    name: Merge container BOM (main)
+    # Single artifact for promotion: commit SHA + per-image tags (including sha-*). Runs only when all builds succeed.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build_core_image
+      - build_microservices
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Download BOM fragments
+        uses: actions/download-artifact@v4
+        with:
+          path: bom-artifacts
+          pattern: bom-fragment-*
+          merge-multiple: true
+
+      - name: Merge fragments to artifacts/bom/main-<sha>.json
+        shell: bash
+        run: ./scripts/ci/merge-bom-artifacts.sh bom-artifacts "artifacts/bom/main-${GITHUB_SHA}.json"
+
+      - name: Upload BOM (bom-main)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bom-main
+          path: artifacts/bom/main-${{ github.sha }}.json
+          retention-days: 90

--- a/scripts/ci/merge-bom-artifacts.sh
+++ b/scripts/ci/merge-bom-artifacts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Merge per-job BOM fragment.json files (from upload-artifact) into one manifest.
+# Promotion / deploy workflows will consume artifacts/bom/main-<sha>.json (see on-changes.yml).
+
+set -euo pipefail
+
+INPUT_DIR="${1:?usage: merge-bom-artifacts.sh <input-dir> <output-json>}"
+OUTPUT_JSON="${2:?usage: merge-bom-artifacts.sh <input-dir> <output-json>}"
+
+COMMIT="${GITHUB_SHA:?GITHUB_SHA is required}"
+REF="${GITHUB_REF:?GITHUB_REF is required}"
+BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+mapfile -t FRAGS < <(find "${INPUT_DIR}" -type f -name '*.json' 2>/dev/null | sort -u)
+
+if [ "${#FRAGS[@]}" -eq 0 ]; then
+  echo "merge-bom-artifacts: no *.json fragments under ${INPUT_DIR}" >&2
+  exit 1
+fi
+
+IMAGES_JSON="$(jq -s '[.[]]' "${FRAGS[@]}")"
+
+mkdir -p "$(dirname "${OUTPUT_JSON}")"
+
+jq -n \
+  --arg commit "${COMMIT}" \
+  --arg ref "${REF}" \
+  --arg built_at "${BUILT_AT}" \
+  --argjson images "${IMAGES_JSON}" \
+  '{commit: $commit, ref: $ref, built_at: $built_at, images: $images}' \
+  > "${OUTPUT_JSON}"
+
+echo "Wrote ${OUTPUT_JSON} (${#FRAGS[@]} image fragment(s))"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub issue #671](https://github.com/SprocketBot/sprocket/issues/671): after a successful **push to `main`**, the autobuild workflow uploads a single JSON **bill of materials** artifact listing the commit and each built image’s **branch tag** plus immutable **`sha-<full_sha>`** tag (and digest when available).

Also covers the immutable-tag expectation from related issue **#670** by tagging both `monorepo-core` and each matrix service with `sha-${{ github.sha }}` on main.

## Changes

- **`.github/workflows/on-changes.yml`**
  - `monorepo-core`: multi-line tags (`main`, `sha-<sha>` on main pushes).
  - Per-job **BOM fragments** (`bom-fragment-*` artifacts) when that leg actually builds on a main push.
  - New job **`merge_bom`**: downloads all `bom-fragment-*`, runs `scripts/ci/merge-bom-artifacts.sh`, uploads artifact **`bom-main`** containing `artifacts/bom/main-<sha>.json` (90-day retention).
- **`.github/reusable_workflows/build_container/action.yaml`**
  - Optional `immutable_sha` input; adds `sha-<sha>` tag on main.
  - Exposes **`digest`** and **`image_name`** outputs for BOM fragments.
- **`scripts/ci/merge-bom-artifacts.sh`**: merges downloaded `*.json` fragments into the final manifest.

## BOM shape

```json
{
  "commit": "<full sha>",
  "ref": "refs/heads/main",
  "built_at": "<iso8601>",
  "images": [
    { "name": "core", "tags": ["main", "sha-..."], "digest": "sha256:..." }
  ]
}
```

**Note:** Services whose matrix leg **skips** the build (paths-filter) do not upload a fragment, so they are **omitted** from the BOM for that run—this matches “failed / incomplete matrix must not publish a full BOM” (merge only runs when all jobs succeed; skipped legs are not failures).

## Validation

- Local smoke: `merge-bom-artifacts.sh` with sample JSON fragments.
- YAML parse check via Ruby `YAML.load_file`.

## Closes

Closes #671
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65feaefc-943b-491e-8c6e-65c72209cf2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65feaefc-943b-491e-8c6e-65c72209cf2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

