### PR TITLE
feat: add MLEDB Franchise presentation layer

### DIFF
--- a/core/src/mledb/mledb-franchise/index.ts
+++ b/core/src/mledb/mledb-franchise/index.ts
@@ -1,0 +1,3 @@
+export * from "./mledb-franchise.presentation.types";
+export * from "./mledb-franchise.presentation.service";
+export * from "./mledb-franchise.presentation.resolver";

--- a/core/src/mledb/mledb-franchise/mledb-franchise.presentation.resolver.ts
+++ b/core/src/mledb/mledb-franchise/mledb-franchise.presentation.resolver.ts
@@ -1,0 +1,98 @@
+import {Args, Int, Query, Resolver} from "@nestjs/graphql";
+
+import {MledbFranchisePresentationService} from "./mledb-franchise.presentation.service";
+import {
+    MlePresentationFranchiseDetail,
+    MlePresentationFranchiseSummary,
+} from "./mledb-franchise.presentation.types";
+
+@Resolver()
+export class MledbFranchisePresentationResolver {
+    constructor(private readonly franchiseService: MledbFranchisePresentationService) {}
+
+    @Query(() => [MlePresentationFranchiseSummary])
+    async mlePresentationFranchiseSearch(
+        @Args("query", {type: () => String}) query: string,
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationFranchiseSummary[]> {
+        const franchises = await this.franchiseService.searchFranchises(query, limit ?? 10);
+        return franchises.map((f) => ({
+            name: f.name,
+            callsign: f.callsign,
+            division: f.division,
+            rosterCount: f.rosterCount,
+            usedSalary: f.usedSalary,
+        }));
+    }
+
+    @Query(() => [MlePresentationFranchiseSummary])
+    async mlePresentationAllFranchises(
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationFranchiseSummary[]> {
+        const franchises = await this.franchiseService.getAllFranchises(limit ?? 50);
+        return franchises.map((f) => ({
+            name: f.name,
+            callsign: f.callsign,
+            division: f.division,
+            rosterCount: f.rosterCount,
+            usedSalary: f.usedSalary,
+        }));
+    }
+
+    @Query(() => MlePresentationFranchiseDetail, {nullable: true})
+    async mlePresentationFranchiseDetail(
+        @Args("name", {type: () => String}) name: string,
+    ): Promise<MlePresentationFranchiseDetail | null> {
+        const detail = await this.franchiseService.getFranchiseDetail(name);
+        if (!detail) {
+            return null;
+        }
+
+        return {
+            name: detail.name,
+            callsign: detail.callsign,
+            division: detail.division,
+            conference: detail.conference,
+            branding: detail.branding
+                ? {
+                      logo: detail.branding.logo,
+                      primaryColor: detail.branding.primaryColor,
+                      secondaryColor: detail.branding.secondaryColor,
+                  }
+                : undefined,
+            franchiseManager: detail.franchiseManager
+                ? {
+                      id: detail.franchiseManager.id,
+                      name: detail.franchiseManager.name,
+                      role: detail.franchiseManager.role,
+                  }
+                : undefined,
+            generalManagers: detail.generalManagers.map((gm) => ({
+                id: gm.id,
+                name: gm.name,
+                role: gm.role,
+            })),
+            assistantGeneralManagers: detail.assistantGeneralManagers.map((agm) => ({
+                id: agm.id,
+                name: agm.name,
+                role: agm.role,
+            })),
+            captains: detail.captains.map((c) => ({
+                id: c.id,
+                name: c.name,
+                role: c.role,
+            })),
+            roster: detail.roster.map((p) => ({
+                id: p.id,
+                mleid: p.mleid,
+                name: p.name,
+                role: p.role,
+                league: p.league,
+                salary: p.salary,
+            })),
+            totalSalaryCap: detail.totalSalaryCap,
+            usedSalary: detail.usedSalary,
+            remainingSalary: detail.remainingSalary,
+        };
+    }
+}

--- a/core/src/mledb/mledb-franchise/mledb-franchise.presentation.service.ts
+++ b/core/src/mledb/mledb-franchise/mledb-franchise.presentation.service.ts
@@ -1,0 +1,262 @@
+import {Injectable} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import {Repository, ILike} from "typeorm";
+import {MLE_Player, MLE_Team, MLE_TeamBranding, MLE_TeamToCaptain} from "../../database/mledb";
+
+interface FranchiseStaff {
+    id: number;
+    name: string;
+    role: string;
+}
+
+interface FranchiseBranding {
+    logo?: string;
+    primaryColor?: string;
+    secondaryColor?: string;
+}
+
+interface RosterPlayer {
+    id: number;
+    mleid: number;
+    name: string;
+    role?: string;
+    league?: string;
+    salary: number;
+}
+
+interface FranchiseDetailResult {
+    name: string;
+    callsign: string;
+    division?: string;
+    conference?: string;
+    branding?: FranchiseBranding;
+    franchiseManager?: FranchiseStaff;
+    generalManagers: FranchiseStaff[];
+    assistantGeneralManagers: FranchiseStaff[];
+    captains: FranchiseStaff[];
+    roster: RosterPlayer[];
+    totalSalaryCap: number;
+    usedSalary: number;
+    remainingSalary: number;
+}
+
+interface FranchiseSummaryResult {
+    name: string;
+    callsign: string;
+    division?: string;
+    rosterCount: number;
+    usedSalary: number;
+}
+
+/**
+ * Service for MLEDB franchise presentation layer.
+ * Provides franchise search and detail queries for the presentation layer.
+ */
+@Injectable()
+export class MledbFranchisePresentationService {
+    constructor(
+        @InjectRepository(MLE_Team)
+        private readonly teamRepo: Repository<MLE_Team>,
+        @InjectRepository(MLE_Player)
+        private readonly playerRepo: Repository<MLE_Player>,
+    ) {}
+
+    /**
+     * Search franchises by partial name match.
+     */
+    async searchFranchises(query: string, limit: number = 10): Promise<FranchiseSummaryResult[]> {
+        const normalizedQuery = query.trim();
+        if (!normalizedQuery) {
+            return [];
+        }
+
+        const safeLimit = Math.min(Math.max(limit, 1), 25);
+
+        const teams = await this.teamRepo.find({
+            where: {name: ILike(`%${normalizedQuery}%`)},
+            take: safeLimit,
+            relations: ["branding"],
+            order: {name: "ASC"},
+        });
+
+        // Get roster counts and salary totals for each team
+        const results: FranchiseSummaryResult[] = [];
+        for (const team of teams) {
+            const roster = await this.getRosterForTeam(team.name);
+            const usedSalary = roster.reduce((sum, p) => sum + p.salary, 0);
+
+            results.push({
+                name: team.name,
+                callsign: team.callsign,
+                division: team.divisionName?.name,
+                rosterCount: roster.length,
+                usedSalary,
+            });
+        }
+
+        return results;
+    }
+
+    /**
+     * Get all franchises for index page.
+     */
+    async getAllFranchises(limit: number = 50): Promise<FranchiseSummaryResult[]> {
+        const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+        const teams = await this.teamRepo.find({
+            take: safeLimit,
+            relations: ["branding"],
+            order: {name: "ASC"},
+        });
+
+        const results: FranchiseSummaryResult[] = [];
+        for (const team of teams) {
+            const roster = await this.getRosterForTeam(team.name);
+            const usedSalary = roster.reduce((sum, p) => sum + p.salary, 0);
+
+            results.push({
+                name: team.name,
+                callsign: team.callsign,
+                division: team.divisionName?.name,
+                rosterCount: roster.length,
+                usedSalary,
+            });
+        }
+
+        return results;
+    }
+
+    /**
+     * Get detailed franchise information including staff and roster.
+     */
+    async getFranchiseDetail(name: string): Promise<FranchiseDetailResult | null> {
+        const team = await this.teamRepo.findOne({
+            where: {name},
+            relations: [
+                "branding",
+                "franchiseManager",
+                "generalManager",
+                "doublesAssistantGeneralManager",
+                "standardAssistantGeneralManager",
+                "divisionName",
+            ],
+        });
+
+        if (!team) {
+            return null;
+        }
+
+        // Build staff list
+        const staff: FranchiseStaff[] = [];
+        if (team.franchiseManager) {
+            staff.push({
+                id: team.franchiseManager.id,
+                name: team.franchiseManager.name,
+                role: "Franchise Manager",
+            });
+        }
+        if (team.generalManager) {
+            staff.push({
+                id: team.generalManager.id,
+                name: team.generalManager.name,
+                role: "General Manager",
+            });
+        }
+        if (team.doublesAssistantGeneralManager) {
+            staff.push({
+                id: team.doublesAssistantGeneralManager.id,
+                name: team.doublesAssistantGeneralManager.name,
+                role: "Doubles Assistant GM",
+            });
+        }
+        if (team.standardAssistantGeneralManager) {
+            staff.push({
+                id: team.standardAssistantGeneralManager.id,
+                name: team.standardAssistantGeneralManager.name,
+                role: "Standard Assistant GM",
+            });
+        }
+
+        // Get captains from team_to_captain table
+        const captains = await this.getCaptainsForTeam(name);
+
+        // Get roster
+        const roster = await this.getRosterForTeam(name);
+        const usedSalary = roster.reduce((sum, p) => sum + p.salary, 0);
+
+        // Default salary cap (can be made configurable)
+        const totalSalaryCap = 1000;
+
+        // Determine conference from division
+        let conference: string | undefined;
+        if (team.divisionName?.name) {
+            const divName = team.divisionName.name;
+            if (divName.includes("Premier") || divName.includes("Champ") || divName.includes("Master")) {
+                conference = "Champions";
+            } else {
+                conference = "Contenders";
+            }
+        }
+
+        return {
+            name: team.name,
+            callsign: team.callsign,
+            division: team.divisionName?.name,
+            conference,
+            branding: team.branding
+                ? {
+                      logo: team.branding.logoImgLink ?? undefined,
+                      primaryColor: team.branding.primaryColor ?? undefined,
+                      secondaryColor: team.branding.secondaryColor ?? undefined,
+                  }
+                : undefined,
+            franchiseManager: staff.find((s) => s.role === "Franchise Manager"),
+            generalManagers: staff.filter((s) => s.role === "General Manager"),
+            assistantGeneralManagers: staff.filter((s) => s.role.includes("Assistant GM")),
+            captains,
+            roster,
+            totalSalaryCap,
+            usedSalary,
+            remainingSalary: totalSalaryCap - usedSalary,
+        };
+    }
+
+    private async getRosterForTeam(teamName: string): Promise<RosterPlayer[]> {
+        const players = await this.playerRepo.find({
+            where: {teamName},
+        });
+
+        return players.map((p) => ({
+            id: p.id,
+            mleid: p.mleid,
+            name: p.name,
+            role: p.role ?? undefined,
+            league: p.league ? String(p.league) : undefined,
+            salary: p.salary,
+        }));
+    }
+
+    private async getCaptainsForTeam(teamName: string): Promise<FranchiseStaff[]> {
+        const captainRepo = this.playerRepo.manager.getRepository(MLE_TeamToCaptain);
+
+        const captains = await captainRepo.find({
+            where: {teamName},
+        });
+
+        const staff: FranchiseStaff[] = [];
+        for (const captain of captains) {
+            const player = await this.playerRepo.findOne({
+                where: {id: captain.playerId},
+            });
+            if (player) {
+                staff.push({
+                    id: player.id,
+                    name: player.name,
+                    role: "Captain",
+                });
+            }
+        }
+
+        return staff;
+    }
+}

--- a/core/src/mledb/mledb-franchise/mledb-franchise.presentation.types.ts
+++ b/core/src/mledb/mledb-franchise/mledb-franchise.presentation.types.ts
@@ -1,0 +1,106 @@
+import {Field, Int, ObjectType} from "@nestjs/graphql";
+
+@ObjectType()
+export class MlePresentationFranchiseStaff {
+    @Field(() => Int)
+    id!: number;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String)
+    role!: string;
+}
+
+@ObjectType()
+export class MlePresentationFranchiseBranding {
+    @Field(() => String, {nullable: true})
+    logo?: string;
+
+    @Field(() => String, {nullable: true})
+    primaryColor?: string;
+
+    @Field(() => String, {nullable: true})
+    secondaryColor?: string;
+}
+
+@ObjectType()
+export class MlePresentationFranchiseRosterPlayer {
+    @Field(() => Int)
+    id!: number;
+
+    @Field(() => Int)
+    mleid!: number;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String, {nullable: true})
+    role?: string;
+
+    @Field(() => String, {nullable: true})
+    league?: string;
+
+    @Field(() => Int)
+    salary!: number;
+}
+
+@ObjectType()
+export class MlePresentationFranchiseDetail {
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String)
+    callsign!: string;
+
+    @Field(() => String, {nullable: true})
+    division?: string;
+
+    @Field(() => String, {nullable: true})
+    conference?: string;
+
+    @Field(() => MlePresentationFranchiseBranding, {nullable: true})
+    branding?: MlePresentationFranchiseBranding;
+
+    @Field(() => MlePresentationFranchiseStaff, {nullable: true})
+    franchiseManager?: MlePresentationFranchiseStaff;
+
+    @Field(() => [MlePresentationFranchiseStaff])
+    generalManagers!: MlePresentationFranchiseStaff[];
+
+    @Field(() => [MlePresentationFranchiseStaff])
+    assistantGeneralManagers!: MlePresentationFranchiseStaff[];
+
+    @Field(() => [MlePresentationFranchiseStaff])
+    captains!: MlePresentationFranchiseStaff[];
+
+    @Field(() => [MlePresentationFranchiseRosterPlayer])
+    roster!: MlePresentationFranchiseRosterPlayer[];
+
+    @Field(() => Int)
+    totalSalaryCap!: number;
+
+    @Field(() => Int)
+    usedSalary!: number;
+
+    @Field(() => Int)
+    remainingSalary!: number;
+}
+
+@ObjectType()
+export class MlePresentationFranchiseSummary {
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String)
+    callsign!: string;
+
+    @Field(() => String, {nullable: true})
+    division?: string;
+
+    @Field(() => Int)
+    rosterCount!: number;
+
+    @Field(() => Int)
+    usedSalary!: number;
+}

