### PR TITLE
feat: MLEDB Player Lookup presentation layer

### DIFF
--- a/core/src/mledb/mledb-interface.module.ts
+++ b/core/src/mledb/mledb-interface.module.ts
@@ -21,9 +21,10 @@ import {SprocketRatingModule} from "../sprocket-rating";
 import {UtilModule} from "../util/util.module";
 import {MledbMatchController} from "./mledb-match/mledb-match.controller";
 import {MledbMatchService} from "./mledb-match/mledb-match.service";
-import {FormerPlayerScrimGuard} from "./mledb-player/mledb-player.guard";
 import {MledbPlayerService} from "./mledb-player";
 import {MledbPlayerController} from "./mledb-player/mledb-player.controller";
+import {FormerPlayerScrimGuard} from "./mledb-player/mledb-player.guard";
+import {MledbPlayerPresentationResolver} from "./mledb-player/mledb-player.presentation.resolver";
 import {MledbPlayerAccountService} from "./mledb-player-account";
 import {MledbFinalizationService} from "./mledb-scrim";
 import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mledb-team-role-usage";
@@ -53,6 +54,7 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
     ],
     providers: [
         MledbPlayerService,
+        MledbPlayerPresentationResolver,
         MledbPlayerAccountService,
         MledbFinalizationService,
         MledbMatchService,

--- a/core/src/mledb/mledb-player/mledb-player.presentation.resolver.ts
+++ b/core/src/mledb/mledb-player/mledb-player.presentation.resolver.ts
@@ -1,0 +1,61 @@
+import {Args, Int, Query, Resolver} from "@nestjs/graphql";
+
+import type {MLE_Player} from "../../database/mledb";
+import {MledbPlayerService} from "./mledb-player.service";
+import {
+    MlePresentationPlayerDetail,
+    MlePresentationPlayerSearchResult,
+} from "./mledb-player.presentation.types";
+
+@Resolver()
+export class MledbPlayerPresentationResolver {
+    constructor(private readonly mledbPlayerService: MledbPlayerService) {}
+
+    @Query(() => [MlePresentationPlayerSearchResult])
+    async mlePresentationPlayerSearch(
+        @Args("query", {type: () => String}) query: string,
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationPlayerSearchResult[]> {
+        const players = await this.mledbPlayerService.searchPresentationPlayers(query, limit ?? 10);
+        return players.map(player => this.toSearchResult(player));
+    }
+
+    @Query(() => MlePresentationPlayerDetail, {nullable: true})
+    async mlePresentationPlayerDetail(
+        @Args("playerId", {type: () => Int}) playerId: number,
+    ): Promise<MlePresentationPlayerDetail | null> {
+        const detail = await this.mledbPlayerService.getPresentationPlayerDetail(playerId);
+        if (!detail) {
+            return null;
+        }
+
+        const {player, orgTeams, platformAccounts} = detail;
+        return {
+            ...this.toSearchResult(player),
+            role: player.role ?? undefined,
+            preferredPlatform: player.preferredPlatform ?? undefined,
+            peakMmr: player.peakMmr ?? undefined,
+            timezone: player.timezone ? String(player.timezone) : undefined,
+            discordId: player.discordId ?? undefined,
+            modePreference: player.modePreference ? String(player.modePreference) : undefined,
+            orgTeams,
+            platformAccounts: platformAccounts.map(account => ({
+                platform: String(account.platform),
+                platformId: account.platformId ?? "",
+                tracker: account.tracker ?? undefined,
+            })),
+        };
+    }
+
+    private toSearchResult(player: MLE_Player): MlePresentationPlayerSearchResult {
+        return {
+            id: player.id,
+            mleid: player.mleid,
+            name: player.name,
+            teamName: player.teamName ?? undefined,
+            league: player.league ? String(player.league) : undefined,
+            salary: player.salary,
+            suspended: player.suspended,
+        };
+    }
+}

--- a/core/src/mledb/mledb-player/mledb-player.presentation.types.ts
+++ b/core/src/mledb/mledb-player/mledb-player.presentation.types.ts
@@ -1,0 +1,87 @@
+import {
+    Field, Float, Int, ObjectType,
+} from "@nestjs/graphql";
+
+@ObjectType()
+export class MlePresentationPlayerSearchResult {
+    @Field(() => Int)
+    id!: number;
+
+    @Field(() => Int)
+    mleid!: number;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String, {nullable: true})
+    teamName?: string;
+
+    @Field(() => String, {nullable: true})
+    league?: string;
+
+    @Field(() => Float, {nullable: true})
+    salary?: number;
+
+    @Field(() => Boolean)
+    suspended!: boolean;
+}
+
+@ObjectType()
+export class MlePresentationPlayerPlatformAccount {
+    @Field(() => String)
+    platform!: string;
+
+    @Field(() => String)
+    platformId!: string;
+
+    @Field(() => String, {nullable: true})
+    tracker?: string;
+}
+
+@ObjectType()
+export class MlePresentationPlayerDetail {
+    @Field(() => Int)
+    id!: number;
+
+    @Field(() => Int)
+    mleid!: number;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => Float, {nullable: true})
+    salary?: number;
+
+    @Field(() => String, {nullable: true})
+    teamName?: string;
+
+    @Field(() => String, {nullable: true})
+    league?: string;
+
+    @Field(() => String, {nullable: true})
+    role?: string;
+
+    @Field(() => String, {nullable: true})
+    preferredPlatform?: string;
+
+    @Field(() => Int, {nullable: true})
+    peakMmr?: number;
+
+    @Field(() => String, {nullable: true})
+    timezone?: string;
+
+    @Field(() => String, {nullable: true})
+    discordId?: string;
+
+    @Field(() => String, {nullable: true})
+    modePreference?: string;
+
+    @Field(() => Boolean)
+    suspended!: boolean;
+
+    @Field(() => [Int])
+    orgTeams!: number[];
+
+    @Field(() => [MlePresentationPlayerPlatformAccount])
+    platformAccounts!: MlePresentationPlayerPlatformAccount[];
+}

