### PR TITLE
Make Sprocket authoritative for franchise roster/staff reads (GH-728)

### DIFF
--- a/core/src/franchise/franchise.module.ts
+++ b/core/src/franchise/franchise.module.ts
@@ -1,12 +1,29 @@
 import {forwardRef, Module} from "@nestjs/common";
 import {JwtModule} from "@nestjs/jwt";
+import {TypeOrmModule} from "@nestjs/typeorm";
 import {
     AnalyticsModule, config, EventsModule, NotificationModule,
 } from "@sprocketbot/common";
 
+import {FranchiseLeadershipRole} from "../database/authorization/franchise_leadership_role";
+import {FranchiseLeadershipSeat} from "../database/authorization/franchise_leadership_seat";
+import {FranchiseStaffRole} from "../database/authorization/franchise_staff_role";
+import {FranchiseStaffSeat} from "../database/authorization/franchise_staff_seat";
+import {FranchiseLeadershipAppointment} from "../database/franchise/franchise_leadership_appointment";
+import {FranchiseStaffAppointment} from "../database/franchise/franchise_staff_appointment";
+import {Player} from "../database/franchise/player/player.model";
+import {RosterRole} from "../database/franchise/roster_role";
+import {RosterSlot} from "../database/franchise/roster_slot";
+import {Team} from "../database/franchise/team/team.model";
 import {DatabaseModule} from "../database";
 import {EloConnectorModule} from "../elo/elo-connector";
 import {GameModule} from "../game";
+import {MLE_Player} from "../database/mledb/Player.model";
+import {MLE_Team} from "../database/mledb/Team.model";
+import {MLE_TeamToCaptain} from "../database/mledb/TeamToCaptain.model";
+import {LeagueToSkillGroup} from "../database/mledb-bridge/league_to_skill_group.model";
+import {PlayerToPlayer} from "../database/mledb-bridge/player_to_player.model";
+import {TeamToFranchise} from "../database/mledb-bridge/team_to_franchise.model";
 import {MledbInterfaceModule} from "../mledb";
 import {OrganizationModule} from "../organization/organization.module";
 import {UtilModule} from "../util/util.module";
