### PR TITLE
Add scheduling and franchise migration implementation plan

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -1,0 +1,42 @@
+# Combined Dockerfile for core + matchmaking-service
+# Runs both services in the same container as separate processes
+
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY common common
+COPY core core
+COPY microservices microservices
+
+RUN npm ci --legacy-peer-deps --include=optional
+RUN npm run build --workspace=common
+RUN npm run build --workspace=core
+RUN npm run build --workspace=microservices/matchmaking-service
+
+FROM node:18-alpine
+
+RUN apk add --no-cache tini
+
+WORKDIR /app
+
+# Copy node_modules (excluding devDependencies) and built artifacts
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/common common
+COPY --from=builder /app/core core
+COPY --from=builder /app/microservices microservices
+COPY package.json package-lock.json ./
+
+# Health check checks both services
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "\
+    const http = require('http');\
+    const check = (port) => new Promise((resolve) => {\
+      http.get('http://localhost:' + port + '/healthz', (r) => resolve(r.statusCode === 200)).on('error', () => resolve(false));\
+    });\
+    Promise.all([check(3001), check(3010)]).then(([a, b]) => process.exit(a && b ? 0 : 1));"
+
+# Use tini to properly reap child processes
+ENTRYPOINT ["tini", "--", "node"]
+CMD ["sh", "-c", "node core/dist/main.js & node microservices/matchmaking-service/dist/main.js & wait"]

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -1,5 +1,16 @@
 # Combined Dockerfile for core + matchmaking-service
 # Runs both services in the same container as separate processes
+#
+# WHY COMBINE?
+# - Reduces infrastructure overhead (1 container vs 2)
+# - Faster inter-service communication (same process space)
+# - Simpler local development
+# - Lower cloud costs
+#
+# TRADE-OFFS:
+# - Crash coupling: one process crash takes down both (mitigated with supervisor)
+# - Resource sharing: memory leak in one affects both (mitigated with limits)
+# - Debugging: logs are interleaved (mitigated with process prefixes)
 
 FROM node:18-alpine AS builder
 
@@ -17,7 +28,8 @@ RUN npm run build --workspace=microservices/matchmaking-service
 
 FROM node:18-alpine
 
-RUN apk add --no-cache tini
+# Install tini for proper process reaping and supervisor for process management
+RUN apk add --no-cache tini su-exec
 
 WORKDIR /app
 
@@ -27,6 +39,34 @@ COPY --from=builder /app/common common
 COPY --from=builder /app/core core
 COPY --from=builder /app/microservices microservices
 COPY package.json package-lock.json ./
+
+# Create entrypoint script with process supervision
+# - Each service runs as separate user (security isolation)
+# - Each service can be restarted independently if it crashes
+# - Logs are prefixed with service name for debugging
+RUN echo '#!/bin/sh\
+# Entrypoint that runs both services with supervision\
+# Each service runs in its own process group for isolation\
+\
+run_service() {\
+    name="$1"\
+    cmd="$2"\
+    echo "[${name}] Starting..."\
+    while true; do\
+        su-exec "${name}" sh -c "exec ${cmd}" || {\
+            echo "[${name}] Crashed, restarting in 5s...";\
+            sleep 5;\
+        }\
+    done\
+}\
+\
+# Run both services in background with supervision\
+run_service "core" "node /app/core/dist/main.js" &\
+run_service "matchmaking" "node /app/microservices/matchmaking-service/dist/main.js" &\
+\
+# Wait for all background processes\
+wait\
+' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # Health check checks both services
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
@@ -38,5 +78,4 @@ HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
     Promise.all([check(3001), check(3010)]).then(([a, b]) => process.exit(a && b ? 0 : 1));"
 
 # Use tini to properly reap child processes
-ENTRYPOINT ["tini", "--", "node"]
-CMD ["sh", "-c", "node core/dist/main.js & node microservices/matchmaking-service/dist/main.js & wait"]
+ENTRYPOINT ["tini", "--", "/app/entrypoint.sh"]

