### PR TITLE
fix(web): show skill group for casual scrims on home list (#662)

### DIFF
--- a/clients/web/src/lib/components/molecules/scrims/ScrimCard.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/ScrimCard.svelte
@@ -20,6 +20,11 @@
         </tr>
     
         <tr>
+            <th>Skill Group</th>
+            <td>{scrim.skillGroup?.profile?.description ?? ""}</td>
+        </tr>
+
+        <tr>
             <th>Game Mode</th>
             <td>{scrim.gameMode.description}</td>
         </tr>

--- a/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/ScrimTable.svelte
@@ -27,7 +27,7 @@
     {#each scrims as scrim (scrim.id)}
         <tr>
             <td>{scrim.gameMode.game.title}</td>
-            <td>{scrim.settings.competitive ? scrim.skillGroup?.profile?.description : ""}</td>
+            <td>{scrim.skillGroup?.profile?.description ?? ""}</td>
             <td>{scrim.gameMode.description}</td>
             <td>{screamingSnakeToHuman(scrim.settings.mode)}</td>
             <td>{scrim.playerCount} / {scrim.maxPlayers}</td>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes https://github.com/SprocketBot/sprocket/issues/662.

The pending scrims GraphQL payload already includes `skillGroup`; the home list UI only rendered it when `settings.competitive` was true, so casual scrims showed an empty Skill Group column.

## Changes
- **`ScrimTable.svelte`**: Always show `scrim.skillGroup?.profile?.description` (same data as after joining).
- **`ScrimCard.svelte`**: Add a Skill Group row for the mobile layout so narrow viewports match the table.

## Validation
- `npm run check --workspace=clients/web` — fails with many pre-existing project errors; no new issues identified in the edited files beyond existing `ScrimTable` typing noise.

## Branch / commit
- Branch: `cursor/issue-662-casual-scrim-skill-group-0a5a`
- Base: `main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9753322-e694-4e73-85ce-a629483e0a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9753322-e694-4e73-85ce-a629483e0a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

