### PR TITLE
fix: pass default value to getNumberConfig for pool_size

### DIFF
--- a/common/src/util/config.ts
+++ b/common/src/util/config.ts
@@ -107,7 +107,7 @@ export const config = {
             return ConfigResolver.getBooleanConfig("POSTGRES_ENABLE_LOGS", "db.enable_logs");
         },
         get pool_size(): number {
-            return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size") ?? 1;
+            return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size", 1);
         },
     },
     gql: {


### PR DESCRIPTION
## Summary

Fixes a bug where the `pool_size` config throws an error on startup instead of using the default value.

### Problem

```typescript
// Broken - throws before ?? operator can execute
return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size") ?? 1;
```

### Fix

```typescript
// Works - default passed directly to function
return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size", 1);
```

The `getNumberConfig` function throws when the config key doesn't exist and no default is provided. The `?? 1` fallback never gets a chance to run.
