### PR TITLE
feature: Add scrim points and eligibility date to web client

### DIFF
--- a/clients/web/src/lib/api/queries/CurrentUser.store.ts
+++ b/clients/web/src/lib/api/queries/CurrentUser.store.ts
@@ -6,15 +6,20 @@ export interface CurrentUserResult {
         id: number;
         members: Array<{
             id: number;
-            players: {
+            players: Array<{
                 skillGroup: {
+                    profile: {
+                        description: string;
+                    };
                     game: {
                         title: string;
                     };
                 };
                 franchisePositions: string[];
                 franchiseName: string;
-            };
+                scrimPoints: number | null;
+                eligibilityEndDate: string | null;
+            }>;
         }>;
     };
 }
@@ -41,6 +46,8 @@ export class CurrentUserStore extends QueryStore<CurrentUserResult, CurrentUserV
             }
             franchisePositions
             franchiseName
+            scrimPoints
+            eligibilityEndDate
           }
         }
       }

--- a/clients/web/src/routes/scrims/index.svelte
+++ b/clients/web/src/routes/scrims/index.svelte
@@ -25,6 +25,25 @@
     let currentUserFranchises: string[] | undefined;
     $: currentUserFranchises = $currentUser.data?.me?.members?.flatMap(m => m.players.flatMap(p => p.franchiseName as string) as string[]);
 
