### PR TITLE
feat: add MLEDB FA/RFA/Waivers presentation layer

### DIFF
--- a/core/src/mledb/mledb-fa/index.ts
+++ b/core/src/mledb/mledb-fa/index.ts
@@ -1,0 +1,3 @@
+export * from "./mledb-fa.presentation.types";
+export * from "./mledb-fa.presentation.service";
+export * from "./mledb-fa.presentation.resolver";

--- a/core/src/mledb/mledb-fa/mledb-fa.presentation.resolver.ts
+++ b/core/src/mledb/mledb-fa/mledb-fa.presentation.resolver.ts
@@ -1,0 +1,78 @@
+import {Args, Int, Query, Resolver} from "@nestjs/graphql";
+
+import {MledbFaPresentationService} from "./mledb-fa.presentation.service";
+import {MlePresentationFaList, MlePresentationFreeAgent} from "./mledb-fa.presentation.types";
+
+@Resolver()
+export class MledbFaPresentationResolver {
+    constructor(private readonly faService: MledbFaPresentationService) {}
+
+    @Query(() => MlePresentationFaList)
+    async mlePresentationFreeAgents(
+        @Args("league", {type: () => String, nullable: true}) league?: string,
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationFaList> {
+        const result = await this.faService.getFreeAgents(league, limit ?? 50);
+        return {
+            league: result.league,
+            players: result.players.map((p) => ({
+                id: p.id,
+                mleid: p.mleid,
+                name: p.name,
+                teamName: p.teamName,
+                league: p.league,
+                salary: p.salary,
+                role: p.role,
+                suspended: p.suspended,
+            })),
+            totalCount: result.totalCount,
+            totalSalary: result.totalSalary,
+        };
+    }
+
+    @Query(() => MlePresentationFaList)
+    async mlePresentationRestrictedFreeAgents(
+        @Args("league", {type: () => String, nullable: true}) league?: string,
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationFaList> {
+        const result = await this.faService.getRestrictedFreeAgents(league, limit ?? 50);
+        return {
+            league: result.league,
+            players: result.players.map((p) => ({
+                id: p.id,
+                mleid: p.mleid,
+                name: p.name,
+                teamName: p.teamName,
+                league: p.league,
+                salary: p.salary,
+                role: p.role,
+                suspended: p.suspended,
+            })),
+            totalCount: result.totalCount,
+            totalSalary: result.totalSalary,
+        };
+    }
+
+    @Query(() => MlePresentationFaList)
+    async mlePresentationWaiverClaims(
+        @Args("league", {type: () => String, nullable: true}) league?: string,
+        @Args("limit", {type: () => Int, nullable: true}) limit?: number,
+    ): Promise<MlePresentationFaList> {
+        const result = await this.faService.getWaiverClaims(league, limit ?? 50);
+        return {
+            league: result.league,
+            players: result.players.map((p) => ({
+                id: p.id,
+                mleid: p.mleid,
+                name: p.name,
+                teamName: p.teamName,
+                league: p.league,
+                salary: p.salary,
+                role: p.role,
+                suspended: p.suspended,
+            })),
+            totalCount: result.totalCount,
+            totalSalary: result.totalSalary,
+        };
+    }
+}

--- a/core/src/mledb/mledb-fa/mledb-fa.presentation.service.ts
+++ b/core/src/mledb/mledb-fa/mledb-fa.presentation.service.ts
@@ -1,0 +1,178 @@
+import {Injectable} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import {Repository} from "typeorm";
+import {MLE_Player} from "../../database/mledb";
+
+interface FreeAgent {
+    id: number;
+    mleid: number;
+    name: string;
+    teamName?: string;
+    league?: string;
+    salary: number;
+    role?: string;
+    suspended: boolean;
+}
+
+interface FaListResult {
+    league: string;
+    players: FreeAgent[];
+    totalCount: number;
+    totalSalary: number;
+}
+
+/**
+ * Service for MLEDB Free Agent presentation layer.
+ * Provides FA/RFA/Waivers queries for the presentation layer.
+ */
+@Injectable()
+export class MledbFaPresentationService {
+    constructor(
+        @InjectRepository(MLE_Player)
+        private readonly playerRepo: Repository<MLE_Player>,
+    ) {}
+
+    /**
+     * Get free agents (players where teamName = 'FA')
+     */
+    async getFreeAgents(league?: string, limit: number = 50): Promise<FaListResult> {
+        const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+        const query = this.playerRepo.createQueryBuilder("player")
+            .where("player.teamName = :teamName", {teamName: "FA"})
+            .andWhere("player.suspended = :suspended", {suspended: false})
+            .orderBy("player.salary", "DESC")
+            .addOrderBy("player.name", "ASC")
+            .take(safeLimit);
+
+        if (league) {
+            query.andWhere("player.league = :league", {league});
+        }
+
+        const players = await query.getMany();
+
+        const mappedPlayers: FreeAgent[] = players.map((p) => ({
+            id: p.id,
+            mleid: p.mleid,
+            name: p.name,
+            teamName: p.teamName ?? undefined,
+            league: p.league ? String(p.league) : undefined,
+            salary: p.salary,
+            role: p.role ?? undefined,
+            suspended: p.suspended,
+        }));
+
+        const totalSalary = mappedPlayers.reduce((sum, p) => sum + p.salary, 0);
+        const leagueName = league ?? "ALL";
+
+        return {
+            league: leagueName,
+            players: mappedPlayers,
+            totalCount: mappedPlayers.length,
+            totalSalary,
+        };
+    }
+
+    /**
+     * Get restricted free agents (players where teamName = 'RFA')
+     */
+    async getRestrictedFreeAgents(league?: string, limit: number = 50): Promise<FaListResult> {
+        const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+        const query = this.playerRepo.createQueryBuilder("player")
+            .where("player.teamName = :teamName", {teamName: "RFA"})
+            .andWhere("player.suspended = :suspended", {suspended: false})
+            .orderBy("player.salary", "DESC")
+            .addOrderBy("player.name", "ASC")
+            .take(safeLimit);
+
+        if (league) {
+            query.andWhere("player.league = :league", {league});
+        }
+
+        const players = await query.getMany();
+
+        const mappedPlayers: FreeAgent[] = players.map((p) => ({
+            id: p.id,
+            mleid: p.mleid,
+            name: p.name,
+            teamName: p.teamName ?? undefined,
+            league: p.league ? String(p.league) : undefined,
+            salary: p.salary,
+            role: p.role ?? undefined,
+            suspended: p.suspended,
+        }));
+
+        const totalSalary = mappedPlayers.reduce((sum, p) => sum + p.salary, 0);
+        const leagueName = league ?? "ALL";
+
+        return {
+            league: leagueName,
+            players: mappedPlayers,
+            totalCount: mappedPlayers.length,
+            totalSalary,
+        };
+    }
+
+    /**
+     * Get waiver claims (players where teamName = 'WAIVERS')
+     */
+    async getWaiverClaims(league?: string, limit: number = 50): Promise<FaListResult> {
+        const safeLimit = Math.min(Math.max(limit, 1), 100);
+
+        const query = this.playerRepo.createQueryBuilder("player")
+            .where("player.teamName = :teamName", {teamName: "WAIVERS"})
+            .andWhere("player.suspended = :suspended", {suspended: false})
+            .orderBy("player.salary", "DESC")
+            .addOrderBy("player.name", "ASC")
+            .take(safeLimit);
+
+        if (league) {
+            query.andWhere("player.league = :league", {league});
+        }
+
+        const players = await query.getMany();
+
+        const mappedPlayers: FreeAgent[] = players.map((p) => ({
+            id: p.id,
+            mleid: p.mleid,
+            name: p.name,
+            teamName: p.teamName ?? undefined,
+            league: p.league ? String(p.league) : undefined,
+            salary: p.salary,
+            role: p.role ?? undefined,
+            suspended: p.suspended,
+        }));
+
+        const totalSalary = mappedPlayers.reduce((sum, p) => sum + p.salary, 0);
+        const leagueName = league ?? "ALL";
+
+        return {
+            league: leagueName,
+            players: mappedPlayers,
+            totalCount: mappedPlayers.length,
+            totalSalary,
+        };
+    }
+
+    /**
+     * Get all free agent categories at once
+     */
+    async getAllFreeAgentCategories(league?: string): Promise<{
+        freeAgents: FaListResult;
+        restrictedFreeAgents: FaListResult;
+        waiverClaims: FaListResult;
+    }> {
+        const [freeAgents, restrictedFreeAgents, waiverClaims] = await Promise.all([
+            this.getFreeAgents(league),
+            this.getRestrictedFreeAgents(league),
+            this.getWaiverClaims(league),
+        ]);
+
+        return {
+            freeAgents,
+            restrictedFreeAgents,
+            waiverClaims,
+        };
+    }
+}

--- a/core/src/mledb/mledb-fa/mledb-fa.presentation.types.ts
+++ b/core/src/mledb/mledb-fa/mledb-fa.presentation.types.ts
@@ -1,0 +1,43 @@
+import {Field, Float, Int, ObjectType} from "@nestjs/graphql";
+
+@ObjectType()
+export class MlePresentationFreeAgent {
+    @Field(() => Int)
+    id!: number;
+
+    @Field(() => Int)
+    mleid!: number;
+
+    @Field(() => String)
+    name!: string;
+
+    @Field(() => String, {nullable: true})
+    teamName?: string;
+
+    @Field(() => String, {nullable: true})
+    league?: string;
+
+    @Field(() => Float)
+    salary!: number;
+
+    @Field(() => String, {nullable: true})
+    role?: string;
+
+    @Field(() => Boolean)
+    suspended!: boolean;
+}
+
+@ObjectType()
+export class MlePresentationFaList {
+    @Field(() => String)
+    league!: string;
+
+    @Field(() => [MlePresentationFreeAgent])
+    players!: MlePresentationFreeAgent[];
+
+    @Field(() => Int)
+    totalCount!: number;
+
+    @Field(() => Int)
+    totalSalary!: number;
+}

--- a/core/src/mledb/mledb-interface.module.ts
+++ b/core/src/mledb/mledb-interface.module.ts
@@ -9,7 +9,7 @@ import {RosterRoleUsage} from "../database/franchise/roster_role_usages/roster_r
 import {RosterSlot} from "../database/franchise/roster_slot/roster_slot.model";
 import {Team} from "../database/franchise/team/team.model";
 import {MLE_Series} from "../database/mledb/Series.model";
-import {MLE_Team, MLE_TeamToCaptain} from "../database/mledb";
+import {MLE_Player, MLE_Team, MLE_TeamToCaptain} from "../database/mledb";
 import {MLE_TeamRoleUsage} from "../database/mledb/TeamRoleUsage.model";
 import {SeriesToMatchParent} from "../database/mledb-bridge/series_to_match_parent.model";
 import {Match} from "../database/scheduling/match/match.model";
@@ -31,6 +31,7 @@ import {
     MledbFranchisePresentationResolver,
     MledbFranchisePresentationService,
 } from "./mledb-franchise";
+import {MledbFaPresentationResolver, MledbFaPresentationService} from "./mledb-fa";
 import {MledbFinalizationService} from "./mledb-scrim";
 import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mledb-team-role-usage";
 
@@ -40,6 +41,7 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
             MLE_TeamRoleUsage,
             MLE_Team,
             MLE_TeamToCaptain,
+            MLE_Player,
             MLE_Series,
             SeriesToMatchParent,
             Match,
@@ -65,6 +67,8 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
         MledbPlayerAccountService,
         MledbFranchisePresentationService,
         MledbFranchisePresentationResolver,
+        MledbFaPresentationService,
+        MledbFaPresentationResolver,
         MledbFinalizationService,
         MledbMatchService,
         MledbNcpTeamRoleUsageService,


### PR DESCRIPTION
## Summary

Adds GraphQL queries for free agent lists to support the MLEDB sunset migration.

## GraphQL Queries Added

### mlePresentationFreeAgents
Get players where teamName = 'FA':
```graphql
query {
  mlePresentationFreeAgents(league: "PREMIER", limit: 20) {
    league
    totalCount
    totalSalary
    players {
      id
      mleid
      name
      salary
      league
    }
  }
}
```

### mlePresentationRestrictedFreeAgents
Get players where teamName = 'RFA':
```graphql
query {
  mlePresentationRestrictedFreeAgents(league: "CHAMPION") {
    league
    totalCount
    totalSalary
    players { id name salary }
  }
}
```

### mlePresentationWaiverClaims
Get players where teamName = 'WAIVERS':
```graphql
query {
  mlePresentationWaiverClaims {
    league
    totalCount
    totalSalary
    players { id name salary }
  }
}
```

## Implementation Details

- Filters by  column (FA, RFA, WAIVERS)
- Optional league filter
- Returns sorted by salary (desc), then name (asc)
- Includes totals: totalCount, totalSalary

## Files Changed
- `core/src/mledb/mledb-fa/` (new) - presentation types, service, resolver
- `core/src/mledb/mledb-interface.module.ts` - registered resolver and service

Part of MLEDB sunset - provides presentation layer for FA/RFA/Waivers lists.