### PR TITLE
[codex] Fix matchmaking Postgres game hydration

### DIFF
--- a/core/migrations/1778569600000-PlatformEphemeralStatePostgres.ts
+++ b/core/migrations/1778569600000-PlatformEphemeralStatePostgres.ts
@@ -4,6 +4,25 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
   name = 'PlatformEphemeralStatePostgres1778569600000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    const d = await queryRunner.query(`
+  SELECT
+    pg_backend_pid() AS backend_pid,
+    txid_current_if_assigned() AS txid,
+    current_database() AS db,
+    current_user AS db_user,
+    current_schema() AS current_schema,
+    inet_client_addr() AS client_addr,
+    application_name
+  FROM pg_stat_activity
+  WHERE pid = pg_backend_pid()
+`);
+
+    console.log('[migration debug]', {
+      nodePid: process.pid,
+      migration: 'PlatformEphemeralStatePostgres1778569600000',
+      at: 'before platform_event',
+      d,
+    });
     await queryRunner.query('CREATE SCHEMA IF NOT EXISTS "sprocket"');
 
     await queryRunner.query(`
@@ -33,11 +52,19 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
                 CONSTRAINT "PK_scrim_queue" PRIMARY KEY ("id")
             )
         `);
-        await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_status\" ON \"sprocket\".\"scrim_queue\" (\"status\")");
-        await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_submission_id\" ON \"sprocket\".\"scrim_queue\" (\"submission_id\")");
-        await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_skill_group_id\" ON \"sprocket\".\"scrim_queue\" (\"skill_group_id\")");
-        // Index for scrim clock efficient query - find pending/popped scrims that may need cleanup
-        await queryRunner.query("CREATE INDEX \"IDX_scrim_queue_status_updated\" ON \"sprocket\".\"scrim_queue\" (\"status\", \"updated_at\")");
+    await queryRunner.query(
+      'CREATE INDEX "IDX_scrim_queue_status" ON "sprocket"."scrim_queue" ("status")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_scrim_queue_submission_id" ON "sprocket"."scrim_queue" ("submission_id")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_scrim_queue_skill_group_id" ON "sprocket"."scrim_queue" ("skill_group_id")',
+    );
+    // Index for scrim clock efficient query - find pending/popped scrims that may need cleanup
+    await queryRunner.query(
+      'CREATE INDEX "IDX_scrim_queue_status_updated" ON "sprocket"."scrim_queue" ("status", "updated_at")',
+    );
 
     await queryRunner.query(`
             CREATE TABLE "sprocket"."scrim_queue_player" (
@@ -169,6 +196,20 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
             )
         `);
 
+    const existingRpcQueue = await queryRunner.query(`
+  SELECT
+    c.oid::regclass AS regclass_name,
+    n.nspname AS schema_name,
+    c.relname AS relation_name,
+    c.relkind,
+    pg_get_userbyid(c.relowner) AS owner
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'sprocket'
+    AND c.relname = 'platform_rpc_queue'
+`);
+
+    console.log('platform_rpc_queue before create:', existingRpcQueue);
     await queryRunner.query(`
             CREATE TABLE "sprocket"."platform_rpc_queue" (
                 "id" uuid NOT NULL,
@@ -184,9 +225,32 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
                 CONSTRAINT "PK_platform_rpc_queue" PRIMARY KEY ("id")
             )
         `);
-        await queryRunner.query("CREATE INDEX \"IDX_platform_rpc_queue_pending\" ON \"sprocket\".\"platform_rpc_queue\" (\"queue\", \"status\", \"created_at\")");
-        await queryRunner.query("CREATE INDEX \"IDX_platform_rpc_queue_locked_at\" ON \"sprocket\".\"platform_rpc_queue\" (\"status\", \"locked_at\") WHERE \"status\" = 'processing'");
+    await queryRunner.query(
+      'CREATE INDEX "IDX_platform_rpc_queue_pending" ON "sprocket"."platform_rpc_queue" ("queue", "status", "created_at")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_platform_rpc_queue_locked_at" ON "sprocket"."platform_rpc_queue" ("status", "locked_at") WHERE "status" = \'processing\'',
+    );
 
+    const debug = await queryRunner.query(`
+  SELECT
+    pg_backend_pid() AS backend_pid,
+    txid_current_if_assigned() AS txid,
+    current_database() AS db,
+    current_user AS db_user,
+    current_schema() AS current_schema,
+    inet_client_addr() AS client_addr,
+    application_name
+  FROM pg_stat_activity
+  WHERE pid = pg_backend_pid()
+`);
+
+    console.log('[migration debug]', {
+      nodePid: process.pid,
+      migration: 'PlatformEphemeralStatePostgres1778569600000',
+      at: 'before platform_event',
+      debug,
+    });
     await queryRunner.query(`
             CREATE TABLE "sprocket"."platform_event" (
                 "id" BIGSERIAL NOT NULL,
@@ -196,8 +260,12 @@ export class PlatformEphemeralStatePostgres1778569600000 implements MigrationInt
                 CONSTRAINT "PK_platform_event" PRIMARY KEY ("id")
             )
         `);
-        await queryRunner.query("CREATE INDEX \"IDX_platform_event_topic\" ON \"sprocket\".\"platform_event\" (\"topic\", \"id\")");
-        await queryRunner.query("CREATE INDEX \"IDX_platform_event_created_at\" ON \"sprocket\".\"platform_event\" (\"created_at\")");
+    await queryRunner.query(
+      'CREATE INDEX "IDX_platform_event_topic" ON "sprocket"."platform_event" ("topic", "id")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_platform_event_created_at" ON "sprocket"."platform_event" ("created_at")',
+    );
 
     await queryRunner.query(`
             CREATE TABLE "sprocket"."platform_task_queue" (

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
@@ -143,6 +143,87 @@ describe("ScrimPostgresRepository", () => {
         );
     });
 
