### PR TITLE
Fix Postgres RPC JSONB serialization and service DB config

### DIFF
--- a/common/src/events/rmq.service.ts
+++ b/common/src/events/rmq.service.ts
@@ -2,6 +2,7 @@ import {Injectable, Logger} from "@nestjs/common";
 import {Observable} from "rxjs";
 
 import {PostgresService} from "../postgres";
+import {toJsonbParam} from "../postgres-transport";
 
 interface PostgresEventMessage {
     fields: {
@@ -36,7 +37,7 @@ export class RmqService {
         await this.ensureSchema();
         await this.postgres.query(
             "INSERT INTO sprocket.platform_event (topic, payload) VALUES ($1, $2)",
-            [topic, JSON.parse(data.toString())],
+            [topic, toJsonbParam(JSON.parse(data.toString()))],
         );
         return true;
     }

--- a/common/src/postgres-transport/postgres-client.ts
+++ b/common/src/postgres-transport/postgres-client.ts
@@ -6,6 +6,7 @@ import {
     PostgresTransportBase,
     PostgresTransportOptions,
     RpcQueueRow,
+    toJsonbParam,
 } from "./postgres-transport";
 
 export class PostgresClientProxy extends ClientProxy {
@@ -60,7 +61,7 @@ export class PostgresClientProxy extends ClientProxy {
                 INSERT INTO sprocket.platform_rpc_queue (id, queue, pattern, payload)
                 VALUES ($1, $2, $3, $4)
             `,
-            [id, this.transport.queue, pattern, packet.data],
+            [id, this.transport.queue, pattern, toJsonbParam(packet.data)],
         );
     }
 
@@ -93,6 +94,10 @@ export class PostgresClientProxy extends ClientProxy {
                     err: this.deserializeError(row.error),
                     isDisposed: true,
                 });
+                await this.transport.pool.query(
+                    "DELETE FROM sprocket.platform_rpc_queue WHERE id = $1",
+                    [id],
+                );
                 return;
             }
             await new Promise(resolve => setTimeout(resolve, this.transport.pollIntervalMs));

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -6,6 +6,7 @@ import {
     PostgresTransportBase,
     PostgresTransportOptions,
     RpcQueueRow,
+    toJsonbParam,
     withTransaction,
 } from "./postgres-transport";
 
@@ -136,25 +137,9 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
         // Debug: log what we're about to store
         console.log(`[PostgresServer] Storing response for ${id}:`, JSON.stringify(response).substring(0, 200));
         
-        // Explicitly handle JSON serialization to prevent double-encoding issues
-        // If response is already a string, parse it first to ensure it's valid JSON, then stringify again
-        // This handles edge cases where response might be a pre-serialized JSON string
-        let jsonValue: unknown = response;
-        if (typeof response === 'string') {
-            try {
-                // Try to parse as JSON - if it succeeds, use the parsed value
-                // This handles the case where response is a stringified JSON string
-                jsonValue = JSON.parse(response);
-            } catch {
-                // If parsing fails, treat it as a plain string value
-                jsonValue = response;
-            }
-        }
-        
-        // Validate JSON before storing - this catches malformed objects that would
-        // fail when PostgreSQL tries to parse them as JSON (e.g., extra braces)
+        let jsonValue: string | null;
         try {
-            jsonValue = JSON.parse(JSON.stringify(jsonValue));
+            jsonValue = toJsonbParam(response);
         } catch (error) {
             this.logger.error(`Failed to serialize response for ${id}: ${response}`, error);
             await this.fail(id, new Error(`Response serialization failed: ${error}`));
@@ -167,7 +152,7 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
                 SET status = 'completed', response = $2, updated_at = now()
                 WHERE id = $1
             `,
-            [id, jsonValue ?? null],
+            [id, jsonValue],
         );
     }
 
@@ -178,7 +163,7 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
                 SET status = 'failed', error = $2, updated_at = now()
                 WHERE id = $1
             `,
-            [id, this.serializeError(error)],
+            [id, toJsonbParam(this.serializeError(error))],
         );
     }
 

--- a/common/src/postgres-transport/postgres-transport.ts
+++ b/common/src/postgres-transport/postgres-transport.ts
@@ -35,6 +35,21 @@ export function createTransportPool(): Pool {
     });
 }
 
+export function toJsonbParam(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+
+    let jsonValue: unknown = value;
+    if (typeof value === "string") {
+        try {
+            jsonValue = JSON.parse(value);
+        } catch {
+            jsonValue = value;
+        }
+    }
+
+    return JSON.stringify(JSON.parse(JSON.stringify(jsonValue)));
+}
+
 export abstract class PostgresTransportBase {
     protected readonly logger: Logger;
 

--- a/infra/platform/src/Platform.ts
+++ b/infra/platform/src/Platform.ts
@@ -360,6 +360,7 @@ export class Platform extends pulumi.ComponentResource {
                 ? undefined
                 : new SprocketService(`${name}-discord-bot`, {
                     ...this.buildDefaultConfiguration("discord-bot", args.configRoot),
+                    flags: { database: true },
                     secrets: [{
                         secretId: this.secrets.discordBotToken.id,
                         secretName: this.secrets.discordBotToken.name,
@@ -386,6 +387,7 @@ export class Platform extends pulumi.ComponentResource {
                 ? undefined
                 : new SprocketService(`${name}-notification-service`, {
                     ...this.buildDefaultConfiguration("notification-service", args.configRoot),
+                    flags: { database: true },
                     secrets: [{
                         secretId: this.secrets.redisPassword.id,
                         secretName: this.secrets.redisPassword.name,
@@ -396,6 +398,7 @@ export class Platform extends pulumi.ComponentResource {
                 ? undefined
                 : new SprocketService(`${name}-image-generation-service`, {
                     ...this.buildDefaultConfiguration("image-generation-service", args.configRoot),
+                    flags: { database: true },
                     secrets: [{
                         secretId: this.secrets.s3SecretKey.id,
                         secretName: this.secrets.s3SecretKey.name,
@@ -404,10 +407,6 @@ export class Platform extends pulumi.ComponentResource {
                         secretId: this.secrets.s3AccessKey.id,
                         secretName: this.secrets.s3AccessKey.name,
                         fileName: "/app/secret/minio-access.txt"
-                    }, {
-                        secretId: this.secrets.postgresPassword.id,
-                        secretName: this.secrets.postgresPassword.name,
-                        fileName: "/app/secret/db-secret.txt"
                     }]
                 }, { parent: this }),
 
@@ -415,6 +414,7 @@ export class Platform extends pulumi.ComponentResource {
                 ? undefined
                 : new SprocketService(`${name}-server-analytics-service`, {
                     ...this.buildDefaultConfiguration("server-analytics-service", args.configRoot),
+                    flags: { database: true },
                     networks: [
                         args.monitoringNetworkId,
                         args.ingressNetworkId
@@ -439,6 +439,7 @@ export class Platform extends pulumi.ComponentResource {
 
             replayParse: new SprocketService(`${name}-replay-parse-service`, {
                 ...this.buildDefaultConfiguration("replay-parse-service", args.configRoot),
+                flags: { database: true },
                 env: {
                     ENV: "production",
                     CELERY_WORKER_MAX_TASKS_PER_CHILD: "50",

--- a/infra/platform/src/config/services/discord-bot.json
+++ b/infra/platform/src/config/services/discord-bot.json
@@ -3,6 +3,13 @@
     "prefix": "{{ bot.prefix }}"
   },
   "transport": {{{transport}}},
+  "db": {
+    "host": "{{database.host}}",
+    "port": {{database.port}},
+    "username": "{{database.username}}",
+    "database": "{{database.database}}",
+    "enable_logs": false
+  },
   "minio": {
     "endPoint": "{{s3.endpoint}}",
     "port": {{ s3.port }},

--- a/infra/platform/src/config/services/notification-service.json
+++ b/infra/platform/src/config/services/notification-service.json
@@ -1,5 +1,12 @@
 {
   "transport": {{{ transport }}},
+  "db": {
+    "host": "{{database.host}}",
+    "port": {{database.port}},
+    "username": "{{database.username}}",
+    "database": "{{database.database}}",
+    "enable_logs": false
+  },
   "logger": {
     "levels": {{{logger.levels}}}
   },

--- a/infra/platform/src/config/services/replay-parse-service.json
+++ b/infra/platform/src/config/services/replay-parse-service.json
@@ -5,6 +5,12 @@
     "queue": "{{ celery.queue }}"
   },
   "transport": {{{transport}}},
+  "db": {
+    "host": "{{database.host}}",
+    "port": {{database.port}},
+    "username": "{{database.username}}",
+    "database": "{{database.database}}"
+  },
   "minio": {
     "hostname": "{{ s3.endpoint }}",
     "bucket": "{{s3.buckets.replayParse}}",

--- a/infra/platform/src/config/services/server-analytics-service.json
+++ b/infra/platform/src/config/services/server-analytics-service.json
@@ -1,5 +1,12 @@
 {
   "transport": {{{transport}}},
+  "db": {
+    "host": "{{database.host}}",
+    "port": {{database.port}},
+    "username": "{{database.username}}",
+    "database": "{{database.database}}",
+    "enable_logs": false
+  },
   "logger": {
     "levels": {{{logger.levels}}}
   },


### PR DESCRIPTION

## Summary
- normalize Postgres transport RPC/event JSONB parameters through `toJsonbParam` so top-level JS arrays are bound as JSON, not PostgreSQL array literals
- delete failed RPC queue rows once the client observes the error, preventing permanently stuck failed requests from accumulating
- wire Postgres database config and password secret mounts into services now using the Postgres transport: discord bot, notification service, image generation, server analytics, and replay parse

## Production root cause
`GetAllScrims` returns a top-level JavaScript array. `node-postgres` binds JS arrays as PostgreSQL array literals, so writing the RPC response into a `jsonb` column failed with `invalid input syntax for type json`. That left queue rows failed/stuck and made matchmaking flaky after the Postgres transport migration.

Several services using the Postgres transport also lacked generated DB config or the expected `/app/secret/db-password.txt` secret mount, causing restart loops or fallback connection attempts.

## Production validation
- patched prod matchmaking image was able to complete a synthetic `GetAllScrims` RPC with an array response
- synthetic analytics RPC completed successfully
- affected prod services converged to 1/1 replicas after DB config/secret updates
- stale failed `GetAllScrims` queue rows were cleared after verification

## Local validation
- `npm run build --workspace=common`
- `npx tsc -p infra/platform/tsconfig.json --noEmit`

## Note
This branch intentionally carries the existing local Postgres migration history because GitHub `main` is behind the code currently needed to rebuild production cleanly. The final commit on this branch is the production hotfix from this investigation.
