### PR TITLE
ci: immutable container image tags (sha-*) on all branch pushes (#670)

### DIFF
--- a/.github/workflows/on-changes.yml
+++ b/.github/workflows/on-changes.yml
@@ -1,3 +1,8 @@
+# Container images are pushed with a branch tag (e.g. main, pr-123) plus an immutable
+# ghcr.io/.../name:sha-<git-sha> tag. Deployments should pin sha-* (or digest), not only
+# moving branch tags — see infra/README.md. Wiring Pulumi to consume sha-* is tracked
+# separately (e.g. #672 / #673).
+
 name: 'Autobuild Docker Containers'
 
 on:
@@ -55,9 +60,12 @@ jobs:
           REGISTRY="ghcr.io/sprocketbot/monorepo-core"
           BRANCH="${{ steps.extract_branch.outputs.branch }}"
           TAGS="${REGISTRY}:${BRANCH}"
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            TAGS="${TAGS}"$'\n'"${REGISTRY}:sha-${{ github.sha }}"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            IMMUTABLE_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            IMMUTABLE_SHA="${{ github.sha }}"
           fi
+          TAGS="${TAGS}"$'\n'"${REGISTRY}:sha-${IMMUTABLE_SHA}"
           {
             echo 'tags<<EOF'
             echo "${TAGS}"
@@ -167,7 +175,8 @@ jobs:
           docker_tag: ${{steps.extract_branch.outputs.branch}}
           discord_webhook: ${{ secrets.discord_webhook }}
           push_image: ${{ github.event_name != 'pull_request' }}
-          immutable_sha: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || '' }}
+          # Empty on pull_request (images are not pushed); push + workflow_dispatch use commit SHA.
+          immutable_sha: ${{ github.event_name != 'pull_request' && github.sha || '' }}
 
       # Per-service BOM fragment (main pushes only, same conditions as build). merge-bom assembles the full manifest.
       - name: Write BOM fragment (service)

--- a/infra/README.md
+++ b/infra/README.md
@@ -104,6 +104,10 @@ npm run infra:up -- platform prod --yes
 
 ## GitHub Actions
 
+### Container image tags (CI)
+
+Autobuild (`.github/workflows/on-changes.yml`) pushes each image with a **branch-style** tag (`main`, `staging`, `dev`, or `pr-<n>`) and an **immutable** tag `sha-<full-git-sha>` (PR builds that push use the pull-request **head** SHA, not the merge ref). Prefer pinning deploys to `sha-*` or digest; moving tags are convenience aliases only. Adopting those refs in Pulumi stack config is tracked separately (e.g. issues #672 / #673).
+
 The reusable GitHub Actions entrypoint for the same contract lives at:
 
 - `.github/reusable_workflows/pulumi_up/action.yaml`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #670.

## Summary

- **Core image** (`monorepo-core`): always pushes `ghcr.io/sprocketbot/monorepo-core:sha-<full-git-sha>` in addition to the branch tag (`main`, `staging`, `dev`, or `pr-<n>`). For `pull_request` events that push, the SHA is **`github.event.pull_request.head.sha`** so the immutable tag matches the PR head, not the merge ref.
- **Matrix services** (reusable `build_container`): pass `immutable_sha` on every **push** and **workflow_dispatch** (not only `main`), so `staging` / `dev` builds also get `sha-*` tags. PR builds still omit `immutable_sha` because `push_image` is false for fork PRs and the composite action only logs in when pushing.

## Documentation

- Short note at the top of `.github/workflows/on-changes.yml` and a **Container image tags (CI)** subsection under **GitHub Actions** in `infra/README.md`: deployable refs should pin `sha-*` or digest; moving tags are aliases.

## Out of scope (per issue)

- **Pulumi** stack YAML still does not need to consume `sha-*` yet — that remains **#672 / #673** (and related promotion work).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-778d6447-ae2e-4a7b-9358-6e60af92dca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-778d6447-ae2e-4a7b-9358-6e60af92dca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

