### PR TITLE
debug: add logging to trace submission response issue

### DIFF
--- a/common/src/postgres-transport/postgres-client.ts
+++ b/common/src/postgres-transport/postgres-client.ts
@@ -80,6 +80,7 @@ export class PostgresClientProxy extends ClientProxy {
                 return;
             }
             if (row.status === "completed") {
+                console.log(`[PostgresClient] Received response for ${id}:`, JSON.stringify(row.response).substring(0, 200));
                 callback({response: row.response, isDisposed: true});
                 await this.transport.pool.query(
                     "DELETE FROM sprocket.platform_rpc_queue WHERE id = $1",

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -121,9 +121,9 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
         }
 
         try {
-            const response$ = this.transformToObservable(
-                await handler(packet.data, new BaseRpcContext([row])),
-            );
+            const handlerResult = await handler(packet.data, new BaseRpcContext([row]));
+            console.log(`[PostgresServer] Handler result for ${row.pattern}:`, JSON.stringify(handlerResult).substring(0, 200));
+            const response$ = this.transformToObservable(handlerResult);
             const respond = async (packet: WritePacket): Promise<void> => {
                 if (packet.err) {
                     await this.fail(row.id, packet.err);
@@ -140,6 +140,8 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
     }
 
     private async complete(id: string, response: unknown): Promise<void> {
+        // Debug: log what we're about to store
+        console.log(`[PostgresServer] Storing response for ${id}:`, JSON.stringify(response).substring(0, 200));
         await this.transport.pool.query(
             `
                 UPDATE sprocket.platform_rpc_queue

--- a/microservices/submission-service/src/replay-submission/persistence/replay-submission-postgres.repository.ts
+++ b/microservices/submission-service/src/replay-submission/persistence/replay-submission-postgres.repository.ts
@@ -70,10 +70,18 @@ export class ReplaySubmissionPostgresRepository {
     constructor(private readonly postgres: PostgresService) {}
 
     async findAll(): Promise<CompatibleSubmission[]> {
-        const result = await this.postgres.query<SubmissionRow>(
-            "SELECT * FROM sprocket.replay_submission ORDER BY created_at ASC",
-        );
-        return Promise.all(result.rows.map(row => this.hydrate(row)));
+        try {
+            const result = await this.postgres.query<SubmissionRow>(
+                "SELECT * FROM sprocket.replay_submission ORDER BY created_at ASC",
+            );
+            console.log(`[Repo] findAll: rows length = ${result.rows.length}`);
+            const hydrated = await Promise.all(result.rows.map(row => this.hydrate(row)));
+            console.log(`[Repo] findAll: hydrated length = ${hydrated.length}`);
+            return hydrated;
+        } catch (error) {
+            console.error(`[Repo] findAll error:`, error);
+            throw error;
+        }
     }
 
     async findById(submissionId: string): Promise<CompatibleSubmission | undefined> {


### PR DESCRIPTION
Add debug logging to trace the {} response issue in submission service:

- PostgresServer: log handler result before storing
- PostgresServer: log response before storing  
- PostgresClient: log received response
- Repository: log row count and hydration results

This will help identify where the empty object response is coming from.