+    it("hydrates all scrims with batched game rows", async () => {
+        const query = jest.fn()
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: "00000000-0000-4000-8000-000000000001",
+                    created_at: new Date("2026-01-01T00:00:00.000Z"),
+                    updated_at: new Date("2026-01-01T00:01:00.000Z"),
+                    status: ScrimStatus.IN_PROGRESS,
+                    unlocked_status: null,
+                    author_id: 1,
+                    organization_id: 2,
+                    game_mode_id: 3,
+                    skill_group_id: 4,
+                    submission_id: "scrim-submission",
+                    timeout_job_id: null,
+                    group_invite_opens_at: null,
+                    popped_at: new Date("2026-01-01T00:01:00.000Z"),
+                    lobby_name: "lobby",
+                    lobby_password: "pass",
+                    settings_team_size: 3,
+                    settings_team_count: 2,
+                    settings_mode: ScrimMode.TEAMS,
+                    settings_competitive: true,
+                    settings_observable: false,
+                    settings_lfs: false,
+                    settings_checkin_timeout: 120000,
+                }],
+            })
+            .mockResolvedValueOnce({
+                rows: [{
+                    scrim_id: "00000000-0000-4000-8000-000000000001",
+                    player_id: 10,
+                    name: "Player",
+                    joined_at: new Date("2026-01-01T00:00:00.000Z"),
+                    leave_at: new Date("2026-01-01T00:05:00.000Z"),
+                    group_key: "A",
+                    checked_in: true,
+                }],
+            })
+            .mockResolvedValueOnce({
+                rows: [{
+                    scrim_id: "00000000-0000-4000-8000-000000000001",
+                    id: 99,
+                }],
+            })
+            .mockResolvedValueOnce({
+                rows: [{
+                    game_scrim_id: "00000000-0000-4000-8000-000000000001",
+                    game_id: 99,
+                    team_index: 0,
+                    player_id: 10,
+                    name: "Player",
+                    joined_at: new Date("2026-01-01T00:00:00.000Z"),
+                    leave_at: new Date("2026-01-01T00:05:00.000Z"),
+                    group_key: "A",
+                    checked_in: true,
+                }],
+            });
+        const repo = new ScrimPostgresRepository({query} as any);
+
+        const scrims = await repo.findAll();
+
+        expect(scrims).toMatchObject([{
+            id: "00000000-0000-4000-8000-000000000001",
+            games: [{
+                teams: [{
+                    players: [{
+                        id: 10,
+                        name: "Player",
+                        group: "A",
+                        checkedIn: true,
+                    }],
+                }],
+            }],
+        }]);
+        expect(query.mock.calls[3][0]).toContain(
+            "INNER JOIN sprocket.scrim_queue_game qg ON qg.id = gp.game_id",
+        );
+        expect(query.mock.calls[3][0]).not.toContain("SELECT g.scrim_id");
+    });
+
     it("updates status in the scrim table and stamps popped time for popped scrims", async () => {
         const query = jest.fn().mockResolvedValue({rows: []});
         const repo = new ScrimPostgresRepository({query} as any);

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
@@ -697,10 +697,20 @@ export class ScrimPostgresRepository {
         
         const playerResult = await this.postgres.query<ScrimGamePlayerRow & {game_scrim_id: string}>(
             `
-                SELECT g.scrim_id as game_scrim_id, g.game_id, g.team_index, g.player_id, g.name, g.joined_at, g.leave_at, g.group_key, g.checked_in
-                FROM sprocket.scrim_queue_game_player g
-                WHERE g.game_id = ANY($1::int[])
-                ORDER BY g.game_id ASC, g.team_index ASC, g.position ASC
+                SELECT
+                    qg.scrim_id as game_scrim_id,
+                    gp.game_id,
+                    gp.team_index,
+                    gp.player_id,
+                    gp.name,
+                    gp.joined_at,
+                    gp.leave_at,
+                    gp.group_key,
+                    gp.checked_in
+                FROM sprocket.scrim_queue_game_player gp
+                INNER JOIN sprocket.scrim_queue_game qg ON qg.id = gp.game_id
+                WHERE gp.game_id = ANY($1::int[])
+                ORDER BY gp.game_id ASC, gp.team_index ASC, gp.position ASC
             `,
             [gameIds],
         );
@@ -718,7 +728,7 @@ export class ScrimPostgresRepository {
         
         for (const gameRow of gameResult.rows) {
             const players = playersByGame.get(gameRow.id) || [];
-            const teamCount = Math.max(0, ...players.map(row => row.team_index)) + 1;
+            const teamCount = Math.max(-1, ...players.map(row => row.team_index)) + 1;
             
             const game: ScrimGame = {
                 teams: Array.from({length: teamCount}).map((_, teamIndex) => ({


### PR DESCRIPTION
## Summary

Fixes the matchmaking service Postgres scrim hydration path used by `GetAllScrims`, scrim metrics, and the scrim clock.

The batched game-player loader was selecting `scrim_id` from `sprocket.scrim_queue_game_player`, but that table only stores `game_id`. The fix joins through `sprocket.scrim_queue_game` to recover the parent scrim id, then hydrates games under the correct scrim. It also makes empty-game team calculation match the single-scrim loader.

This PR also includes related diagnostics in `core/migrations/1778569600000-PlatformEphemeralStatePostgres.ts` for the platform ephemeral state migration, including backend/session context logging around platform queue/event table creation.

## Root Cause

The Redis-to-Postgres migration normalized scrim games into `scrim_queue_game` and `scrim_queue_game_player`. The batch loader accidentally treated the child game-player table as if it still carried the parent `scrim_id`, which breaks full-list hydration paths after games exist.

## Validation

- `npm run test --workspace=microservices/matchmaking-service -- scrim-postgres.repository.spec.ts --runInBand`
- `npm run build --workspace=microservices/matchmaking-service`
- `npm run test --workspace=microservices/matchmaking-service -- --runInBand`
- `npm run build --workspace=core`

Note: the matchmaking test suite still prints the existing `NODE_ENV=test` config warning.

## Scope Note

The worktree also contains local untracked files, but `core/env.fish` contains live credentials and `.agent-shell` transcripts may contain those values after inspection, so they were intentionally excluded from this PR. `.gitignore` and `AGENTS.md` local edits also remain excluded.