@@ -22,11 +39,32 @@ import {
 import {PlayerService} from "./player";
 import {PlayerController} from "./player/player.controller";
 import {PlayerResolver} from "./player/player.resolver";
+import {RosterAuthorityService} from "./roster-authority.service";
 import {TeamService} from "./team/team.service";
+
+const rosterAuthorityOrm = TypeOrmModule.forFeature([
+    MLE_Player,
+    MLE_Team,
+    MLE_TeamToCaptain,
+    TeamToFranchise,
+    LeagueToSkillGroup,
+    PlayerToPlayer,
+    Player,
+    RosterRole,
+    RosterSlot,
+    Team,
+    FranchiseStaffAppointment,
+    FranchiseLeadershipAppointment,
+    FranchiseStaffRole,
+    FranchiseStaffSeat,
+    FranchiseLeadershipRole,
+    FranchiseLeadershipSeat,
+]);
 
 @Module({
     imports: [
         DatabaseModule,
+        rosterAuthorityOrm,
         UtilModule,
         NotificationModule,
         EventsModule,
@@ -41,6 +79,7 @@ import {TeamService} from "./team/team.service";
     ],
     providers: [
         PlayerService,
+        RosterAuthorityService,
         GameSkillGroupService,
         GameSkillGroupResolver,
         FranchiseService,
@@ -49,7 +88,7 @@ import {TeamService} from "./team/team.service";
         PlayerResolver,
         TeamService,
     ],
-    exports: [PlayerService, FranchiseService, GameSkillGroupService, TeamService],
+    exports: [PlayerService, FranchiseService, GameSkillGroupService, TeamService, RosterAuthorityService],
     controllers: [FranchiseController, GameSkillGroupController, PlayerController],
 })
 export class FranchiseModule {}

--- a/core/src/franchise/franchise/franchise.service.ts
+++ b/core/src/franchise/franchise/franchise.service.ts
@@ -12,6 +12,7 @@ import {FranchiseProfile} from "$db/franchise/franchise_profile/franchise_profil
 import {MledbPlayerService} from "../../mledb";
 import {MemberService} from "../../organization";
 import {PlayerService} from "../player";
+import {RosterAuthorityService} from "../roster-authority.service";
 
 @Injectable()
 export class FranchiseService {
@@ -23,6 +24,7 @@ export class FranchiseService {
     private readonly sprocketMemberService: MemberService,
     @InjectRepository(FranchiseProfile)
     private readonly franchiseProfileRepository: Repository<FranchiseProfile>,
+    private readonly rosterAuthorityService: RosterAuthorityService,
     ) {}
 
     async getFranchiseProfile(franchiseId: number): Promise<FranchiseProfile> {
@@ -62,6 +64,11 @@ export class FranchiseService {
     }
 
     async getPlayerFranchisesByUserId(userId: number): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
+        const fromSprocket = await this.rosterAuthorityService.getPlayerFranchisesFromSprocket(userId);
+        if (fromSprocket.length > 0) {
+            return fromSprocket;
+        }
+
         const mlePlayer = await this.mledbPlayerService.getMlePlayerBySprocketUser(userId);
 
         const playerId = mlePlayer.id;

--- a/core/src/franchise/franchise/franchise.service.ts
+++ b/core/src/franchise/franchise/franchise.service.ts
@@ -65,10 +65,25 @@ export class FranchiseService {
 
     async getPlayerFranchisesByUserId(userId: number): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
         const fromSprocket = await this.rosterAuthorityService.getPlayerFranchisesFromSprocket(userId);
-        if (fromSprocket.length > 0) {
+
+        let fromMle: CoreOutput<CoreEndpoint.GetPlayerFranchises> = [];
+        try {
+            fromMle = await this.getPlayerFranchisesFromMle(userId);
+        } catch {
+            // No linked MLE player (or other read failure): Sprocket-only is fine.
+        }
+
+        if (fromMle.length === 0) {
             return fromSprocket;
         }
 
+        return this.mergePlayerFranchiseRows(fromSprocket, fromMle);
+    }
+
+    /**
+     * Legacy MLE read path (dual-read with Sprocket until projection/backfill is complete everywhere).
+     */
+    private async getPlayerFranchisesFromMle(userId: number): Promise<CoreOutput<CoreEndpoint.GetPlayerFranchises>> {
         const mlePlayer = await this.mledbPlayerService.getMlePlayerBySprocketUser(userId);
 
         const playerId = mlePlayer.id;
@@ -117,6 +132,46 @@ export class FranchiseService {
             console.error(`Failed to find franchise for team "${team.name}" (player ${playerId}, member ${userId}). Checking staff assignments as fallback:`, error instanceof Error ? error.message : error);
             return this.getFranchisesFromStaffAssignments(playerId, userId);
         }
+    }
+
+    private mergePlayerFranchiseRows(
+        sprocket: CoreOutput<CoreEndpoint.GetPlayerFranchises>,
+        mle: CoreOutput<CoreEndpoint.GetPlayerFranchises>,
+    ): CoreOutput<CoreEndpoint.GetPlayerFranchises> {
+        type Acc = {id: number; name: string; staffByCode: Map<string, {id: number; name: string;}>;};
+        const byFranchiseId = new Map<number, Acc>();
+
+        const mergeRow = (row: {id: number; name: string; staffPositions: Array<{id: number; name: string;}>;}) => {
+            let acc = byFranchiseId.get(row.id);
+            if (!acc) {
+                acc = {
+                    id: row.id,
+                    name: row.name,
+                    staffByCode: new Map(),
+                };
+                byFranchiseId.set(row.id, acc);
+            } else if (!acc.name && row.name) {
+                acc.name = row.name;
+            }
+            for (const sp of row.staffPositions) {
+                if (!acc.staffByCode.has(sp.name)) {
+                    acc.staffByCode.set(sp.name, sp);
+                }
+            }
+        };
+
+        for (const row of sprocket) {
+            mergeRow(row);
+        }
+        for (const row of mle) {
+            mergeRow(row);
+        }
+
+        return [...byFranchiseId.values()].map(acc => ({
+            id: acc.id,
+            name: acc.name,
+            staffPositions: [...acc.staffByCode.values()],
+        }));
     }
 
     /**

--- a/core/src/franchise/player/player.service.ts
+++ b/core/src/franchise/player/player.service.ts
@@ -48,6 +48,7 @@ import {PlatformService} from "../../game";
 import {OrganizationService} from "../../organization";
 import {MemberService} from "../../organization/member/member.service";
 import {GameSkillGroupService} from "../game-skill-group";
+import {RosterAuthorityService} from "../roster-authority.service";
 import type {RankdownJwtPayload} from "./player.types";
 import type {CreatePlayerTuple} from "./player.types";
 
@@ -83,7 +84,18 @@ export class PlayerService {
     private readonly eloConnectorService: EloConnectorService,
     private readonly platformService: PlatformService,
     private readonly analyticsService: AnalyticsService,
+    private readonly rosterAuthorityService: RosterAuthorityService,
     ) {}
+
+    private async syncRosterAuthorityAfterMleSave(mlePlayerId: number): Promise<void> {
+        try {
+            await this.rosterAuthorityService.syncFromMlePlayerId(mlePlayerId);
+        } catch (err) {
+            this.logger.warn(
+                `Roster authority sync failed for MLE player ${mlePlayerId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+    }
 
     async getPlayer(query: FindOneOptions<Player>): Promise<Player> {
         this.logger.debug(`getPlayer: ${JSON.stringify(query)}`);
@@ -339,6 +351,11 @@ export class PlayerService {
                 throw new Error(`Tried updating player with MLEID: ${mleid}, but that MLEID does not yet exist.`);
             }
             await runner.commitTransaction();
+
+            const mleAfter = await this.mle_playerRepository.findOne({where: {mleid} });
+            if (mleAfter) {
+                await this.syncRosterAuthorityAfterMleSave(mleAfter.id);
+            }
         } catch (e) {
             await runner.rollbackTransaction();
             this.logger.error(e);
@@ -375,9 +392,10 @@ export class PlayerService {
         });
 
         if (runner) {
-            await runner.manager.save(player);
+            await runner.manager.save(MLE_Player, updatedPlayer);
         } else {
-            await this.mle_playerRepository.save(player);
+            await this.mle_playerRepository.save(updatedPlayer);
+            await this.syncRosterAuthorityAfterMleSave(updatedPlayer.id);
         }
 
         return updatedPlayer;
@@ -434,6 +452,7 @@ export class PlayerService {
             await runner.manager.save(ptpBridge);
         } else {
             await this.ptpRepo.save(ptpBridge);
+            await this.syncRosterAuthorityAfterMleSave(player.id);
         }
 
         return player;
@@ -788,6 +807,7 @@ export class PlayerService {
                 });
 
                 await this.mle_playerRepository.save(newMlePlayer);
+                await this.syncRosterAuthorityAfterMleSave(newMlePlayer.id);
 
                 this.logger.debug(`Player ${playerDelta.playerId}: Salary update complete`);
             }
@@ -842,6 +862,7 @@ export class PlayerService {
             const mlePlayer = await this.getMlePlayerBySprocketPlayer(sprocPlayerId);
             mlePlayer.salary = salary;
             await this.mle_playerRepository.save(mlePlayer);
+            await this.syncRosterAuthorityAfterMleSave(mlePlayer.id);
             return mlePlayer;
         }
 
@@ -872,6 +893,7 @@ export class PlayerService {
         }
 
         await this.mle_playerRepository.save(player);
+        await this.syncRosterAuthorityAfterMleSave(player.id);
 
         return player;
     }
@@ -907,6 +929,7 @@ export class PlayerService {
         });
 
         await this.mle_playerRepository.save(player);
+        await this.syncRosterAuthorityAfterMleSave(player.id);
 
         // Move player to Waiver Wire
         // TODO fix later when we abstract away from MLE
@@ -954,6 +977,7 @@ export class PlayerService {
         });
 
         await this.mle_playerRepository.save(player);
+        await this.syncRosterAuthorityAfterMleSave(player.id);
         return player;
     }
 
@@ -1268,6 +1292,19 @@ export class PlayerService {
             await runner.commitTransaction();
             this.logger.log(`Transaction committed successfully`);
 
+            const rlPlayers = await this.playerRepository.find({
+                where: {
+                    member: {user: {id: user.id} },
+                    skillGroup: {game: {id: 7} },
+                },
+            });
+            for (const pl of rlPlayers) {
+                const bridge = await this.ptpRepo.findOne({where: {sprocketPlayerId: pl.id} });
+                if (bridge) {
+                    await this.syncRosterAuthorityAfterMleSave(bridge.mledPlayerId);
+                }
+            }
+
             const result = `Successfully created/updated user with ID ${user.id}.`;
             this.logger.log(`=== INTAKE USER COMPLETED ===`);
             this.logger.log(`Result: ${result}`);
@@ -1332,6 +1369,7 @@ export class PlayerService {
         });
         mlePlayer.discordId = newAcct;
         await this.mle_playerRepository.save(mlePlayer);
+        await this.syncRosterAuthorityAfterMleSave(mlePlayer.id);
 
         // Then, follow up with Sprocket.
         const uaa = await this.userAuthRepository.findOneOrFail({
@@ -1351,6 +1389,7 @@ export class PlayerService {
         });
         mlePlayer.teamName = newTeam;
         await this.mle_playerRepository.save(mlePlayer);
+        await this.syncRosterAuthorityAfterMleSave(mlePlayer.id);
     }
 
     async changePlayerName(mleid: number, newName: string): Promise<void> {

--- a/core/src/franchise/roster-authority.service.ts
+++ b/core/src/franchise/roster-authority.service.ts
@@ -1,6 +1,6 @@
 import {Injectable, Logger} from "@nestjs/common";
-import {InjectRepository} from "@nestjs/typeorm";
-import {Repository} from "typeorm";
+import {InjectDataSource, InjectRepository} from "@nestjs/typeorm";
+import {DataSource, Repository} from "typeorm";
 
 import {FranchiseLeadershipAppointment} from "$db/franchise/franchise_leadership_appointment/franchise_leadership_appointment.model";
 import {FranchiseStaffAppointment} from "$db/franchise/franchise_staff_appointment/franchise_staff_appointment.model";
@@ -82,6 +82,8 @@ export class RosterAuthorityService {
     private readonly franchiseLeadershipRoleRepository: Repository<FranchiseLeadershipRole>,
     @InjectRepository(FranchiseLeadershipSeat)
     private readonly franchiseLeadershipSeatRepository: Repository<FranchiseLeadershipSeat>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
     ) {}
 
     /**
@@ -237,8 +239,6 @@ export class RosterAuthorityService {
     }
 
     private async syncStaffAndCaptainFromMle(memberId: number, mlePlayer: MLE_Player): Promise<void> {
-        await this.clearFranchiseStaffForMember(memberId);
-
         const staffTeams = await this.mleTeamRepository.find({
             where: [
                 {franchiseManagerId: mlePlayer.id},
@@ -270,6 +270,9 @@ export class RosterAuthorityService {
             })
             : [];
 
+        const newLeadership: FranchiseLeadershipAppointment[] = [];
+        const newStaff: FranchiseStaffAppointment[] = [];
+
         for (const mleTeam of staffTeams) {
             const bridge = await this.teamToFranchiseRepository.findOne({where: {team: mleTeam.name} });
             if (!bridge) {
@@ -281,7 +284,7 @@ export class RosterAuthorityService {
             if (fmRole && mleTeam.franchiseManagerId === mlePlayer.id) {
                 const seat = await this.franchiseLeadershipSeatRepository.findOne({where: {role: {id: fmRole.id} } });
                 if (seat) {
-                    await this.franchiseLeadershipAppointmentRepository.save(
+                    newLeadership.push(
                         this.franchiseLeadershipAppointmentRepository.create({
                             franchise: {id: franchiseId} as never,
                             member: {id: memberId} as never,
@@ -293,7 +296,7 @@ export class RosterAuthorityService {
             if (gmStaffRole && mleTeam.generalManagerId === mlePlayer.id) {
                 const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: gmStaffRole.id} } });
                 if (seat) {
-                    await this.franchiseStaffAppointmentRepository.save(
+                    newStaff.push(
                         this.franchiseStaffAppointmentRepository.create({
                             franchise: {id: franchiseId} as never,
                             member: {id: memberId} as never,
@@ -304,7 +307,7 @@ export class RosterAuthorityService {
             }
             if (agmStaffRole && agmSeats.length > 0) {
                 if (mleTeam.doublesAssistantGeneralManagerId === mlePlayer.id) {
-                    await this.franchiseStaffAppointmentRepository.save(
+                    newStaff.push(
                         this.franchiseStaffAppointmentRepository.create({
                             franchise: {id: franchiseId} as never,
                             member: {id: memberId} as never,
@@ -314,7 +317,7 @@ export class RosterAuthorityService {
                 }
                 if (mleTeam.standardAssistantGeneralManagerId === mlePlayer.id) {
                     const seat = agmSeats.length > 1 ? agmSeats[1] : agmSeats[0];
-                    await this.franchiseStaffAppointmentRepository.save(
+                    newStaff.push(
                         this.franchiseStaffAppointmentRepository.create({
                             franchise: {id: franchiseId} as never,
                             member: {id: memberId} as never,
@@ -326,7 +329,7 @@ export class RosterAuthorityService {
             if (prStaffRole && mleTeam.prSupportId === mlePlayer.id) {
                 const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: prStaffRole.id} } });
                 if (seat) {
-                    await this.franchiseStaffAppointmentRepository.save(
+                    newStaff.push(
                         this.franchiseStaffAppointmentRepository.create({
                             franchise: {id: franchiseId} as never,
                             member: {id: memberId} as never,
@@ -343,7 +346,7 @@ export class RosterAuthorityService {
             if (!bridge || !captainStaffRole) continue;
             const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: captainStaffRole.id} } });
             if (!seat) continue;
-            await this.franchiseStaffAppointmentRepository.save(
+            newStaff.push(
                 this.franchiseStaffAppointmentRepository.create({
                     franchise: {id: bridge.franchiseId} as never,
                     member: {id: memberId} as never,
@@ -351,34 +354,40 @@ export class RosterAuthorityService {
                 }),
             );
         }
-    }
 
-    private async clearFranchiseStaffForMember(memberId: number): Promise<void> {
-        await this.franchiseStaffAppointmentRepository
-            .createQueryBuilder()
-            .delete()
-            .from(FranchiseStaffAppointment)
-            .where('"memberId" = :memberId', {memberId})
-            .andWhere(
-                `"seatId" IN (SELECT id FROM sprocket.franchise_staff_seat WHERE "roleId" IN `
-                + `(SELECT id FROM sprocket.franchise_staff_role WHERE "gameId" = :gid))`,
-                {gid: ROCKET_LEAGUE_GAME_ID},
-            )
-            .execute();
-
-        const fmRole = await this.franchiseLeadershipRoleRepository.findOne({where: {name: LEADERSHIP_ROLE_FM} });
-        if (fmRole) {
-            await this.franchiseLeadershipAppointmentRepository
+        await this.dataSource.transaction(async em => {
+            await em
                 .createQueryBuilder()
                 .delete()
-                .from(FranchiseLeadershipAppointment)
+                .from(FranchiseStaffAppointment)
                 .where('"memberId" = :memberId', {memberId})
                 .andWhere(
-                    `"seatId" IN (SELECT id FROM sprocket.franchise_leadership_seat WHERE "roleId" = :roleId)`,
-                    {roleId: fmRole.id},
+                    `"seatId" IN (SELECT id FROM sprocket.franchise_staff_seat WHERE "roleId" IN `
+                    + `(SELECT id FROM sprocket.franchise_staff_role WHERE "gameId" = :gid))`,
+                    {gid: ROCKET_LEAGUE_GAME_ID},
                 )
                 .execute();
-        }
+
+            if (fmRole) {
+                await em
+                    .createQueryBuilder()
+                    .delete()
+                    .from(FranchiseLeadershipAppointment)
+                    .where('"memberId" = :memberId', {memberId})
+                    .andWhere(
+                        `"seatId" IN (SELECT id FROM sprocket.franchise_leadership_seat WHERE "roleId" = :roleId)`,
+                        {roleId: fmRole.id},
+                    )
+                    .execute();
+            }
+
+            for (const row of newLeadership) {
+                await em.save(FranchiseLeadershipAppointment, row);
+            }
+            for (const row of newStaff) {
+                await em.save(FranchiseStaffAppointment, row);
+            }
+        });
     }
 
     /**

--- a/core/src/franchise/roster-authority.service.ts
+++ b/core/src/franchise/roster-authority.service.ts
@@ -1,0 +1,491 @@
+import {Injectable, Logger} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import {Repository} from "typeorm";
+
+import {FranchiseLeadershipAppointment} from "$db/franchise/franchise_leadership_appointment/franchise_leadership_appointment.model";
+import {FranchiseStaffAppointment} from "$db/franchise/franchise_staff_appointment/franchise_staff_appointment.model";
+import {Player} from "$db/franchise/player/player.model";
+import {RosterRole} from "$db/franchise/roster_role/roster_role.model";
+import {RosterSlot} from "$db/franchise/roster_slot/roster_slot.model";
+import {Team} from "$db/franchise/team/team.model";
+import {FranchiseLeadershipRole} from "$db/authorization/franchise_leadership_role/franchise_leadership_role.model";
+import {FranchiseLeadershipSeat} from "$db/authorization/franchise_leadership_seat/franchise_leadership_seat.model";
+import {FranchiseStaffRole} from "$db/authorization/franchise_staff_role/franchise_staff_role.model";
+import {FranchiseStaffSeat} from "$db/authorization/franchise_staff_seat/franchise_staff_seat.model";
+import {UserAuthenticationAccount} from "$db/identity/user_authentication_account/user_authentication_account.model";
+import {UserAuthenticationAccountType} from "$db/identity/user_authentication_account/user_authentication_account_type.enum";
+
+import {MLE_Player} from "../database/mledb/Player.model";
+import {MLE_Team} from "../database/mledb/Team.model";
+import {MLE_TeamToCaptain} from "../database/mledb/TeamToCaptain.model";
+import {LeagueToSkillGroup} from "../database/mledb-bridge/league_to_skill_group.model";
+import {PlayerToPlayer} from "../database/mledb-bridge/player_to_player.model";
+import {TeamToFranchise} from "../database/mledb-bridge/team_to_franchise.model";
+
+/** MLE `team.name` values that mean the player is not on a franchise roster slot in Sprocket. */
+const NON_FRANCHISE_ROSTER_TEAM_NAMES = new Set([
+    "FP",
+    "FA",
+    "Pend",
+    "Waivers",
+    "RFA",
+]);
+
+const ROCKET_LEAGUE_GAME_ID = 7;
+
+const STAFF_ROLE_GM = "General Manager";
+const STAFF_ROLE_AGM = "Assistant General Manager";
+const STAFF_ROLE_CAPTAIN = "Captain";
+const STAFF_ROLE_PR = "PR Support";
+const LEADERSHIP_ROLE_FM = "Franchise Manager";
+
+export type PlayerFranchiseRow = {
+    id: number;
+    name: string;
+    staffPositions: Array<{id: number; name: string;}>;
+};
+
+@Injectable()
+export class RosterAuthorityService {
+    private readonly logger = new Logger(RosterAuthorityService.name);
+
+    constructor(
+    @InjectRepository(Player)
+    private readonly playerRepository: Repository<Player>,
+    @InjectRepository(MLE_Player)
+    private readonly mlePlayerRepository: Repository<MLE_Player>,
+    @InjectRepository(MLE_Team)
+    private readonly mleTeamRepository: Repository<MLE_Team>,
+    @InjectRepository(MLE_TeamToCaptain)
+    private readonly mleTeamToCaptainRepository: Repository<MLE_TeamToCaptain>,
+    @InjectRepository(TeamToFranchise)
+    private readonly teamToFranchiseRepository: Repository<TeamToFranchise>,
+    @InjectRepository(LeagueToSkillGroup)
+    private readonly leagueToSkillGroupRepository: Repository<LeagueToSkillGroup>,
+    @InjectRepository(PlayerToPlayer)
+    private readonly playerToPlayerRepository: Repository<PlayerToPlayer>,
+    @InjectRepository(RosterSlot)
+    private readonly rosterSlotRepository: Repository<RosterSlot>,
+    @InjectRepository(RosterRole)
+    private readonly rosterRoleRepository: Repository<RosterRole>,
+    @InjectRepository(Team)
+    private readonly teamRepository: Repository<Team>,
+    @InjectRepository(FranchiseStaffAppointment)
+    private readonly franchiseStaffAppointmentRepository: Repository<FranchiseStaffAppointment>,
+    @InjectRepository(FranchiseLeadershipAppointment)
+    private readonly franchiseLeadershipAppointmentRepository: Repository<FranchiseLeadershipAppointment>,
+    @InjectRepository(FranchiseStaffRole)
+    private readonly franchiseStaffRoleRepository: Repository<FranchiseStaffRole>,
+    @InjectRepository(FranchiseStaffSeat)
+    private readonly franchiseStaffSeatRepository: Repository<FranchiseStaffSeat>,
+    @InjectRepository(FranchiseLeadershipRole)
+    private readonly franchiseLeadershipRoleRepository: Repository<FranchiseLeadershipRole>,
+    @InjectRepository(FranchiseLeadershipSeat)
+    private readonly franchiseLeadershipSeatRepository: Repository<FranchiseLeadershipSeat>,
+    ) {}
+
+    /**
+     * Project MLE roster / staff / captain state into Sprocket after an MLE player row changes.
+     * MLE writes remain a temporary legacy path; Sprocket tables are the read model for franchise APIs.
+     */
+    async syncFromMlePlayerId(mledPlayerId: number): Promise<void> {
+        const mlePlayer = await this.mlePlayerRepository.findOne({where: {id: mledPlayerId} });
+        if (!mlePlayer) {
+            this.logger.warn(`syncFromMlePlayerId: no MLE player ${mledPlayerId}`);
+            return;
+        }
+
+        const bridge = await this.playerToPlayerRepository.findOne({where: {mledPlayerId} });
+        if (!bridge) {
+            this.logger.debug(`syncFromMlePlayerId: no player_to_player bridge for MLE id ${mledPlayerId}`);
+            return;
+        }
+
+        const fullPlayer = await this.playerRepository.findOne({
+            where: {id: bridge.sprocketPlayerId},
+            relations: {
+                member: true,
+                skillGroup: {
+                    game: true,
+                    organization: true,
+                },
+                slot: {
+                    role: true,
+                    team: true,
+                },
+            },
+        });
+        if (!fullPlayer) {
+            this.logger.warn(`syncFromMlePlayerId: no Sprocket player ${bridge.sprocketPlayerId}`);
+            return;
+        }
+
+        if (fullPlayer.skillGroup.game.id !== ROCKET_LEAGUE_GAME_ID) {
+            return;
+        }
+
+        await this.syncRosterSlotFromMle(fullPlayer, mlePlayer);
+        await this.syncStaffAndCaptainFromMle(fullPlayer.member.id, mlePlayer);
+    }
+
+    private async syncRosterSlotFromMle(sprocketPlayer: Player, mlePlayer: MLE_Player): Promise<void> {
+        const teamName = mlePlayer.teamName?.trim() ?? "";
+        if (!teamName || NON_FRANCHISE_ROSTER_TEAM_NAMES.has(teamName)) {
+            await this.clearPlayerRosterSlot(sprocketPlayer.id);
+            return;
+        }
+
+        const tf = await this.teamToFranchiseRepository.findOne({where: {team: teamName} });
+        if (!tf) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: no team_to_franchise for MLE team "${teamName}"; clearing roster slot for player ${sprocketPlayer.id}`,
+            );
+            await this.clearPlayerRosterSlot(sprocketPlayer.id);
+            return;
+        }
+
+        const leagueRow = await this.leagueToSkillGroupRepository.findOne({where: {league: mlePlayer.league} });
+        if (!leagueRow) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: no league_to_skill_group for league ${mlePlayer.league}; skipping slot for player ${sprocketPlayer.id}`,
+            );
+            return;
+        }
+
+        const orgId = sprocketPlayer.skillGroup.organizationId;
+        const franchiseTeam = await this.teamRepository.findOne({
+            where: {
+                franchise: {id: tf.franchiseId},
+                skillGroup: {id: leagueRow.skillGroupId, organization: {id: orgId} },
+            },
+        });
+        if (!franchiseTeam) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: no sprocket.team for franchise ${tf.franchiseId}, skillGroup ${leagueRow.skillGroupId}, org ${orgId}`,
+            );
+            return;
+        }
+
+        const roleCode = mlePlayer.role?.trim();
+        if (!roleCode || roleCode === "NONE") {
+            await this.clearPlayerRosterSlot(sprocketPlayer.id);
+            return;
+        }
+
+        const rosterRole = await this.rosterRoleRepository.findOne({
+            where: {
+                code: roleCode,
+                skillGroup: {id: leagueRow.skillGroupId},
+                organization: {id: orgId},
+            },
+        });
+        if (!rosterRole) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: no roster_role code=${roleCode} skillGroup=${leagueRow.skillGroupId} org=${orgId}`,
+            );
+            return;
+        }
+
+        const targetSlot = await this.rosterSlotRepository.findOne({
+            where: {
+                team: {id: franchiseTeam.id},
+                role: {id: rosterRole.id},
+            },
+            relations: {player: true},
+        });
+        if (!targetSlot) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: no roster_slot for team ${franchiseTeam.id} role ${rosterRole.code}`,
+            );
+            return;
+        }
+
+        if (targetSlot.player && targetSlot.player.id !== sprocketPlayer.id) {
+            this.logger.warn(
+                `syncRosterSlotFromMle: slot team ${franchiseTeam.id} role ${rosterRole.code} already held by player ${targetSlot.player.id}`,
+            );
+            return;
+        }
+
+        await this.detachPlayerFromOtherSlots(sprocketPlayer.id, targetSlot.id);
+
+        if (!targetSlot.player || targetSlot.player.id !== sprocketPlayer.id) {
+            await this.rosterSlotRepository.update(
+                {id: targetSlot.id},
+                {player: {id: sprocketPlayer.id} as Player},
+            );
+        }
+    }
+
+    private async detachPlayerFromOtherSlots(sprocketPlayerId: number, keepSlotId: number): Promise<void> {
+        const occupied = await this.rosterSlotRepository.find({
+            where: {player: {id: sprocketPlayerId} },
+        });
+        for (const slot of occupied) {
+            if (slot.id === keepSlotId) continue;
+            await this.rosterSlotRepository.update({id: slot.id}, {player: null});
+        }
+    }
+
+    private async clearPlayerRosterSlot(sprocketPlayerId: number): Promise<void> {
+        const occupied = await this.rosterSlotRepository.find({
+            where: {player: {id: sprocketPlayerId} },
+        });
+        for (const slot of occupied) {
+            await this.rosterSlotRepository.update({id: slot.id}, {player: null});
+        }
+    }
+
+    private async syncStaffAndCaptainFromMle(memberId: number, mlePlayer: MLE_Player): Promise<void> {
+        await this.clearFranchiseStaffForMember(memberId);
+
+        const staffTeams = await this.mleTeamRepository.find({
+            where: [
+                {franchiseManagerId: mlePlayer.id},
+                {generalManagerId: mlePlayer.id},
+                {doublesAssistantGeneralManagerId: mlePlayer.id},
+                {standardAssistantGeneralManagerId: mlePlayer.id},
+                {prSupportId: mlePlayer.id},
+            ],
+        });
+
+        const fmRole = await this.franchiseLeadershipRoleRepository.findOne({where: {name: LEADERSHIP_ROLE_FM} });
+        const gmStaffRole = await this.franchiseStaffRoleRepository.findOne({
+            where: {name: STAFF_ROLE_GM, game: {id: ROCKET_LEAGUE_GAME_ID} },
+        });
+        const agmStaffRole = await this.franchiseStaffRoleRepository.findOne({
+            where: {name: STAFF_ROLE_AGM, game: {id: ROCKET_LEAGUE_GAME_ID} },
+        });
+        const captainStaffRole = await this.franchiseStaffRoleRepository.findOne({
+            where: {name: STAFF_ROLE_CAPTAIN, game: {id: ROCKET_LEAGUE_GAME_ID} },
+        });
+        const prStaffRole = await this.franchiseStaffRoleRepository.findOne({
+            where: {name: STAFF_ROLE_PR, game: {id: ROCKET_LEAGUE_GAME_ID} },
+        });
+
+        const agmSeats = agmStaffRole
+            ? await this.franchiseStaffSeatRepository.find({
+                where: {role: {id: agmStaffRole.id} },
+                order: {id: "ASC"},
+            })
+            : [];
+
+        for (const mleTeam of staffTeams) {
+            const bridge = await this.teamToFranchiseRepository.findOne({where: {team: mleTeam.name} });
+            if (!bridge) {
+                this.logger.warn(`syncStaffAndCaptainFromMle: no franchise bridge for staff team "${mleTeam.name}"`);
+                continue;
+            }
+            const franchiseId = bridge.franchiseId;
+
+            if (fmRole && mleTeam.franchiseManagerId === mlePlayer.id) {
+                const seat = await this.franchiseLeadershipSeatRepository.findOne({where: {role: {id: fmRole.id} } });
+                if (seat) {
+                    await this.franchiseLeadershipAppointmentRepository.save(
+                        this.franchiseLeadershipAppointmentRepository.create({
+                            franchise: {id: franchiseId} as never,
+                            member: {id: memberId} as never,
+                            seat,
+                        }),
+                    );
+                }
+            }
+            if (gmStaffRole && mleTeam.generalManagerId === mlePlayer.id) {
+                const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: gmStaffRole.id} } });
+                if (seat) {
+                    await this.franchiseStaffAppointmentRepository.save(
+                        this.franchiseStaffAppointmentRepository.create({
+                            franchise: {id: franchiseId} as never,
+                            member: {id: memberId} as never,
+                            seat,
+                        }),
+                    );
+                }
+            }
+            if (agmStaffRole && agmSeats.length > 0) {
+                if (mleTeam.doublesAssistantGeneralManagerId === mlePlayer.id) {
+                    await this.franchiseStaffAppointmentRepository.save(
+                        this.franchiseStaffAppointmentRepository.create({
+                            franchise: {id: franchiseId} as never,
+                            member: {id: memberId} as never,
+                            seat: agmSeats[0],
+                        }),
+                    );
+                }
+                if (mleTeam.standardAssistantGeneralManagerId === mlePlayer.id) {
+                    const seat = agmSeats.length > 1 ? agmSeats[1] : agmSeats[0];
+                    await this.franchiseStaffAppointmentRepository.save(
+                        this.franchiseStaffAppointmentRepository.create({
+                            franchise: {id: franchiseId} as never,
+                            member: {id: memberId} as never,
+                            seat,
+                        }),
+                    );
+                }
+            }
+            if (prStaffRole && mleTeam.prSupportId === mlePlayer.id) {
+                const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: prStaffRole.id} } });
+                if (seat) {
+                    await this.franchiseStaffAppointmentRepository.save(
+                        this.franchiseStaffAppointmentRepository.create({
+                            franchise: {id: franchiseId} as never,
+                            member: {id: memberId} as never,
+                            seat,
+                        }),
+                    );
+                }
+            }
+        }
+
+        const captainRows = await this.mleTeamToCaptainRepository.find({where: {playerId: mlePlayer.id} });
+        for (const cap of captainRows) {
+            const bridge = await this.teamToFranchiseRepository.findOne({where: {team: cap.teamName} });
+            if (!bridge || !captainStaffRole) continue;
+            const seat = await this.franchiseStaffSeatRepository.findOne({where: {role: {id: captainStaffRole.id} } });
+            if (!seat) continue;
+            await this.franchiseStaffAppointmentRepository.save(
+                this.franchiseStaffAppointmentRepository.create({
+                    franchise: {id: bridge.franchiseId} as never,
+                    member: {id: memberId} as never,
+                    seat,
+                }),
+            );
+        }
+    }
+
+    private async clearFranchiseStaffForMember(memberId: number): Promise<void> {
+        await this.franchiseStaffAppointmentRepository
+            .createQueryBuilder()
+            .delete()
+            .from(FranchiseStaffAppointment)
+            .where('"memberId" = :memberId', {memberId})
+            .andWhere(
+                `"seatId" IN (SELECT id FROM sprocket.franchise_staff_seat WHERE "roleId" IN `
+                + `(SELECT id FROM sprocket.franchise_staff_role WHERE "gameId" = :gid))`,
+                {gid: ROCKET_LEAGUE_GAME_ID},
+            )
+            .execute();
+
+        const fmRole = await this.franchiseLeadershipRoleRepository.findOne({where: {name: LEADERSHIP_ROLE_FM} });
+        if (fmRole) {
+            await this.franchiseLeadershipAppointmentRepository
+                .createQueryBuilder()
+                .delete()
+                .from(FranchiseLeadershipAppointment)
+                .where('"memberId" = :memberId', {memberId})
+                .andWhere(
+                    `"seatId" IN (SELECT id FROM sprocket.franchise_leadership_seat WHERE "roleId" = :roleId)`,
+                    {roleId: fmRole.id},
+                )
+                .execute();
+        }
+    }
+
+    /**
+     * Franchises and staff roles for a user from Sprocket (roster_slot + appointments), populated by syncFromMlePlayerId.
+     */
+    async getPlayerFranchisesFromSprocket(userId: number): Promise<PlayerFranchiseRow[]> {
+        const players = await this.playerRepository.find({
+            where: {
+                member: {user: {id: userId} },
+                skillGroup: {game: {id: ROCKET_LEAGUE_GAME_ID} },
+            },
+            relations: {
+                member: true,
+                skillGroup: {game: true},
+                slot: {
+                    team: {
+                        franchise: {profile: true},
+                    },
+                },
+            },
+        });
+
+        if (players.length === 0) {
+            return [];
+        }
+
+        const memberId = players[0].member.id;
+
+        const staffAppts = await this.franchiseStaffAppointmentRepository.find({
+            where: {member: {id: memberId} },
+            relations: {
+                franchise: {profile: true},
+                seat: {role: true},
+            },
+        });
+
+        const leadershipAppts = await this.franchiseLeadershipAppointmentRepository.find({
+            where: {member: {id: memberId} },
+            relations: {
+                franchise: {profile: true},
+                seat: {role: true},
+            },
+        });
+
+        type Entry = {id: number; name: string; staffPositions: Map<string, {id: number; name: string;}>;};
+        const byFranchise = new Map<number, Entry>();
+
+        const ensure = (franchiseId: number, title: string): Entry => {
+            let e = byFranchise.get(franchiseId);
+            if (!e) {
+                e = {id: franchiseId, name: title, staffPositions: new Map()};
+                byFranchise.set(franchiseId, e);
+            }
+            return e;
+        };
+
+        for (const p of players) {
+            const fr = p.slot?.team?.franchise;
+            const title = fr?.profile?.title;
+            if (fr && title) {
+                ensure(fr.id, title);
+            }
+        }
+
+        for (const a of staffAppts) {
+            const title = a.franchise.profile?.title ?? "";
+            const entry = ensure(a.franchise.id, title);
+            const code = this.staffRoleNameToCode(a.seat.role.name);
+            if (code) {
+                entry.staffPositions.set(code, {id: a.seat.role.id, name: code});
+            }
+        }
+
+        for (const a of leadershipAppts) {
+            if (a.seat.role.name !== LEADERSHIP_ROLE_FM) continue;
+            const title = a.franchise.profile?.title ?? "";
+            const entry = ensure(a.franchise.id, title);
+            entry.staffPositions.set("FM", {id: a.seat.role.id, name: "FM"});
+        }
+
+        return [...byFranchise.values()].map(v => ({
+            id: v.id,
+            name: v.name,
+            staffPositions: [...v.staffPositions.values()],
+        }));
+    }
+
+    private staffRoleNameToCode(name: string): "GM" | "AGM" | "CAP" | "PR" | null {
+        if (name === STAFF_ROLE_GM) return "GM";
+        if (name === STAFF_ROLE_AGM) return "AGM";
+        if (name === STAFF_ROLE_CAPTAIN) return "CAP";
+        if (name === STAFF_ROLE_PR || name === "PR_SUPPORT") return "PR";
+        return null;
+    }
+
+    async getLeagueSuspendedFromMle(userId: number): Promise<boolean> {
+        const row = await this.mlePlayerRepository
+            .createQueryBuilder("p")
+            .innerJoin(
+                UserAuthenticationAccount,
+                "uaa",
+                "uaa.accountId = p.discord_id AND uaa.userId = :userId AND uaa.accountType = :atype",
+                {userId, atype: UserAuthenticationAccountType.DISCORD},
+            )
+            .select("p.suspended", "suspended")
+            .getRawOne<{suspended: boolean;}>();
+
+        return row?.suspended === true;
+    }
+}

--- a/reports/issue-728-sprocket-roster-authority.md
+++ b/reports/issue-728-sprocket-roster-authority.md
@@ -1,0 +1,28 @@
+# Issue 728 — Sprocket as roster / staff / suspension read model
+
+## Source of truth (current)
+
+For **Rocket League** (`game.id === 7`), franchise-facing reads should use **Sprocket** first:
+
+- **Active roster slot:** `sprocket.roster_slot` (player ↔ team ↔ `roster_role`), populated from MLE `player.team_name`, `player.league`, `player.role` via `RosterAuthorityService.syncFromMlePlayerId`.
+- **Franchise staff / captain / FM:** `sprocket.franchise_staff_appointment`, `sprocket.franchise_leadership_appointment`, keyed by `member` and franchise, populated from MLE `team` staff columns and `mledb.team_to_captain`.
+- **League suspension (lookup):** `mledb.player.suspended` remains the legacy field; `RosterAuthorityService.getLeagueSuspendedFromMle` exposes it for callers that need it until a first-class Sprocket column exists.
+
+`FranchiseService.getPlayerFranchisesByUserId` uses `getPlayerFranchisesFromSprocket` when any Sprocket data exists; otherwise it falls back to the previous MLE-only path (backfill / cold start).
+
+## Temporary legacy mirror
+
+**MLE** (`mledb.player`, `mledb.team`, `mledb.team_to_captain`) is still written by existing flows (e.g. `PlayerService` rank moves, `forcePlayerToTeam`, bot-era paths). After each relevant `mledb.player` save, core runs `RosterAuthorityService.syncFromMlePlayerId` so Sprocket stays aligned.
+
+**Removal checklist (when bot commands are retired):**
+
+1. Stop writing MLE roster/staff/captain fields; drive `roster_slot` and appointments from Sprocket-native mutations only.
+2. Drop the post-save `syncFromMlePlayerId` hooks from `PlayerService` once MLE is no longer authoritative.
+3. Remove the MLE fallback branch in `FranchiseService.getPlayerFranchisesByUserId`.
+4. Add a Sprocket-native suspension field (or extend member restrictions) and migrate `suspended` reads off MLE.
+
+## Relevant code
+
+- `core/src/franchise/roster-authority.service.ts` — sync + Sprocket franchise aggregation
+- `core/src/franchise/player/player.service.ts` — triggers sync after MLE player saves
+- `core/src/franchise/franchise/franchise.service.ts` — prefers Sprocket for `GetPlayerFranchises`

--- a/reports/issue-728-sprocket-roster-authority.md
+++ b/reports/issue-728-sprocket-roster-authority.md
@@ -8,7 +8,9 @@ For **Rocket League** (`game.id === 7`), franchise-facing reads should use **Spr
 - **Franchise staff / captain / FM:** `sprocket.franchise_staff_appointment`, `sprocket.franchise_leadership_appointment`, keyed by `member` and franchise, populated from MLE `team` staff columns and `mledb.team_to_captain`.
 - **League suspension (lookup):** `mledb.player.suspended` remains the legacy field; `RosterAuthorityService.getLeagueSuspendedFromMle` exposes it for callers that need it until a first-class Sprocket column exists.
 
-`FranchiseService.getPlayerFranchisesByUserId` uses `getPlayerFranchisesFromSprocket` when any Sprocket data exists; otherwise it falls back to the previous MLE-only path (backfill / cold start).
+`FranchiseService.getPlayerFranchisesByUserId` **dual-reads**: it loads Sprocket and MLE (when an MLE player exists), then **merges by franchise id** so partial Sprocket projection cannot hide legacy-only franchises or staff roles. If there is no MLE row, Sprocket-only is returned.
+
+Staff appointment replacement from MLE runs in a **single DB transaction** (delete RL staff/FM appointments for the member, then insert the computed replacement set) so a failure cannot leave the member with appointments wiped.
 
 ## Temporary legacy mirror
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a **Sprocket-first read path** for franchise roster slots, staff/captain roles, and documents the **temporary MLE legacy mirror** for issue [#728](https://github.com/SprocketBot/sprocket/issues/728).

## What changed

- **`RosterAuthorityService`** (`core/src/franchise/roster-authority.service.ts`): After MLE `player` changes, projects state into `sprocket.roster_slot` (via `mledb_bridge.team_to_franchise` + `league_to_skill_group` + MLE `role` codes) and into `franchise_staff_appointment` / `franchise_leadership_appointment` (from MLE `team` staff columns, `team_to_captain`, and PR support when a matching `franchise_staff_role` named `PR Support` exists). **RL staff/FM replacement runs in one DB transaction** (compute replacement set, delete scoped rows, insert replacements) so partial failure cannot leave appointments wiped.
- **`PlayerService`**: Runs sync after MLE player saves (and after `updatePlayer` / `intakeUser` commits so the bridge row exists).
- **`FranchiseService.getPlayerFranchisesByUserId`**: **Dual-reads** Sprocket and MLE (when an MLE player exists) and **merges by franchise id** so partial Sprocket projection cannot hide legacy-only franchises or staff roles. If there is no MLE row, Sprocket-only is returned.
- **`reports/issue-728-sprocket-roster-authority.md`**: States source of truth, legacy mirror, dual-read, transactional staff replacement, and removal checklist.

## Suspension

`getLeagueSuspendedFromMle` is added for callers that need `mledb.player.suspended` until a first-class Sprocket field exists (not wired into GraphQL in this PR).

## Proof

- `npm run build --workspace=core` (passes).

## Follow-ups (not in this PR)

- One-shot backfill job for existing production rows where MLE was updated outside these code paths.
- Native Sprocket suspension storage and retiring MLE `suspended`.
- RFA as more than a pseudo team name if product requires it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ace1d90-58d5-4a81-94c1-ba147d47426f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ace1d90-58d5-4a81-94c1-ba147d47426f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