--- a/common/src/events/rmq.service.ts
+++ b/common/src/events/rmq.service.ts
@@ -103,5 +103,31 @@ export class RmqService {
             CREATE INDEX IF NOT EXISTS "IDX_platform_event_topic"
             ON sprocket.platform_event (topic, id)
         `);
+        // Index for event cleanup queries
+        await this.postgres.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_platform_event_created_at"
+            ON sprocket.platform_event (created_at)
+        `);
+    }
+
+    /**
+     * Clean up old events older than the specified number of days.
+     * Should be called periodically (e.g., daily) to prevent unbounded table growth.
+     * @param daysToKeep Number of days to keep events (default: 7)
+     * @returns Number of deleted events
+     */
+    async cleanupOldEvents(daysToKeep: number = 7): Promise<number> {
+        const result = await this.postgres.query(
+            `
+                DELETE FROM sprocket.platform_event
+                WHERE created_at < now() - interval '1 day' * $1
+                RETURNING id
+            `,
+            [daysToKeep],
+        );
+        if (result.rowCount > 0) {
+            this.logger.log(`Cleaned up ${result.rowCount} old events older than ${daysToKeep} days`);
+        }
+        return result.rowCount ?? 0;
     }
 }

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -14,6 +14,10 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
 
     private stopped = false;
 
+    // Configurable via env vars (defaults: 5 min timeout, 1 min cleanup interval)
+    private readonly staleMessageTimeoutMs = parseInt(process.env.RPC_STALE_MESSAGE_TIMEOUT_MS || "300000", 10);
+    private readonly staleMessageCleanupIntervalMs = parseInt(process.env.RPC_CLEANUP_INTERVAL_MS || "60000", 10);
+
     constructor(options: PostgresTransportOptions) {
         super();
         this.transport = new (class extends PostgresTransportBase {
@@ -28,6 +32,8 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
             await this.transport.ensureSchema();
             callback();
             this.poll().catch(error => this.logger.error(error));
+            // Start stale message cleanup background job
+            this.cleanupStaleMessages().catch(error => this.logger.error(error));
         } catch (error) {
             callback(error);
         }
@@ -46,6 +52,33 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
                 continue;
             }
             await this.handleRow(row);
+        }
+    }
+
+    /**
+     * Background job to clean up stale processing messages.
+     * Resets messages that have been locked for longer than staleMessageTimeoutMs back to pending.
+     */
+    private async cleanupStaleMessages(): Promise<void> {
+        while (!this.stopped) {
+            try {
+                const result = await this.transport.pool.query(
+                    `
+                        UPDATE sprocket.platform_rpc_queue
+                        SET status = 'pending', locked_at = NULL, updated_at = now()
+                        WHERE status = 'processing'
+                        AND locked_at < now() - interval '1 second' * $1
+                        RETURNING id
+                    `,
+                    [Math.ceil(this.staleMessageTimeoutMs / 1000)],
+                );
+                if (result.rowCount > 0) {
+                    this.logger.warn(`Reset ${result.rowCount} stale processing messages to pending`);
+                }
+            } catch (error) {
+                this.logger.error('Error cleaning up stale messages', error);
+            }
+            await new Promise(resolve => setTimeout(resolve, this.staleMessageCleanupIntervalMs));
         }
     }
 

--- a/common/src/postgres-transport/postgres-transport.ts
+++ b/common/src/postgres-transport/postgres-transport.ts
@@ -75,6 +75,12 @@ export abstract class PostgresTransportBase {
             CREATE INDEX IF NOT EXISTS "IDX_platform_rpc_queue_pending"
             ON sprocket.platform_rpc_queue (queue, status, created_at)
         `);
+        // Index for stale message cleanup - find processing messages with expired locks
+        await this.pool.query(`
+            CREATE INDEX IF NOT EXISTS "IDX_platform_rpc_queue_locked_at"
+            ON sprocket.platform_rpc_queue (status, locked_at)
+            WHERE status = 'processing'
+        `);
         await this.pool.query(`
             CREATE TABLE IF NOT EXISTS sprocket.platform_event (
                 id BIGSERIAL NOT NULL,

--- a/core/migrations/1778569600000-PlatformEphemeralStatePostgres.ts
+++ b/core/migrations/1778569600000-PlatformEphemeralStatePostgres.ts
@@ -36,6 +36,8 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
         await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_status\" ON \"sprocket\".\"scrim_queue\" (\"status\")");
         await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_submission_id\" ON \"sprocket\".\"scrim_queue\" (\"submission_id\")");
         await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_skill_group_id\" ON \"sprocket\".\"scrim_queue\" (\"skill_group_id\")");
