### PR TITLE
fix(core): explicitly configure CORS to resolve GraphQL auth header issues

### DIFF
--- a/core/src/main.ts
+++ b/core/src/main.ts
@@ -26,7 +26,12 @@ async function bootstrap(): Promise<void> {
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.core_queue}),
     });
-    app.enableCors();
+    app.enableCors({
+        origin: true,
+        credentials: true,
+        allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+        methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    });
     app.useGlobalPipes(new ValidationPipe());
 
     const httpAdapter = app.get(HttpAdapterHost);


### PR DESCRIPTION
## Problem

Some users are experiencing CORS errors when the frontend makes GraphQL requests to the API.

The frontend (hosted at `https://sprocket.mlesports.gg`) and API (hosted at `https://api.sprocket.mlesports.gg/graphql`) are on different origins. The frontend sends `Authorization: Bearer <token>` headers and cookies.

The backend was using bare `app.enableCors()` with no configuration, which can fail in some browser/load-balancer combinations when credentials are involved.

## Changes

Explicitly configure CORS in `core/src/main.ts`:

- `origin: true` — reflect the request origin (required when `credentials: true`)
- `credentials: true` — allow cookies and auth headers across origins
- `allowedHeaders` — explicitly allow `Content-Type`, `Authorization`, `X-Requested-With`
- `methods` — allow all common HTTP methods

## Testing

- [ ] Deploy to staging and verify GraphQL queries from the frontend no longer trigger CORS errors
- [ ] Confirm WebSocket subscriptions still work
- [ ] Confirm file uploads (multipart) still work