### PR TITLE
Add MLEDB write classification guardrail

### DIFF
--- a/core/src/mledb/index.ts
+++ b/core/src/mledb/index.ts
@@ -2,3 +2,4 @@ export * from "./mledb-interface.module";
 export * from "./mledb-player";
 export * from "./mledb-player-account";
 export * from "./mledb-scrim";
+export * from "./mledb-write-classification";

--- a/core/src/mledb/mledb-write-classification.spec.ts
+++ b/core/src/mledb/mledb-write-classification.spec.ts
@@ -1,0 +1,60 @@
+import {
+    assertMledbWriteCanBeGated,
+    getMledbWriteClassification,
+    getMledbWriteClassificationsByCategory,
+    getMledbWritesBlockedFromGating,
+    MLEDB_WRITE_CLASSIFICATIONS,
+    MledbWriteReplacementReadiness,
+    MledbWriteRetirementCategory,
+} from "./mledb-write-classification";
+
+describe("MLEDB write classification", () => {
+    it("records a non-empty classification ledger with unique keys", () => {
+        expect(MLEDB_WRITE_CLASSIFICATIONS.length).toBeGreaterThan(0);
+
+        const keys = MLEDB_WRITE_CLASSIFICATIONS.map((classification) => classification.key);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("marks operational MLEDB mirrors as replacement-first before gating", () => {
+        const blockedWrites = getMledbWritesBlockedFromGating();
+        const blockedKeys = blockedWrites.map((classification) => classification.key);
+
+        expect(blockedKeys).toEqual(expect.arrayContaining([
+            "franchise.player.createPlayer.mledbBridge",
+            "franchise.player.updateSkillGroupAndSalary.mledbMirror",
+            "mledb.ncpTeamRoleUsage.writeMledbFirst",
+            "scheduling.match.reportCardLegacyMirror",
+        ]));
+
+        for (const classification of blockedWrites) {
+            expect(classification.replacementFirst).toBe(true);
+            expect(classification.readiness).toBe(MledbWriteReplacementReadiness.ReplacementNeededBeforeGating);
+            expect(classification.verification.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("allows read-only migration bootstrap writes to remain operator tooling", () => {
+        const bootstrapWrites = getMledbWriteClassificationsByCategory(MledbWriteRetirementCategory.ReadOnlyMigrationBootstrap);
+
+        expect(bootstrapWrites).toHaveLength(1);
+        expect(bootstrapWrites[0].key).toBe("mledb.backfillBridge");
+        expect(bootstrapWrites[0].replacementFirst).toBe(false);
+        expect(bootstrapWrites[0].readiness).toBe(MledbWriteReplacementReadiness.NoRuntimeGateNeeded);
+    });
+
+    it("throws when a replacement-first write is gated before its replacement is ready", () => {
+        expect(() => assertMledbWriteCanBeGated("mledb.ncpTeamRoleUsage.writeMledbFirst"))
+            .toThrow("MLEDB write cannot be gated before replacement is ready: mledb.ncpTeamRoleUsage.writeMledbFirst");
+    });
+
+    it("does not throw for non-runtime bootstrap writes", () => {
+        expect(() => assertMledbWriteCanBeGated("mledb.backfillBridge")).not.toThrow();
+    });
+
+    it("throws for unknown write classifications", () => {
+        expect(getMledbWriteClassification("missing.write.path")).toBeUndefined();
+        expect(() => assertMledbWriteCanBeGated("missing.write.path"))
+            .toThrow("Unknown MLEDB write classification: missing.write.path");
+    });
+});

--- a/core/src/mledb/mledb-write-classification.ts
+++ b/core/src/mledb/mledb-write-classification.ts
@@ -1,0 +1,138 @@
+export enum MledbWriteRetirementCategory {
+    RequiredCompatibilityMirror = "required_compatibility_mirror",
+    ValidationOnlyMirror = "validation_only_mirror",
+    RemovableLegacyWrite = "removable_legacy_write",
+    ReadOnlyMigrationBootstrap = "read_only_migration_bootstrap",
+    NativeSprocketMemberOrgBound = "native_sprocket_member_org_bound",
+}
+
+export enum MledbWriteReplacementReadiness {
+    ReplacementReady = "replacement_ready",
+    ReplacementNeededBeforeGating = "replacement_needed_before_gating",
+    NoRuntimeGateNeeded = "no_runtime_gate_needed",
+}
+
+export interface MledbWriteClassification {
+    readonly key: string;
+    readonly category: MledbWriteRetirementCategory;
+    readonly readiness: MledbWriteReplacementReadiness;
+    readonly replacementFirst: boolean;
+    readonly currentWritePath: string;
+    readonly sprocketReplacement: string;
+    readonly verification: readonly string[];
+    readonly notes: string;
+}
+
+export const MLEDB_WRITE_CLASSIFICATIONS: readonly MledbWriteClassification[] = [
+    {
+        key: "franchise.player.createPlayer.mledbBridge",
+        category: MledbWriteRetirementCategory.RequiredCompatibilityMirror,
+        readiness: MledbWriteReplacementReadiness.ReplacementNeededBeforeGating,
+        replacementFirst: true,
+        currentWritePath: "PlayerService.createPlayer creates Sprocket player state and MLEDB bridge/account compatibility rows.",
+        sprocketReplacement: "Canonical player plus platform account link write path that no longer needs an MLEDB player mirror.",
+        verification: [
+            "Unit test player creation without requiring MLEDB writes.",
+            "Backfill comparison proves every active MLEDB player maps to one Sprocket player.",
+            "Dataset player/account-link outputs have v2 API parity.",
+        ],
+        notes: "Do not gate until player identity/account-link replacements are live and dataset parity is proven.",
+    },
+    {
+        key: "franchise.player.updateSkillGroupAndSalary.mledbMirror",
+        category: MledbWriteRetirementCategory.RequiredCompatibilityMirror,
+        readiness: MledbWriteReplacementReadiness.ReplacementNeededBeforeGating,
+        replacementFirst: true,
+        currentWritePath: "Sprocket player skill group and salary changes are mirrored to MLEDB for compatibility.",
+        sprocketReplacement: "Canonical Sprocket/v2 player league participation, skill group, salary, and public dataset/API read model.",
+        verification: [
+            "Unit test skill group and salary update behavior against Sprocket state.",
+            "Daily comparison between MLEDB exports and Sprocket/v2 read model.",
+            "Public players/eligibility datasets match v2 API outputs before mirror removal.",
+        ],
+        notes: "This is operationally important because public exports and legacy tooling still consume MLEDB-shaped player data.",
+    },
+    {
+        key: "mledb.ncpTeamRoleUsage.writeMledbFirst",
+        category: MledbWriteRetirementCategory.RequiredCompatibilityMirror,
+        readiness: MledbWriteReplacementReadiness.ReplacementNeededBeforeGating,
+        replacementFirst: true,
+        currentWritePath: "NCP team role usage resolver writes MLEDB first and updates Sprocket best-effort.",
+        sprocketReplacement: "Canonical role assignment or roster role usage write path in Sprocket/v2, with MLEDB reduced to validation/export only.",
+        verification: [
+            "Unit test role usage writes against canonical Sprocket state.",
+            "Comparison report for MLEDB team_role_usage versus Sprocket roster role usage.",
+            "Staff acceptance test for NCP correction workflow in Sprocket UI/API.",
+        ],
+        notes: "This is a high-priority replacement because it writes legacy state before canonical Sprocket state today.",
+    },
+    {
+        key: "scheduling.match.reportCardLegacyMirror",
+        category: MledbWriteRetirementCategory.ValidationOnlyMirror,
+        readiness: MledbWriteReplacementReadiness.ReplacementNeededBeforeGating,
+        replacementFirst: true,
+        currentWritePath: "Match/report-card workflows still mirror or correct MLEDB match/report-card state for legacy compatibility.",
+        sprocketReplacement: "Canonical result submission plus replay evidence workflow, with report cards treated as derived or sunset artifacts.",
+        verification: [
+            "Result submission lifecycle tests cover reset/correction paths.",
+            "Replay evidence and report-card comparison proves external outputs remain available.",
+            "Staff smoke test validates disputed/incorrect result correction without MLEDB authority.",
+        ],
+        notes: "Do not remove while report cards or datasets still depend on legacy match/report-card state.",
+    },
+    {
+        key: "mledb.backfillBridge",
+        category: MledbWriteRetirementCategory.ReadOnlyMigrationBootstrap,
+        readiness: MledbWriteReplacementReadiness.NoRuntimeGateNeeded,
+        replacementFirst: false,
+        currentWritePath: "Bridge backfill scripts write mapping rows that connect MLEDB identities to Sprocket identities.",
+        sprocketReplacement: "Explicit migration mapping tables retained until all legacy ID references are retired.",
+        verification: [
+            "Backfill idempotency checks pass.",
+            "Mapping count and orphan checks are clean.",
+            "No production request path depends on running the backfill.",
+        ],
+        notes: "This should remain available as an operator tool, not a live operational write path.",
+    },
+    {
+        key: "organization.memberRestriction.nativeSprocket",
+        category: MledbWriteRetirementCategory.NativeSprocketMemberOrgBound,
+        readiness: MledbWriteReplacementReadiness.ReplacementNeededBeforeGating,
+        replacementFirst: true,
+        currentWritePath: "Member restrictions are native Sprocket writes but still use organization/member abstractions.",
+        sprocketReplacement: "Queue ban, eligibility status, or exception-ticket write path against player/account/role concepts.",
+        verification: [
+            "Restriction lifecycle tests cover create, expire, and authorization behavior.",
+            "Migration comparison maps member restrictions to player/account-level restrictions.",
+            "Staff smoke test validates restrictions without organization/member IDs.",
+        ],
+        notes: "Not an MLEDB write, but it must be replaced before the v2 model can fully remove organization/member.",
+    },
+];
+
+export function getMledbWriteClassification(key: string): MledbWriteClassification | undefined {
+    return MLEDB_WRITE_CLASSIFICATIONS.find((classification) => classification.key === key);
+}
+
+export function getMledbWriteClassificationsByCategory(category: MledbWriteRetirementCategory): readonly MledbWriteClassification[] {
+    return MLEDB_WRITE_CLASSIFICATIONS.filter((classification) => classification.category === category);
+}
+
+export function getMledbWritesBlockedFromGating(): readonly MledbWriteClassification[] {
+    return MLEDB_WRITE_CLASSIFICATIONS.filter((classification) => (
+        classification.replacementFirst
+        && classification.readiness === MledbWriteReplacementReadiness.ReplacementNeededBeforeGating
+    ));
+}
+
+export function assertMledbWriteCanBeGated(key: string): void {
+    const classification = getMledbWriteClassification(key);
+
+    if (classification === undefined) {
+        throw new Error(`Unknown MLEDB write classification: ${key}`);
+    }
+
+    if (classification.replacementFirst && classification.readiness === MledbWriteReplacementReadiness.ReplacementNeededBeforeGating) {
+        throw new Error(`MLEDB write cannot be gated before replacement is ready: ${key}`);
+    }
+}


### PR DESCRIPTION
## Summary
Add a non-disruptive MLEDB write classification guardrail so replacement-first migration decisions are explicit and unit-tested before any legacy
  writes are gated.

## Context
As part of the MLE platform retirement work, we need to move MLEDB writes behind Sprocket replacements incrementally. The league still needs to op
  erate during the migration, so we should not gate or disable legacy writes until the replacement path is live, tested, and accepted.

This PR creates a small code-level ledger for current MLEDB/Sprocket compatibility writes and marks which ones are blocked from gating until repla
  cement readiness is proven.

## Changes
- Added `mledb-write-classification` definitions for MLEDB retirement categories and replacement readiness states.
- Added classifications for current compatibility/migration paths, including player bridge writes, skill group/salary mirrors, NCP team role usage
  , report-card/match mirrors, bridge backfills, and member-restriction replacement needs.
- Added helper functions to look up classifications, list writes blocked from gating, and fail fast if a replacement-first write is gated too earl
  y.
- Exported the helper from the MLEDB module barrel.
- Added unit tests for the classification ledger and gating assertions.

### Key Implementation Details
This PR intentionally does not change runtime behavior. It does not gate any MLEDB writes yet. It only records migration readiness and exposes ass
  ertions that future cutover work can use once replacement paths are implemented.

## Use Cases
- Identify which MLEDB compatibility writes cannot be gated yet.
- Make replacement-first requirements reviewable in code.
- Provide a tested guardrail for future incremental cutovers.
- Keep bridge/backfill tooling distinct from live operational write paths.

## Testing
```bash
cd core
npx jest src/mledb/mledb-write-classification.spec.ts --runInBand
npm run build

Verified locally:
• Targeted Jest suite passed: 6 tests.
• Core build passed.