--- a/core/src/mledb/mledb-interface.module.ts
+++ b/core/src/mledb/mledb-interface.module.ts
@@ -9,6 +9,7 @@ import {RosterRoleUsage} from "../database/franchise/roster_role_usages/roster_r
 import {RosterSlot} from "../database/franchise/roster_slot/roster_slot.model";
 import {Team} from "../database/franchise/team/team.model";
 import {MLE_Series} from "../database/mledb/Series.model";
+import {MLE_Team, MLE_TeamToCaptain} from "../database/mledb";
 import {MLE_TeamRoleUsage} from "../database/mledb/TeamRoleUsage.model";
 import {SeriesToMatchParent} from "../database/mledb-bridge/series_to_match_parent.model";
 import {Match} from "../database/scheduling/match/match.model";
@@ -26,6 +27,10 @@ import {MledbPlayerController} from "./mledb-player/mledb-player.controller";
 import {FormerPlayerScrimGuard} from "./mledb-player/mledb-player.guard";
 import {MledbPlayerPresentationResolver} from "./mledb-player/mledb-player.presentation.resolver";
 import {MledbPlayerAccountService} from "./mledb-player-account";
+import {
+    MledbFranchisePresentationResolver,
+    MledbFranchisePresentationService,
+} from "./mledb-franchise";
 import {MledbFinalizationService} from "./mledb-scrim";
 import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mledb-team-role-usage";
 
