### PR TITLE
fix: drop unique constraint instead of index in migration

### DIFF
--- a/core/migrations/1773000000000-DropMledbPlayerAccountTrackerUnique.ts
+++ b/core/migrations/1773000000000-DropMledbPlayerAccountTrackerUnique.ts
@@ -8,15 +8,17 @@ import {MigrationInterface, QueryRunner} from "typeorm";
 export class DropMledbPlayerAccountTrackerUnique1773000000000 implements MigrationInterface {
     name = "DropMledbPlayerAccountTrackerUnique1773000000000";
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
+public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the unique constraint (which will also drop the underlying index)
         await queryRunner.query(
-            'DROP INDEX IF EXISTS "mledb"."player_account_tracker_unique"',
+            'ALTER TABLE "mledb"."player_account" DROP CONSTRAINT IF EXISTS "player_account_tracker_unique"',
         );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        // Recreate the unique constraint
         await queryRunner.query(
-            'CREATE UNIQUE INDEX "player_account_tracker_unique" ON "mledb"."player_account" ("tracker")',
+            'ALTER TABLE "mledb"."player_account" ADD CONSTRAINT "player_account_tracker_unique" UNIQUE ("tracker")',
         );
     }
 }


### PR DESCRIPTION
In PostgreSQL, a UNIQUE constraint creates an underlying index. The previous migration tried to DROP INDEX which fails because the constraint depends on it. Changed to use ALTER TABLE DROP CONSTRAINT which properly removes both.

Can be merged immediately - this is a hotfix for the production migration that's currently failing.