+    let scrimPoints: number | null | undefined;
+    $: scrimPoints = $currentUser.data?.me?.members?.[0]?.players?.[0]?.scrimPoints;
+
+    let eligibilityEndDate: string | null | undefined;
+    $: eligibilityEndDate = $currentUser.data?.me?.members?.[0]?.players?.[0]?.eligibilityEndDate;
+
+    $: eligibilityStatus = (() => {
+        if (scrimPoints === undefined) return { label: "Loading...", color: "text-gray-400" };
+        if (scrimPoints !== null && scrimPoints >= 30) {
+            if (eligibilityEndDate) {
+                const date = new Date(eligibilityEndDate);
+                const formatted = date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+                return { label: `Eligible until ${formatted}`, color: "text-green-400" };
+            }
+            return { label: "Eligible", color: "text-green-400" };
+        }
+        return { label: `${scrimPoints ?? 0}/30 points`, color: "text-yellow-400" };
+    })();
+
     function calculateActivityChange() {
         const prev = metrics.previousCompletedScrims ?? 0;
         const cur = metrics?.completedScrims ?? 0;
@@ -71,5 +90,14 @@
     <DashboardNumberCard title="Active Players"
                          value={metrics?.totalPlayers ?? 0}
     />
+    <DashboardCard class="col-span-6 xl:col-span-3">
+        <h3 class="text-lg font-semibold text-sprocket mb-2">Scrim Eligibility</h3>
+        <div class="flex flex-col gap-1">
+            <span class="text-3xl font-bold {eligibilityStatus.color}">{eligibilityStatus.label}</span>
+            {#if scrimPoints !== undefined && scrimPoints !== null}
+                <span class="text-sm text-gray-400">{scrimPoints} points in last 30 days</span>
+            {/if}
+        </div>
+    </DashboardCard>
 
 </DashboardLayout>

--- a/core/src/franchise/franchise.module.ts
+++ b/core/src/franchise/franchise.module.ts
@@ -9,6 +9,7 @@ import {EloConnectorModule} from "../elo/elo-connector";
 import {GameModule} from "../game";
 import {MledbInterfaceModule} from "../mledb";
 import {OrganizationModule} from "../organization/organization.module";
+import {SchedulingModule} from "../scheduling/scheduling.module";
 import {UtilModule} from "../util/util.module";
 import {FranchiseController} from "./franchise/franchise.controller";
 import {FranchiseResolver} from "./franchise/franchise.resolver";
@@ -33,6 +34,7 @@ import {TeamService} from "./team/team.service";
         GameModule,
         forwardRef(() => OrganizationModule),
         forwardRef(() => MledbInterfaceModule),
+        forwardRef(() => SchedulingModule),
         EloConnectorModule,
         AnalyticsModule,
         JwtModule.register({

--- a/core/src/franchise/player/player.resolver.ts
+++ b/core/src/franchise/player/player.resolver.ts
@@ -10,6 +10,7 @@ import {
   Resolver,
   Root,
 } from '@nestjs/graphql';
+import { GraphQLISODateTime } from '@nestjs/graphql';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   EventsService,
@@ -49,6 +50,7 @@ import { parseAndValidateCsv } from '../../util/csv-parse';
 import { PopulateService } from '../../util/populate/populate.service';
 import { FranchiseService } from '../franchise';
 import { GameSkillGroupService } from '../game-skill-group';
+import { EligibilityService } from '../../scheduling/eligibility/eligibility.service';
 import { PlayerService } from './player.service';
 import {
   ChangePlayerNameResult,
@@ -83,6 +85,7 @@ export class PlayerResolver {
     private readonly playerService: PlayerService,
     private readonly franchiseService: FranchiseService,
     private readonly skillGroupService: GameSkillGroupService,
+    private readonly eligibilityService: EligibilityService,
     private readonly eventsService: EventsService,
     private readonly notificationService: NotificationService,
     private readonly eloConnectorService: EloConnectorService,
@@ -135,6 +138,26 @@ export class PlayerResolver {
     if (player.member) return player.member;
 
     return this.popService.populateOneOrFail(Player, player, 'member');
+  }
+
+  @ResolveField(() => Int, { nullable: true })
+  async scrimPoints(@Root() player: Player): Promise<number | null> {
+    try {
+      return this.eligibilityService.getEligibilityPointsForPlayer(player.id);
+    } catch (error) {
+      this.logger.warn(`Failed to get scrim points for player ${player.id}: ${error}`);
+      return null;
+    }
+  }
+
+  @ResolveField(() => GraphQLISODateTime, { nullable: true })
+  async eligibilityEndDate(@Root() player: Player): Promise<Date | null> {
+    try {
+      return this.eligibilityService.getEligibilityEndDate(player.id);
+    } catch (error) {
+      this.logger.warn(`Failed to get eligibility end date for player ${player.id}: ${error}`);
+      return null;
+    }
   }
 
   @Mutation(() => ChangePlayerSkillGroupResult)


### PR DESCRIPTION
## Summary
Add a player's current scrim points and eligibility end date to the web client dashboard, so players can see their scrim eligibility status at a glance.

## Context
Players need to know their scrim eligibility status (based on a rolling 30-day points window) to understand whether they can join scrims. The eligibility calculation logic already exists in the codebase via `EligibilityService`, and the data is stored in the sprocket schema's `eligibility_data` table. However, this information was not exposed through GraphQL or displayed in the web client.

Note: The MLEDB schema's `eligibility_data` is still written during scrim finalization for legacy compatibility. This PR reads from the sprocket schema; bringing the two into parity is out of scope for this change.

## Changes
- Added `scrimPoints` and `eligibilityEndDate` resolve fields on the `Player` GraphQL type
- Imported `SchedulingModule` into `FranchiseModule` to access `EligibilityService`
- Updated the `CurrentUser` GraphQL query to fetch the new eligibility fields
- Added a "Scrim Eligibility" dashboard card to the scrims index page showing:
  - Green "Eligible until {date}" when the player has 30+ points
  - Yellow "{points}/30 points" when below the threshold
- Fixed a pre-existing type bug where `players` in `CurrentUserResult` was typed as a single object instead of an array

### Key Implementation Details
- Both resolve fields are nullable and return `null` on error rather than failing the entire query
- `scrimPoints` uses `EligibilityService.getEligibilityPointsForPlayer()` (rolling 30-day window)
- `eligibilityEndDate` uses `EligibilityService.getEligibilityEndDate()` (projects when points drop below 30)
- The dashboard card reads from the first player of the first member on the current user (matching existing patterns in the codebase)

## Testing
```bash
# Start infrastructure
npm run dev:up

# Build and start core
npm run build --workspace=core
cd core && node dist/main.js

# Start web client
npm run dev --workspace=clients/web

# Verify GraphQL query returns new fields
curl http://localhost:3001/graphql \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer <your-token>' \
  -d '{"query": "{ me { members { players { id scrimPoints eligibilityEndDate } } } }"}'

# Visit http://localhost:3000/scrims and verify the Scrim Eligibility card displays
```

## Links
- Related: MLEDB/sprocket eligibility data parity (separate PR)