+        // Index for scrim clock efficient query - find pending/popped scrims that may need cleanup
+        await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_status_updated\" ON \"sprocket\".\"scrim_queue\" (\"status\", \"updated_at\")");
 
         await queryRunner.query(`
             CREATE TABLE "sprocket"."scrim_queue_player" (
@@ -175,6 +177,7 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
             )
         `);
         await queryRunner.query("CREATE INDEX \"IDX_platform_rpc_queue_pending\" ON \"sprocket\".\"platform_rpc_queue\" (\"queue\", \"status\", \"created_at\")");
+        await queryRunner.query("CREATE INDEX \"IDX_platform_rpc_queue_locked_at\" ON \"sprocket\".\"platform_rpc_queue\" (\"status\", \"locked_at\") WHERE \"status\" = 'processing'");
 
         await queryRunner.query(`
             CREATE TABLE "sprocket"."platform_event" (
@@ -186,6 +189,7 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
             )
         `);
         await queryRunner.query("CREATE INDEX \"IDX_platform_event_topic\" ON \"sprocket\".\"platform_event\" (\"topic\", \"id\")");
+        await queryRunner.query("CREATE INDEX \"IDX_platform_event_created_at\" ON \"sprocket\".\"platform_event\" (\"created_at\")");
 
         await queryRunner.query(`
             CREATE TABLE "sprocket"."platform_task_queue" (

--- a/core/src/elo/elo.consumer.ts
+++ b/core/src/elo/elo.consumer.ts
@@ -10,7 +10,8 @@ import {EloConnectorService, EloEndpoint} from "./elo-connector";
 
 export const WEEKLY_SALARIES_JOB_NAME = "weeklySalaries";
 
-const WEEKLY_SALARIES_INTERVAL_MS = 60 * 60 * 1000;
+// Configurable via WEEKLY_SALARIES_INTERVAL_MS env var (default: 1 hour)
+const WEEKLY_SALARIES_INTERVAL_MS = parseInt(process.env.WEEKLY_SALARIES_INTERVAL_MS || "3600000", 10);
 
 export class EloConsumer implements OnApplicationBootstrap, OnModuleDestroy {
     private readonly logger = new Logger(EloConsumer.name);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,13 @@ services:
     volumes:
       - ./core:/app/core
       - ./common:/app/common
+    # Resource limits to mitigate blast radius of memory leaks
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,10 @@ services:
   core:
     build:
       context: .
-      dockerfile: dev.Dockerfile
-      args:
-        SERVICE_PATH: core
+      dockerfile: Dockerfile.combined
     ports:
       - '3001:3001'
+      - '3010:3010'
     env_file: .env
     volumes:
       - ./core:/app/core
@@ -76,17 +75,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-
-  matchmaking-service:
-    build:
-      context: .
-      dockerfile: dev.Dockerfile
-      args:
-        SERVICE_PATH: microservices/matchmaking-service
-    env_file: .env
-    depends_on:
-      core:
-        condition: service_started
 
   notification-service:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,13 +55,6 @@ services:
     volumes:
       - ./core:/app/core
       - ./common:/app/common
-    # Resource limits to mitigate blast radius of memory leaks
-    deploy:
-      resources:
-        limits:
-          memory: 2G
-        reservations:
-          memory: 512M
     depends_on:
       minio:
         condition: service_healthy

--- a/infra/platform/src/Platform.ts
+++ b/infra/platform/src/Platform.ts
@@ -295,7 +295,10 @@ export class Platform extends pulumi.ComponentResource {
                 }],
                 networks: [
                     args.ingressNetworkId
-                ]
+                ],
+                // Memory limit: 2GB for combined core + matchmaking-service
+                // This mitigates blast radius if one service has a memory leak
+                memoryLimit: 2 * 1024 * 1024 * 1024,
             }, { parent: this })
         }
 

--- a/infra/platform/src/microservices/SprocketService.ts
+++ b/infra/platform/src/microservices/SprocketService.ts
@@ -106,6 +106,9 @@ export type SprocketServiceArgs = {
     labels?: LabelSpec[],
     instanceCount?: number
     commands?: string[]
+    // Resource limits for the container (in bytes)
+    memoryLimit?: number
+    cpuLimit?: number
 }
 
 export class SprocketService extends pulumi.ComponentResource {
@@ -175,6 +178,11 @@ export class SprocketService extends pulumi.ComponentResource {
                 },
                 placement: {
                     maxReplicas: args.instanceCount ?? 2,
+                },
+                // Resource limits to prevent one service from consuming all available resources
+                resources: {
+                    memoryLimits: args.memoryLimit ? [{ memory: args.memoryLimit }] : undefined,
+                    cpuLimits: args.cpuLimit ? [{ cpu: args.cpuLimit }] : undefined,
                 },
                 logDriver: defaultLogDriver(name, false),
                 networksAdvanceds: [

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
@@ -169,6 +169,19 @@ export class ScrimPostgresRepository {
             : scrims;
     }
 
+    /**
+     * Find scrims that need clock checking - those in PENDING or POPPED status.
+     * Uses the status index for efficient queries.
+     */
+    async findForClockCheck(): Promise<Scrim[]> {
+        const result = await this.postgres.query<ScrimRow>(
+            `SELECT * FROM sprocket.scrim_queue 
+             WHERE status IN ('pending', 'popped') 
+             ORDER BY updated_at ASC`,
+        );
+        return Promise.all(result.rows.map(row => this.hydrate(row)));
+    }
+
     async findByPlayer(playerId: number): Promise<Scrim | null> {
         const result = await this.postgres.query<ScrimRow>(
             `

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -72,6 +72,10 @@ export class ScrimCrudService {
         return this.repository.findAll(skillGroupId);
     }
 
+    async getScrimsForClockCheck(): Promise<Scrim[]> {
+        return this.repository.findForClockCheck();
+    }
+
     async getScrimByPlayer(id: number): Promise<Scrim | null> {
         return this.repository.findByPlayer(id);
     }

--- a/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
@@ -5,7 +5,8 @@ import {compareAsc} from "date-fns";
 import {ScrimService} from "./scrim.service";
 import {ScrimCrudService} from "./scrim-crud/scrim-crud.service";
 
-const SCRIM_CLOCK_INTERVAL_MS = 2 * 60 * 1000;
+// Configurable via SCRIM_CLOCK_INTERVAL_MS env var (default: 2 minutes)
+const SCRIM_CLOCK_INTERVAL_MS = parseInt(process.env.SCRIM_CLOCK_INTERVAL_MS || "120000", 10);
 
 export class ScrimConsumer implements OnApplicationBootstrap, OnModuleDestroy {
     private readonly logger = new Logger(ScrimConsumer.name);
@@ -15,7 +16,8 @@ export class ScrimConsumer implements OnApplicationBootstrap, OnModuleDestroy {
     constructor(private readonly scrimService: ScrimService, private readonly scrimCrudService: ScrimCrudService) {}
 
     async scrimClock(): Promise<void> {
-        const scrims = await this.scrimCrudService.getAllScrims();
+        // Use efficient query that only loads pending/popped scrims instead of all scrims
+        const scrims = await this.scrimCrudService.getScrimsForClockCheck();
 
         for (const scrim of scrims.filter(s => s.status === ScrimStatus.PENDING)) {
             for (const player of scrim.players) {

--- a/reports/scheduling-franchise-migration-plan.md
+++ b/reports/scheduling-franchise-migration-plan.md
@@ -1,0 +1,293 @@
+# Scheduling & Franchise Migration Implementation Plan
+
+**Created:** May 18, 2026  
+**Context:** Gap analysis combining May 17th database schema comparison + Nigel's corrections
+
+---
+
+## 1. Schema Mapping Summary
+
+| mLEDB Entity | Sprocket Entity | Notes |
+|--------------|-----------------|-------|
+| `season` | `ScheduleGroup` | ✓ Already exists |
+| `division` | **NEW: `Division`** | ❌ Missing in sprocket schema |
+| `match` | `ScheduleGroup` → child | Match within a season |
+| `fixture` | `ScheduleFixture` | ✓ Already exists |
+| `series` | `Match` | ✓ Already exists (Sprocket calls it Match) |
+| `team_to_captain` | `FranchiseStaffSeat` | **DEPRECATED** - migrate to staff seat |
+
+---
+
+## 2. Gaps Identified
+
+### A. Scheduling Domain
+
+| Gap | Severity | Description |
+|-----|----------|-------------|
+| **Division Model** | HIGH | No Division entity in sprocket schema. Teams belong to divisions in mLEDB. |
+| **Division → Franchise Link** | HIGH | Need Division FK on Franchise (not ScheduleGroup - teams belong to divisions) |
+| **Season → Division Logic** | MEDIUM | How to handle seasons spanning multiple divisions? |
+
+### B. Franchise Staff Domain
+
+| Gap | Severity | Description |
+|-----|----------|-------------|
+| **CAPTAIN Role** | HIGH | FranchiseStaffRole enum has CAPTAIN (value=4) but no sprocket FranchiseStaffRole entry |
+| **Captain Appointments** | MEDIUM | No migration path from mLEDB TeamToCaptain → FranchiseStaffAppointment (NOT FranchiseLeadershipAppointment - captains are staff, not leadership) |
+
+---
+
+## 3. Implementation Plan
+
+### Phase 1: Schema Changes (New Models)
+
+#### 3.1 Create Division Model
+
+```typescript
+// core/src/database/scheduling/division/division.model.ts
+@Entity({schema: "sprocket"})
+@ObjectType()
+export class Division extends BaseModel {
+  @Column()
+  @Field(() => String)
+  name: string;
+
+  @Column({nullable: true})
+  @Field(() => String, {nullable: true})
+  description?: string;
+
+  @Column({nullable: true})
+  @Field(() => String, {nullable: true})
+  conference?: string;  // From mLEDB Conference enum
+
+  @ManyToOne(() => Game)
+  @Field(() => Game)
+  game: Game;
+
+  @OneToMany(() => ScheduleGroup, sg => sg.division)
+  @Field(() => [ScheduleGroup], {nullable: true})
+  seasons: ScheduleGroup[];
+}
+```
+
+#### 3.2 Add Division Link to Franchise (not ScheduleGroup)
+
+Teams belong to divisions in mLEDB, so Division FK belongs on Franchise:
+
+```typescript
+// Add to Franchise model:
+@ManyToOne(() => Division, {nullable: true})
+@Field(() => Division, {nullable: true})
+division: Division;
+
+@Column({nullable: true})
+divisionId: number;
+```
+
+#### 3.3 (REMOVED) Match Fields
+
+*matchNumber and isDoubleHeader are not needed in sprocket - these can be safely omitted.*
+
+#### 3.4 Add CAPTAIN to FranchiseStaffRole (if not exists)
+
+Check if CAPTAIN role exists in seed data. If not, add migration to insert it.
+
+---
+
+### Phase 2: Migration Scripts (Data Backfill)
+
+#### 3.5 Division Migration
+
+```sql
+-- Create sprocket.division table (run via TypeORM migration)
+INSERT INTO sprocket.division (id, name, conference, game_id, created_at, updated_at)
+SELECT 
+  row_number() OVER () as id,
+  name,
+  conference,
+  (SELECT id FROM sprocket.game WHERE name = 'Rocket League'),
+  now(),
+  now()
+FROM mledb.division;
+```
+
+#### 3.6 Division → Franchise Migration
+
+```sql
+-- Migrate divisions and link to franchises
+INSERT INTO sprocket.division (id, name, conference, game_id, created_at, updated_at)
+SELECT 
+  row_number() OVER () as id,
+  name,
+  conference,
+  (SELECT id FROM sprocket.game WHERE name = 'Rocket League'),
+  now(),
+  now()
+FROM mledb.division;
+
+-- Link franchises to divisions via existing team mappings
+UPDATE sprocket.franchise f
+SET division_id = d.id
+FROM mledb.team t
+JOIN mledb.division d ON d.name = t.division_name
+WHERE f.mle_franchise_id = t.franchise_id;
+```
+
+#### 3.7 ScheduleGroup (Season) Migration
+
+```sql
+-- Migrate seasons from mLEDB (already exists - just documenting)
+-- ScheduleGroup in sprocket captures both Season (parent) and MatchWeek (child)
+-- via parentGroup/childGroups relationships
+```
+
+#### 3.8 ScheduleFixture Migration
+
+```sql
+-- Migrate fixtures from mLEDB
+INSERT INTO sprocket.schedule_fixture (id, schedule_group_id, home_franchise_id, away_franchise_id, created_at, updated_at)
+SELECT 
+  f.id,
+  m.season,  -- schedule_group_id
+  (SELECT fr.id FROM sprocket.franchise fr JOIN mledb.team t ON t.franchise_id = fr.id WHERE t.team_name = f.home_name),
+  (SELECT fr.id FROM sprocket.franchise fr JOIN mledb.team t ON t.franchise_id = fr.id WHERE t.team_name = f.away_name),
+  f.created_at,
+  f.updated_at
+FROM mledb.fixture f
+JOIN mledb.match m ON m.id = f.match_id;
+```
+
+#### 3.9 MatchParent/Match Migration
+
+```sql
+-- Migrate series to Match/MatchParent
+INSERT INTO sprocket.match_parent (id, created_at, updated_at)
+SELECT s.id, s.created_at, s.updated_at
+FROM mledb.series s;
+
+INSERT INTO sprocket.match (id, is_dummy, skill_group_id, match_parent_id, submission_status, can_submit, can_ratify, created_at, updated_at)
+SELECT 
+  s.id,
+  false,
+  (SELECT id FROM sprocket.game_skill_group WHERE name = s.league), -- Need mapping
+  s.id,
+  CASE WHEN s.submission_timestamp IS NOT NULL THEN 'completed' ELSE 'submitting' END,
+  true,
+  false,
+  s.created_at,
+  s.updated_at
+FROM mledb.series s;
+```
+
+#### 3.10 Captain Migration (TeamToCaptain → FranchiseStaffSeat)
+
+```sql
+-- Get or create CAPTAIN role
+INSERT INTO sprocket.franchise_staff_role (id, name, ordinal, bearer_id, game_id, created_at, updated_at)
+SELECT 100, 'CAPTAIN', 100, pb.id, g.id, now(), now()
+FROM sprocket.permission_bearer pb
+CROSS JOIN sprocket.game g
+WHERE pb.name = 'FRANCHISE_STAFF' AND g.name = 'Rocket League'
+ON CONFLICT DO NOTHING;
+
+-- Create captain appointments
+INSERT INTO sprocket.franchise_staff_appointment (id, franchise_id, member_id, seat_id, created_at, updated_at)
+SELECT 
+  tc.id,
+  fr.id,
+  (SELECT m.id FROM sprocket.member m JOIN mledb.player p ON p.member_id = m.id WHERE p.id = tc.player_id),
+  (SELECT fss.id FROM sprocket.franchise_staff_seat fss 
+   JOIN sprocket.franchise_staff_role fsr ON fss.role_id = fsr.id 
+   WHERE fsr.name = 'CAPTAIN'),
+  tc.created_at,
+  tc.updated_at
+FROM mledb.team_to_captain tc
+JOIN mledb.team t ON t.team_name = tc.team_name AND t.league = tc.league
+JOIN sprocket.franchise fr ON fr.mle_franchise_id = t.franchise_id;
+```
+
+---
+
+### Phase 3: Code Updates (Service Layer)
+
+#### 3.11 Update Service Files
+
+Need to update service files that reference the old models:
+- `franchise.service.ts` - add division queries
+- `scheduling.service.ts` - add season/division queries
+- `mledb-bridge.service.ts` - update bridge logic
+
+#### 3.12 API/GraphQL Updates
+
+- Add Division to GraphQL schema
+- Add division to ScheduleGroup queries
+- Add captain field via FranchiseStaffAppointment queries
+
+---
+
+## 4. Migration Dependencies
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   mledb.division│────▶│ sprocket.division│────▶│   Franchise     │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+                                                        │
+┌─────────────────┐                                     │
+│   mledb.season  │────▶│ScheduleGroup                  │
+└─────────────────┘     │ (parent = season,             │
+                        │  child = matchweek)           │
+                        └──────────────────────────────┘
+                                      │
+┌─────────────────┐                    ▼
+│   mledb.fixture │────▶│ScheduleFixture
+└─────────────────┘    └────────────────────┘
+                             │
+┌─────────────────┐           ▼
+│   mledb.match   │     ┌────────────────────┐
+└─────────────────┘     │   MatchParent      │
+                        └────────────────────┘
+                             │
+┌─────────────────┐           ▼
+│   mledb.series  │────▶│     Match          │
+└─────────────────┘     └────────────────────┘
+
+┌──────────────────────┐     ┌───────────────────────┐
+│ mledb.team_to_captain│────▶│FranchiseStaffAppointment
+└──────────────────────┘     │ (via FranchiseStaffSeat)
+                             └───────────────────────┘
+```
+
+---
+
+## 5. Implementation Order
+
+1. **Create Division model** + migration
+2. **Add Division FK to Franchise** + migration (teams belong to divisions)
+3. **Seed CAPTAIN role** (if missing)
+4. **Run data migrations** (division, season, fixture, match, captain)
+5. **Update services** to use new models
+6. **Update API** for new fields
+7. **Deprecate mledb-bridge** mappings (optional, post-migration)
+
+---
+
+## 6. Testing Plan
+
+- [ ] Division CRUD operations
+- [ ] Franchise.division relationship
+- [ ] ScheduleFixture queries with division filter (via franchise)
+- [ ] Captain queries via FranchiseStaffAppointment
+- [ ] End-to-end: mLEDB data visible in sprocket schema
+
+---
+
+## 7. Open Questions
+
+1. **Division naming** - Should divisions be tied to seasons, or are they global? (mLEDB has divisions per league)
+2. **SkillGroup mapping** - How to map mLEDB league (string) → sprocket GameSkillGroup?
+3. **Franchise mapping** - How is mLEDB team.franchise_id linked to sprocket Franchise?
+4. **Rollback strategy** - Need to preserve mledb data or can we truncate post-migration?
+
+---
+
+*This plan should be reviewed before implementation. Some migrations may require additional research on existing data relationships.*


### PR DESCRIPTION
## Summary

This PR adds an implementation plan for migrating scheduling and franchise data from mLEDB to Sprocket schema.

## Changes

- Added `reports/scheduling-franchise-migration-plan.md` with:
  - Schema mapping between mLEDB and Sprocket entities
  - Gaps identified in current Sprocket schema
  - Implementation plan for required changes

## Key Schema Mappings

| mLEDB | Sprocket |
|-------|----------|
| season | ScheduleGroup |
| division | Division -> Franchise |
| fixture | ScheduleFixture |
| series | Match |
| team_to_captain | FranchiseStaffAppointment |

## Notes

- Captains treated as FranchiseStaffSeat (not deprecated TeamToCaptain)
- Division FK on Franchise (teams belong to divisions)