### PR TITLE
reduce: limit postgres connection pool to 1 per service

### DIFF
--- a/common/src/postgres-transport/postgres-transport.ts
+++ b/common/src/postgres-transport/postgres-transport.ts
@@ -31,6 +31,7 @@ export function createTransportPool(): Pool {
         ssl: config.db.host === "postgres" || config.db.host === "localhost"
             ? false
             : {rejectUnauthorized: false},
+        max: config.db.pool_size,
     });
 }
 

--- a/common/src/postgres/postgres.service.ts
+++ b/common/src/postgres/postgres.service.ts
@@ -17,6 +17,7 @@ export class PostgresService implements OnModuleDestroy {
                 ssl: config.db.host === "postgres" || config.db.host === "localhost"
                     ? false
                     : {rejectUnauthorized: false},
+                max: config.db.pool_size,
             });
         }
         return this._pool;

--- a/common/src/util/config.ts
+++ b/common/src/util/config.ts
@@ -106,6 +106,9 @@ export const config = {
         get enable_logs(): boolean {
             return ConfigResolver.getBooleanConfig("POSTGRES_ENABLE_LOGS", "db.enable_logs");
         },
+        get pool_size(): number {
+            return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size") ?? 1;
+        },
     },
     gql: {
         get url(): string {

--- a/core/src/database/database.module.ts
+++ b/core/src/database/database.module.ts
@@ -41,11 +41,14 @@ const modules = [
         logging: config.db.enable_logs,
         // Only enable SSL if not in local development (postgres host != "postgres" or "localhost")
         ssl:
-      config.db.host === "postgres" || config.db.host === "localhost"
-          ? false
-          : {
-                  rejectUnauthorized: false,
-              },
+            config.db.host === "postgres" || config.db.host === "localhost"
+                ? false
+                : {
+                      rejectUnauthorized: false,
+                  },
+        extra: {
+            max: config.db.pool_size,
+        },
     }),
 ];
 


### PR DESCRIPTION
## Summary

This PR reduces PostgreSQL connection usage across all services to prevent connection exhaustion.

### Changes

- **Config**: Added db.pool_size setting (default: 1 connection)
- **PostgresService**: Uses configurable pool limit
- **PostgresTransport**: Uses configurable pool limit  
- **TypeORM DatabaseModule**: Uses configurable pool limit

### Impact

| Component | Before | After |
|-----------|--------|-------|
| PostgresService (per service) | 10 | 1 |
| PostgresTransport (per service) | 10 | 1 |
| TypeORM (core service) | 10 | 1 |

Total connections reduced from ~60 to ~6 for the full service stack.

### Testing

Can be overridden via POSTGRES_POOL_SIZE env var or db.pool_size config if more connections are needed.