@@ -33,6 +38,8 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
     imports: [
         TypeOrmModule.forFeature([
             MLE_TeamRoleUsage,
+            MLE_Team,
+            MLE_TeamToCaptain,
             MLE_Series,
             SeriesToMatchParent,
             Match,
@@ -56,6 +63,8 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
         MledbPlayerService,
         MledbPlayerPresentationResolver,
         MledbPlayerAccountService,
+        MledbFranchisePresentationService,
+        MledbFranchisePresentationResolver,
         MledbFinalizationService,
         MledbMatchService,
         MledbNcpTeamRoleUsageService,


### PR DESCRIPTION
## Summary

Adds GraphQL queries for franchise search and detail to support the MLEDB sunset migration.

## GraphQL Queries Added

### mlePresentationFranchiseSearch
Search franchises by name:
```graphql
query {
  mlePresentationFranchiseSearch(query: "FP", limit: 10) {
    name
    callsign
    division
    rosterCount
    usedSalary
  }
}
```

### mlePresentationAllFranchises
Get all franchises for index:
```graphql
query {
  mlePresentationAllFranchises(limit: 50) {
    name
    callsign
    division
    rosterCount
    usedSalary
  }
}
```

### mlePresentationFranchiseDetail
Get detailed franchise info including staff and roster:
```graphql
query {
  mlePresentationFranchiseDetail(name: "FP") {
    name
    callsign
    division
    conference
    branding {
      logo
      primaryColor
      secondaryColor
    }
    franchiseManager { id name role }
    generalManagers { id name role }
    assistantGeneralManagers { id name role }
    captains { id name role }
    roster { id mleid name role league salary }
    totalSalaryCap
    usedSalary
    remainingSalary
  }
}
```

## Files Changed
- `core/src/mledb/mledb-franchise/` (new) - presentation types, service, resolver
- `core/src/mledb/mledb-interface.module.ts` - registered resolver and service

Part of MLEDB sunset - provides presentation layer to replace MLEBot franchise info commands.