### PR TITLE
fix(scrims): team scrim group invite window (#655)

### DIFF
--- a/common/src/service-connectors/matchmaking/types/MatchmakingError.enum.ts
+++ b/common/src/service-connectors/matchmaking/types/MatchmakingError.enum.ts
@@ -10,4 +10,6 @@ export enum MatchmakingError {
     MaxGroupsCreated = "MaxGroupsCreated",
     GroupNotFound = "GroupNotFound",
     GroupFull = "GroupFull",
+    /** Ungrouped joins blocked briefly after the first team group is created (team scrims). */
+    ScrimGroupInviteWindowActive = "ScrimGroupInviteWindowActive",
 }

--- a/common/src/service-connectors/matchmaking/types/Scrim.ts
+++ b/common/src/service-connectors/matchmaking/types/Scrim.ts
@@ -21,6 +21,8 @@ export const ScrimSchema = z.object({
     skillGroupId: z.number(),
     submissionId: z.string().optional(),
     timeoutJobId: z.number().optional(),
+    /** When set, ungrouped players cannot join a team scrim until this instant (teammates may still join via group code). */
+    groupInviteOpensAt: DateSchema.optional(),
 
     players: z.array(ScrimPlayerSchema),
     games: z.array(ScrimGameSchema).default([])

--- a/core/src/scrim/types/Scrim.ts
+++ b/core/src/scrim/types/Scrim.ts
@@ -65,6 +65,9 @@ export class Scrim implements IScrim {
     @Field(() => String, {nullable: true})
   submissionId?: string;
 
+    @Field(() => Date, {nullable: true})
+  groupInviteOpensAt?: Date;
+
     @Field(() => [ScrimPlayer], {nullable: true})
   players: ScrimPlayer[];
 

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -213,6 +213,15 @@ export class ScrimCrudService {
         await this.updateScrimUpdatedAt(scrimId);
     }
 
+    async setGroupInviteOpensAt(scrimId: string, opensAt: Date): Promise<void> {
+        await this.redisService.setJsonField(
+            `${this.prefix}${scrimId}`,
+            "$.groupInviteOpensAt",
+            opensAt,
+        );
+        await this.updateScrimUpdatedAt(scrimId);
+    }
+
     async setTimeoutJobId(scrimId: string, jobId: JobId): Promise<void> {
         await this.redisService.setJsonField(`${this.prefix}${scrimId}`, "$.jobId", jobId);
         await this.updateScrimUpdatedAt(scrimId);

--- a/microservices/matchmaking-service/src/scrim/scrim.service.spec.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.spec.ts
@@ -46,6 +46,7 @@ describe("ScrimService", () => {
     let crudRemoveScrim: jest.SpyInstance;
     let crudUpdateScrimStatus: jest.SpyInstance;
     let crudUpdateScrimUnlockedStatus: jest.SpyInstance;
+    let crudSetGroupInviteOpensAt: jest.SpyInstance;
 
     let logicPopScrim: jest.SpyInstance;
     let logicDeleteScrim: jest.SpyInstance;
@@ -85,6 +86,7 @@ describe("ScrimService", () => {
         crudRemoveScrim = jest.spyOn(scrimCrudService, "removeScrim");
         crudUpdateScrimStatus = jest.spyOn(scrimCrudService, "updateScrimStatus");
         crudUpdateScrimUnlockedStatus = jest.spyOn(scrimCrudService, "updateScrimUnlockedStatus");
+        crudSetGroupInviteOpensAt = jest.spyOn(scrimCrudService, "setGroupInviteOpensAt").mockResolvedValue(undefined);
 
         logicPopScrim = jest.spyOn(scrimLogicService, "popScrim");
         logicDeleteScrim = jest.spyOn(scrimLogicService, "deleteScrim");
@@ -206,9 +208,14 @@ describe("ScrimService", () => {
             const expected: Scrim = {
                 ...scrim,
                 players: [mockPlayerFactories.hyper(someDate, "tekssxisbad")],
+                groupInviteOpensAt: expect.any(Date) as Date,
             };
 
             expect(actual).toEqual(expected);
+            expect(crudSetGroupInviteOpensAt).toHaveBeenCalledWith(
+                scrim.id,
+                expect.any(Date) as Date,
+            );
             expect(crudCreateScrim).toHaveBeenCalledWith({
                 authorId: expected.authorId,
                 organizationId: expected.organizationId,
@@ -480,6 +487,125 @@ describe("ScrimService", () => {
                 joinedAt: expect.any(Date) as Date,
                 leaveAt: expect.any(Date) as Date,
                 group: "tekssxisbad",
+            });
+        });
+
+        describe("Team scrim group invite window (issue #655)", () => {
+            it("Should throw when an ungrouped player joins during the invite window", async () => {
+                const joinScrimData: JoinScrimOptions = {
+                    scrimId: "hello world!",
+                    playerId: 4,
+                    playerName: "Nigel Thornbrake",
+                    leaveAfter: 1000,
+                };
+                const scrim: Scrim = {
+                    id: "hello world!",
+                    createdAt: someDate,
+                    updatedAt: someDate,
+                    status: ScrimStatus.PENDING,
+                    ...getMockScrimIds(),
+                    players: [mockPlayerFactories.hyper(someDate, "abc12")],
+                    games: undefined,
+                    settings: getMockScrimSettings(3, 2, ScrimMode.TEAMS, true, false, 1000),
+                    groupInviteOpensAt: new Date(Date.now() + 60_000),
+                };
+
+                crudGetScrim.mockResolvedValueOnce(scrim);
+                crudPlayerInAnyScrim.mockResolvedValueOnce(false);
+
+                const func = async (): Promise<Scrim> => service.joinScrim(joinScrimData);
+                await expect(func).rejects.toThrow(MatchmakingError.ScrimGroupInviteWindowActive);
+            });
+
+            it("Should allow joining with a group code during the invite window", async () => {
+                const joinScrimData: JoinScrimOptions = {
+                    scrimId: "hello world!",
+                    playerId: 2,
+                    playerName: "tekssx",
+                    leaveAfter: 1000,
+                    joinGroup: "abc12",
+                };
+                const scrim: Scrim = {
+                    id: "hello world!",
+                    createdAt: someDate,
+                    updatedAt: someDate,
+                    status: ScrimStatus.PENDING,
+                    ...getMockScrimIds(),
+                    players: [mockPlayerFactories.hyper(someDate, "abc12")],
+                    games: undefined,
+                    settings: getMockScrimSettings(3, 2, ScrimMode.TEAMS, true, false, 1000),
+                    groupInviteOpensAt: new Date(Date.now() + 60_000),
+                };
+
+                crudGetScrim.mockResolvedValueOnce(scrim);
+                crudPlayerInAnyScrim.mockResolvedValueOnce(false);
+                crudAddPlayerToScrim.mockResolvedValueOnce({});
+
+                const actual = await service.joinScrim(joinScrimData);
+                expect(actual.players).toHaveLength(2);
+                expect(actual.players[1]?.group).toBe("abc12");
+            });
+
+            it("Should allow ungrouped joins after the invite window", async () => {
+                const joinScrimData: JoinScrimOptions = {
+                    scrimId: "hello world!",
+                    playerId: 4,
+                    playerName: "Nigel Thornbrake",
+                    leaveAfter: 1000,
+                };
+                const scrim: Scrim = {
+                    id: "hello world!",
+                    createdAt: someDate,
+                    updatedAt: someDate,
+                    status: ScrimStatus.PENDING,
+                    ...getMockScrimIds(),
+                    players: [mockPlayerFactories.hyper(someDate, "abc12")],
+                    games: undefined,
+                    settings: getMockScrimSettings(3, 2, ScrimMode.TEAMS, true, false, 1000),
+                    groupInviteOpensAt: new Date(Date.now() - 1000),
+                };
+
+                crudGetScrim.mockResolvedValueOnce(scrim);
+                crudPlayerInAnyScrim.mockResolvedValueOnce(false);
+                crudAddPlayerToScrim.mockResolvedValueOnce({});
+
+                const actual = await service.joinScrim(joinScrimData);
+                expect(actual.players).toHaveLength(2);
+                expect(actual.players[1]?.group).toBeUndefined();
+            });
+
+            it("Should start the invite window when the first group is created by joining", async () => {
+                const before = Date.now();
+                const joinScrimData: JoinScrimOptions = {
+                    scrimId: "hello world!",
+                    playerId: 2,
+                    playerName: "tekssx",
+                    leaveAfter: 1000,
+                    createGroup: true,
+                };
+                const scrim: Scrim = {
+                    id: "hello world!",
+                    createdAt: someDate,
+                    updatedAt: someDate,
+                    status: ScrimStatus.PENDING,
+                    ...getMockScrimIds(),
+                    players: [mockPlayerFactories.hyper(someDate)],
+                    games: undefined,
+                    settings: getMockScrimSettings(3, 2, ScrimMode.TEAMS, true, false, 1000),
+                };
+
+                crudGetScrim.mockResolvedValueOnce(scrim);
+                crudPlayerInAnyScrim.mockResolvedValueOnce(false);
+                crudAddPlayerToScrim.mockResolvedValueOnce({});
+                groupsResolveGroupKey.mockImplementationOnce(() => "newgrp");
+
+                await service.joinScrim(joinScrimData);
+
+                expect(crudSetGroupInviteOpensAt).toHaveBeenCalledTimes(1);
+                const [id, opensAt] = crudSetGroupInviteOpensAt.mock.calls[0] as [string, Date];
+                expect(id).toBe("hello world!");
+                expect(opensAt.getTime()).toBeGreaterThanOrEqual(before + 119_000);
+                expect(opensAt.getTime()).toBeLessThanOrEqual(Date.now() + 121_000);
             });
         });
 

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -13,6 +13,7 @@ import {
     AnalyticsService,
     EventTopic,
     MatchmakingError,
+    ScrimMode,
     ScrimSchema,
     ScrimStatus,
 } from "@sprocketbot/common";
@@ -22,6 +23,9 @@ import {EventProxyService} from "./event-proxy/event-proxy.service";
 import {ScrimCrudService} from "./scrim-crud/scrim-crud.service";
 import {ScrimGroupService} from "./scrim-group/scrim-group.service";
 import {ScrimLogicService} from "./scrim-logic/scrim-logic.service";
+
+/** Minutes before ungrouped players can join a team scrim after the first group is created (issue #655). */
+const TEAM_SCRIM_GROUP_INVITE_DELAY_MINUTES = 2;
 
 @Injectable()
 export class ScrimService {
@@ -68,6 +72,9 @@ export class ScrimService {
             scrim.players[0].group = group;
 
             await this.scrimCrudService.updatePlayer(scrim.id, Object.assign(player, {group}));
+            const opensAt = add(new Date(), {minutes: TEAM_SCRIM_GROUP_INVITE_DELAY_MINUTES});
+            scrim.groupInviteOpensAt = opensAt;
+            await this.scrimCrudService.setGroupInviteOpensAt(scrim.id, opensAt);
         }
 
         await this.eventsService.publish(EventTopic.ScrimCreated, scrim, scrim.id);
@@ -181,6 +188,18 @@ export class ScrimService {
         if (scrim.status !== ScrimStatus.PENDING) throw new RpcException(MatchmakingError.ScrimAlreadyInProgress);
         if (await this.scrimCrudService.playerInAnyScrim(playerId)) throw new RpcException(MatchmakingError.PlayerAlreadyInScrim);
 
+        const joiningWithGroup = Boolean(joinGroup) || Boolean(createGroup);
+        if (
+            !joiningWithGroup
+            && scrim.settings.mode === ScrimMode.TEAMS
+            && scrim.groupInviteOpensAt
+            && new Date() < scrim.groupInviteOpensAt
+        ) {
+            throw new RpcException(MatchmakingError.ScrimGroupInviteWindowActive);
+        }
+
+        const hadNoGroups = Object.keys(this.scrimGroupService.getScrimGroups(scrim)).length === 0;
+
         const player: ScrimPlayer = {
             id: playerId,
             name: playerName,
@@ -190,6 +209,11 @@ export class ScrimService {
         };
 
         await this.scrimCrudService.addPlayerToScrim(scrimId, player);
+        if (hadNoGroups && player.group) {
+            const opensAt = add(new Date(), {minutes: TEAM_SCRIM_GROUP_INVITE_DELAY_MINUTES});
+            scrim.groupInviteOpensAt = opensAt;
+            await this.scrimCrudService.setGroupInviteOpensAt(scrimId, opensAt);
+        }
         scrim.players.push(player);
 
         this.analyticsService


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [GitHub issue #655](https://github.com/SprocketBot/sprocket/issues/655): when someone creates a **team** scrim with a group, random players could fill open slots before teammates could join with the group code.

## Behavior

- When the **first group** appears on a **TEAMS** mode scrim (on create with `createGroup`, or on join with `createGroup`), the scrim stores `groupInviteOpensAt` = now + **2 minutes** (persisted in Redis with the scrim).
- Until that time, **`joinScrim` without a group** is rejected with `MatchmakingError.ScrimGroupInviteWindowActive`.
- Joining with **`joinGroup`** or creating another group with **`createGroup`** is still allowed during the window.
- After the window, ungrouped joins behave as before.
- GraphQL `Scrim` exposes optional `groupInviteOpensAt` so the web client can show a countdown or friendlier copy if desired.

## Proof

- `npm run build --workspace=@sprocketbot/common`
- `npm run build --workspace=core`
- `npm run build --workspace=@sprocketbot/matchmaking-service`
- `REDIS_PASSWORD=test npm test -- --testPathPattern=scrim.service.spec` (matchmaking-service)

**Branch:** `cursor/issue-655-scrim-group-invite-timer-0293` · **Commit:** `76ca2c7d`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e223239-bfe8-4715-b561-20e9d2540293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e223239-bfe8-4715-b561-20e9d2540293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

