### PR TITLE
fix(infra): layer_1 GHCR preview — add image-namespace, document stack auth

### DIFF
--- a/.github/workflows/infra-pulumi.yml
+++ b/.github/workflows/infra-pulumi.yml
@@ -16,6 +16,10 @@ name: Infra Pulumi
 # AWS_SECRET_ACCESS_KEY, PULUMI_MANAGER_NODE_HOST, PULUMI_SSH_USER, PULUMI_SSH_KEY,
 # TAILSCALE_AUTHKEY (optional in composite), PULUMI_BACKEND_URL.
 #
+# GHCR is not a separate Actions secret: previews use Pulumi stack config on each project
+# (docker-username, docker-access-token, and image-namespace where GHCR images are resolved).
+# PULUMI_CONFIG_PASSPHRASE decrypts stack secrets in committed Pulumi.*.yaml files.
+#
 # Stack names: PR previews still target the prod stack names until dev/staging stacks exist.
 # TODO(#669): When dev/staging Pulumi stacks exist, add a matrix axis or workflow_dispatch input
 # so PRs can preview non-prod without defaulting to prod.

--- a/infra/layer_1/Pulumi.layer_1.yaml
+++ b/infra/layer_1/Pulumi.layer_1.yaml
@@ -1,4 +1,6 @@
 config:
+  # GHCR org for discord-forward-auth (must match images published under ghcr.io/<namespace>/...)
+  layer_1:image-namespace: sprocketbot
   layer_1:docker-username: asaxplayinghorse
   layer_1:vault-s3-secret-key:
     secure: AAABAK291q/FzpUzT0jbzskiTB4kloS0aTfMPFLy4fvA10LEiz8QLOQe6PZZLFWKouADD5bmyK/JUvCKtQ3Ihly04X2kQ3KASDdd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pulumi infra previews authenticate to GHCR using **Pulumi stack config** (`docker-username`, `docker-access-token`), not GitHub Actions `GITHUB_TOKEN` / a separate GHCR secret. The composite workflow never logs in to GHCR at the Actions layer.

## Root cause (layer_1)

`DiscordForwardAuth` resolves images with `config.require("image-namespace")` and `getImageSha(...)`, but `infra/layer_1/Pulumi.layer_1.yaml` had **no** `layer_1:image-namespace` key. That fails during preview before any registry call.

## Changes

- Set `layer_1:image-namespace: sprocketbot` (aligned with `platform` stack) in `infra/layer_1/Pulumi.layer_1.yaml`.
- Comment in `.github/workflows/infra-pulumi.yml` clarifying GHCR auth + `PULUMI_CONFIG_PASSPHRASE` role.

## If platform (or others) still fail after this

Then investigate **stack secrets**, not missing Actions env vars: expired PAT, username/token mismatch, or missing image/tag under `ghcr.io/sprocketbot/...`.

**Branch:** `cursor/pulumi-ghcr-authentication-failure-0b6c`  
**Commit:** `fbfac8a7`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3db8276e-131a-470e-89a5-660018285db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3db8276e-131a-470e-89a5-660018285db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