--- a/core/src/mledb/mledb-player/mledb-player.service.ts
+++ b/core/src/mledb/mledb-player/mledb-player.service.ts
@@ -3,7 +3,7 @@ import {
 } from "@nestjs/common";
 import {InjectRepository} from "@nestjs/typeorm";
 import {config} from "@sprocketbot/common";
-import {Repository} from "typeorm";
+import {ILike, Repository} from "typeorm";
 
 import type {Player} from "$db/franchise/player/player.model";
 import type {User} from "$db/identity/user/user.model";
@@ -247,5 +247,52 @@ export class MledbPlayerService {
         }
 
         return player;
+    }
+
+    /**
+     * Search presentation players by partial name match.
+     */
+    async searchPresentationPlayers(query: string, limit: number = 10): Promise<MLE_Player[]> {
+        const normalizedQuery = query.trim();
+        if (!normalizedQuery) {
+            return [];
+        }
+
+        const safeLimit = Math.min(Math.max(limit, 1), 25);
+        return this.playerRepository.find({
+            where: {name: ILike(`%${normalizedQuery}%`)},
+            take: safeLimit,
+            order: {name: "ASC"},
+        });
+    }
+
+    /**
+     * Get presentation player details including org team ids and platform accounts.
+     */
+    async getPresentationPlayerDetail(playerId: number): Promise<{
+        player: MLE_Player;
+        orgTeams: number[];
+        platformAccounts: MLE_PlayerAccount[];
+    } | null> {
+        const player = await this.playerRepository.findOne({
+            where: {id: playerId},
+        });
+        if (!player) {
+            return null;
+        }
+
+        const playerOrgs = await this.playerToOrgRepository.find({
+            where: {player: {id: playerId} },
+        });
+
+        const platformAccounts = await this.playerAccountRepository.find({
+            where: {player: {id: playerId} },
+        });
+
+        return {
+            player,
+            orgTeams: playerOrgs.map(playerOrg => playerOrg.orgTeam),
+            platformAccounts,
+        };
     }
 }


### PR DESCRIPTION
## Summary

Adds GraphQL-based Player Lookup presentation layer to replace MLEBot player commands as part of the MLEDB sunset project.

## Changes

- **New resolver**: `MledbPlayerPresentationResolver` with two queries:
  - `mlePresentationPlayerSearch(query, limit)` - search players by name
  - `mlePresentationPlayerDetail(playerId)` - get full player details
- **New types**: GraphQL types for search results and player details
- **Service methods**: Added `searchPresentationPlayers()` and `getPresentationPlayerDetail()` to `MledbPlayerService`

## Migration Strategy

This is Phase 1 of the MLEDB sunset:
1. Build MLEDB-backed presentation layer (this PR)
2. Dual-read + metrics (compare MLEDB vs Sprocket)
3. Flip to Sprocket-only (feature flag)
4. Delete old code paths

## Testing

TypeScript compilation passes. Needs local dev environment to test the GraphQL queries.