### PR TITLE
fix: change franchise salary field from Int to Float

### DIFF
--- a/core/src/mledb/mledb-franchise/mledb-franchise.presentation.types.ts
+++ b/core/src/mledb/mledb-franchise/mledb-franchise.presentation.types.ts
@@ -1,4 +1,4 @@
-import {Field, Int, ObjectType} from "@nestjs/graphql";
+import {Field, Float, Int, ObjectType} from "@nestjs/graphql";
 
 @ObjectType()
 export class MlePresentationFranchiseStaff {
@@ -41,7 +41,7 @@ export class MlePresentationFranchiseRosterPlayer {
     @Field(() => String, {nullable: true})
     league?: string;
 
-    @Field(() => Int)
+    @Field(() => Float)
     salary!: number;
 }
 


### PR DESCRIPTION
## Summary

The salary field in  was declared as  but the database column  is defined as  (floating point).

## Error

When querying :


## Fix

Change  to  for the salary field in:
- 
- 

This matches the database schema and allows fractional salaries.