### PR TITLE
fix: add @Injectable to ScrimConsumer and handle empty object responses

### DIFF
--- a/common/src/service-connectors/matchmaking/matchmaking.service.ts
+++ b/common/src/service-connectors/matchmaking/matchmaking.service.ts
@@ -40,7 +40,21 @@ export class MatchmakingService {
 
             const response = (await lastValueFrom(rx)) as unknown;
 
-            const output = outputSchema.parse(response);
+            // Handle case where response might be {} or null when array/object expected
+            let output: unknown;
+            if (Array.isArray(response)) {
+                output = response;
+            } else if (response && typeof response === 'object' && Object.keys(response).length === 0) {
+                // Handle empty object {} - treat as empty array or null
+                this.logger.debug(`Received empty object {}, treating as empty array for ${endpoint}`);
+                output = [];
+            } else if (response === null || response === undefined) {
+                output = null;
+            } else {
+                output = response;
+            }
+
+            const parsed = outputSchema.parse(output);
             this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(output)})`);
             return {
                 status: ResponseStatus.SUCCESS,

--- a/common/src/service-connectors/matchmaking/matchmaking.service.ts
+++ b/common/src/service-connectors/matchmaking/matchmaking.service.ts
@@ -55,10 +55,10 @@ export class MatchmakingService {
             }
 
             const parsed = outputSchema.parse(output);
-            this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(output)})`);
+            this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(parsed)})`);
             return {
                 status: ResponseStatus.SUCCESS,
-                data: output,
+                data: parsed,
             };
         } catch (e) {
             this.logger.warn(`| < (${rid}) - | \`${endpoint}\` failed ${(e as Error).message}`);

--- a/common/src/service-connectors/submission/submission.service.ts
+++ b/common/src/service-connectors/submission/submission.service.ts
@@ -48,6 +48,12 @@ export class SubmissionService {
             } else if (response && typeof response === 'object' && 'data' in response) {
                 // Handle { data: [...] } wrapper
                 output = (response as {data: unknown}).data;
+            } else if (response && typeof response === 'object' && Object.keys(response).length === 0) {
+                // Handle empty object {} - treat as empty array
+                this.logger.debug(`Received empty object {}, treating as empty array for ${endpoint}`);
+                output = [];
+            } else if (response === null || response === undefined) {
+                output = [];
             } else {
                 throw new Error(`Unexpected response type: ${typeof response}`);
             }

--- a/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.consumer.ts
@@ -1,4 +1,4 @@
-import {Logger, OnApplicationBootstrap, OnModuleDestroy} from "@nestjs/common";
+import {Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy} from "@nestjs/common";
 import {ScrimStatus} from "@sprocketbot/common";
 import {compareAsc} from "date-fns";
 
@@ -8,6 +8,7 @@ import {ScrimCrudService} from "./scrim-crud/scrim-crud.service";
 // Configurable via SCRIM_CLOCK_INTERVAL_MS env var (default: 2 minutes)
 const SCRIM_CLOCK_INTERVAL_MS = parseInt(process.env.SCRIM_CLOCK_INTERVAL_MS || "120000", 10);
 
+@Injectable()
 export class ScrimConsumer implements OnApplicationBootstrap, OnModuleDestroy {
     private readonly logger = new Logger(ScrimConsumer.name);
 


### PR DESCRIPTION
## Summary

### Issue
- Scrim tab shows "Loading..." - scrims completely broken
- Admin submission management card shows errors
- ScrimConsumer failing every 2 minutes with "Cannot read properties of undefined (reading 'getScrimsForClockCheck')"

### Root Causes

1. **ScrimConsumer missing @Injectable()** - The class implements lifecycle interfaces but was missing the  decorator, causing NestJS DI to fail silently. The  was undefined.

2. **Postgres transport returning {} instead of []** - The RPC layer is returning empty object  instead of empty array  in some cases, causing "Expected array, received object" errors.

### Fixes

1. **microservices/matchmaking-service/src/scrim/scrim.consumer.ts**
   - Added @Injectable() decorator

2. **common/src/service-connectors/submission/submission.service.ts**
   - Handle empty object {} as empty array []
   - Handle null/undefined responses gracefully

3. **common/src/service-connectors/matchmaking/matchmaking.service.ts**
   - Same defensive handling for scrims and matchmaking endpoints

### Testing
- Built locally (TypeScript compilation passes)
- Matches the defensive patterns already in the codebase