### PR TITLE
Fix Postgres JSONB RPC array responses

### DIFF
--- a/common/src/events/rmq.service.ts
+++ b/common/src/events/rmq.service.ts
@@ -2,6 +2,7 @@ import {Injectable, Logger} from "@nestjs/common";
 import {Observable} from "rxjs";
 
 import {PostgresService} from "../postgres";
+import {toJsonbParam} from "../postgres-transport";
 
 interface PostgresEventMessage {
     fields: {
@@ -36,7 +37,7 @@ export class RmqService {
         await this.ensureSchema();
         await this.postgres.query(
             "INSERT INTO sprocket.platform_event (topic, payload) VALUES ($1, $2)",
-            [topic, JSON.parse(data.toString())],
+            [topic, toJsonbParam(JSON.parse(data.toString()))],
         );
         return true;
     }

--- a/common/src/postgres-transport/postgres-client.ts
+++ b/common/src/postgres-transport/postgres-client.ts
@@ -6,6 +6,7 @@ import {
     PostgresTransportBase,
     PostgresTransportOptions,
     RpcQueueRow,
+    toJsonbParam,
 } from "./postgres-transport";
 
 export class PostgresClientProxy extends ClientProxy {
@@ -60,7 +61,7 @@ export class PostgresClientProxy extends ClientProxy {
                 INSERT INTO sprocket.platform_rpc_queue (id, queue, pattern, payload)
                 VALUES ($1, $2, $3, $4)
             `,
-            [id, this.transport.queue, pattern, packet.data],
+            [id, this.transport.queue, pattern, toJsonbParam(packet.data)],
         );
     }
 
@@ -93,6 +94,10 @@ export class PostgresClientProxy extends ClientProxy {
                     err: this.deserializeError(row.error),
                     isDisposed: true,
                 });
+                await this.transport.pool.query(
+                    "DELETE FROM sprocket.platform_rpc_queue WHERE id = $1",
+                    [id],
+                );
                 return;
             }
             await new Promise(resolve => setTimeout(resolve, this.transport.pollIntervalMs));

--- a/common/src/postgres-transport/postgres-server.serialization.spec.ts
+++ b/common/src/postgres-transport/postgres-server.serialization.spec.ts
@@ -1,221 +1,79 @@
 /**
- * JSON Serialization Tests
- * 
+ * JSONB parameter serialization smoke tests.
+ *
  * Run with: npx ts-node common/src/postgres-transport/postgres-server.serialization.spec.ts
- * Or compile and run: tsc common/src/postgres-transport/postgres-server.serialization.spec.ts && node common/src/postgres-transport/postgres-server.serialization.spec.js
  */
 
-// Replicate the serializeResponse method for testing
-function serializeResponse(response: unknown): unknown {
-    // Handle null/undefined explicitly
-    if (response === null || response === undefined) {
-        return response;
-    }
+import {toJsonbParam} from "./postgres-transport";
 
-    // If it's already a string, validate it's valid JSON or store as-is
-    if (typeof response === 'string') {
-        try {
-            // Try to parse and re-serialize to ensure it's valid JSON
-            return JSON.parse(response);
-        } catch {
-            // If it's not valid JSON, wrap it in an object to make it valid JSON
-            return { value: response };
-        }
-    }
-
-    // If it has a toJSON method, use it (e.g., Date objects, custom classes)
-    if (typeof response === 'object' && response !== null && 'toJSON' in response) {
-        return (response as { toJSON: () => unknown }).toJSON();
-    }
-
-    // Validate by round-tripping through JSON
-    // This catches malformed objects with extra braces, circular refs, etc.
-    const serialized = JSON.stringify(response);
-    
-    // This will throw on circular references or other serialization issues
-    return JSON.parse(serialized);
-}
-
-// Test runner - renamed to avoid conflict with Jest globals
 let passed = 0;
 let failed = 0;
 
-function runTest(name: string, fn: () => void) {
+function runTest(name: string, fn: () => void): void {
     try {
         fn();
-        console.log(`✓ ${name}`);
+        console.log(`PASS ${name}`);
         passed++;
     } catch (error) {
-        console.error(`✗ ${name}`);
+        console.error(`FAIL ${name}`);
         console.error(`  ${error}`);
         failed++;
     }
 }
 
-// Renamed to avoid conflict with Jest globals - also added toBeNull
-function expectValue(actual: unknown) {
+function expectJsonParam(value: unknown): {
+    toBe(expected: unknown): void;
+} {
     return {
-        toBe(expected: unknown) {
+        toBe(expected: unknown): void {
+            const actual = value === null ? null : JSON.parse(String(value));
             if (JSON.stringify(actual) !== JSON.stringify(expected)) {
                 throw new Error(`Expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
             }
         },
-        toEqual(expected: unknown) {
-            if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-                throw new Error(`Expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
-            }
-        },
-        toThrow() {
-            throw new Error('Function was expected to throw but did not');
-        },
-        toBeNull() {
-            if (actual !== null) {
-                throw new Error(`Expected null but got ${JSON.stringify(actual)}`);
-            }
-        }
     };
 }
 
-// Tests
-console.log('\n=== JSON Serialization Tests ===\n');
+console.log("\n=== JSONB Parameter Serialization Tests ===\n");
 
-runTest('should handle null', () => {
-    expectValue(serializeResponse(null)).toBe(null);
+runTest("serializes top-level arrays as JSON text", () => {
+    const param = toJsonbParam([{id: "scrim-1"}, {id: "scrim-2"}]);
+    if (param !== "[{\"id\":\"scrim-1\"},{\"id\":\"scrim-2\"}]") {
+        throw new Error(`Expected JSON array text but got ${JSON.stringify(param)}`);
+    }
+    expectJsonParam(param).toBe([{id: "scrim-1"}, {id: "scrim-2"}]);
 });
 
-runTest('should handle undefined', () => {
-    expectValue(serializeResponse(undefined)).toBe(undefined);
+runTest("serializes objects as JSON text", () => {
+    expectJsonParam(toJsonbParam({name: "test", value: 123})).toBe({name: "test", value: 123});
 });
 
-runTest('should handle valid JSON string', () => {
-    const input = '{"name": "test", "value": 123}';
-    expectValue(serializeResponse(input)).toEqual({name: 'test', value: 123});
+runTest("preserves valid JSON strings as their parsed JSON value", () => {
+    expectJsonParam(toJsonbParam("[1,2,3]")).toBe([1, 2, 3]);
 });
 
-runTest('should handle plain string and wrap it', () => {
-    const input = 'plain text without json';
-    expectValue(serializeResponse(input)).toEqual({value: 'plain text without json'});
+runTest("stores plain strings as JSON strings", () => {
+    expectJsonParam(toJsonbParam("plain text")).toBe("plain text");
 });
 
-runTest('should handle empty string and wrap it', () => {
-    const input = '';
-    expectValue(serializeResponse(input)).toEqual({value: ''});
+runTest("stores null and undefined as SQL null", () => {
+    if (toJsonbParam(null) !== null) throw new Error("Expected null to become SQL null");
+    if (toJsonbParam(undefined) !== null) throw new Error("Expected undefined to become SQL null");
 });
 
-runTest('should handle simple object', () => {
-    const input = {name: 'test', count: 42};
-    expectValue(serializeResponse(input)).toEqual({name: 'test', count: 42});
-});
-
-runTest('should handle array', () => {
-    const input = [1, 2, 3, 'four'];
-    expectValue(serializeResponse(input)).toEqual([1, 2, 3, 'four']);
-});
-
-runTest('should handle Date objects via toJSON', () => {
-    const date = new Date('2026-06-21T04:00:00Z');
-    expectValue(serializeResponse(date)).toBe('2026-06-21T04:00:00.000Z');
-});
-
-runTest('should handle objects with custom toJSON', () => {
-    const obj = {
-        toJSON() {
-            return {custom: 'serialized'};
-        }
-    };
-    expectValue(serializeResponse(obj)).toEqual({custom: 'serialized'});
-});
-
-runTest('should handle nested objects', () => {
-    const input = {
-        user: {
-            profile: {
-                name: 'John'
-            }
-        }
-    };
-    expectValue(serializeResponse(input)).toEqual(input);
-});
-
-runTest('should handle boolean and number primitives', () => {
-    expectValue(serializeResponse(true)).toBe(true);
-    expectValue(serializeResponse(false)).toBe(false);
-    expectValue(serializeResponse(42)).toBe(42);
-    expectValue(serializeResponse(3.14)).toBe(3.14);
-});
-
-runTest('should throw on circular reference', () => {
-    const obj: Record<string, unknown> = {name: 'test'};
+runTest("throws on circular references", () => {
+    const obj: Record<string, unknown> = {name: "test"};
     obj.self = obj;
-    
+
     let threw = false;
     try {
-        serializeResponse(obj);
+        toJsonbParam(obj);
     } catch {
         threw = true;
     }
-    if (!threw) {
-        throw new Error('Expected to throw on circular reference');
-    }
+    if (!threw) throw new Error("Expected to throw on circular reference");
 });
 
-runTest('should handle object with extra braces (the original bug)', () => {
-    const input = {status: 'IN_PROGRESS', count: 1};
-    expectValue(serializeResponse(input)).toEqual(input);
-});
-
-runTest('should handle special JSON values', () => {
-    expectValue(serializeResponse(NaN)).toBeNull();
-    expectValue(serializeResponse(Infinity)).toBeNull();
-    expectValue(serializeResponse(-Infinity)).toBeNull();
-});
-
-runTest('should handle empty object', () => {
-    expectValue(serializeResponse({})).toEqual({});
-});
-
-runTest('should handle empty array', () => {
-    expectValue(serializeResponse([])).toEqual([]);
-});
-
-runTest('should handle object with null value', () => {
-    const input = {key: null};
-    expectValue(serializeResponse(input)).toEqual({key: null});
-});
-
-runTest('should handle complex nested arrays and objects', () => {
-    const input = {
-        scrims: [
-            {id: '1', status: 'IN_PROGRESS'},
-            {id: '2', status: 'COMPLETED'}
-        ],
-        metadata: {
-            total: 2,
-            page: 1
-        }
-    };
-    expectValue(serializeResponse(input)).toEqual(input);
-});
-
-runTest('should handle Unicode characters', () => {
-    const input = {name: '日本語', emoji: '🎮'};
-    expectValue(serializeResponse(input)).toEqual(input);
-});
-
-runTest('should handle string that looks like JSON array', () => {
-    const input = '[1, 2, 3]';
-    expectValue(serializeResponse(input)).toEqual([1, 2, 3]);
-});
-
-runTest('should handle string that looks like JSON primitive', () => {
-    expectValue(serializeResponse('42')).toBe(42);
-    expectValue(serializeResponse('true')).toBe(true);
-    expectValue(serializeResponse('null')).toBeNull();
-});
-
-// Summary
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);
 
-if (failed > 0) {
-    process.exit(1);
-}
+if (failed > 0) process.exit(1);

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -6,6 +6,7 @@ import {
     PostgresTransportBase,
     PostgresTransportOptions,
     RpcQueueRow,
+    toJsonbParam,
     withTransaction,
 } from "./postgres-transport";
 
@@ -132,55 +133,13 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
         }
 }
 
-    /**
-     * Safely serialize a response for storage in the RPC queue.
-     * This method is robust against various edge cases:
-     * - Pre-serialized JSON strings
-     * - Objects with toJSON() methods
-     * - Circular references (throws error)
-     * - Invalid JSON-producing values
-     * 
-     * @throws Error if serialization fails
-     */
-    private serializeResponse(response: unknown): unknown {
-        // Handle null/undefined explicitly
-        if (response === null || response === undefined) {
-            return response;
-        }
-
-        // If it's already a string, validate it's valid JSON or store as-is
-        if (typeof response === 'string') {
-            try {
-                // Try to parse and re-serialize to ensure it's valid JSON
-                return JSON.parse(response);
-            } catch {
-                // If it's not valid JSON, wrap it in an object to make it valid JSON
-                // This prevents storing raw invalid strings that would fail in PostgreSQL
-                this.logger.warn(`Response is a non-JSON string, wrapping in object: ${response.substring(0, 100)}`);
-                return { value: response };
-            }
-        }
-
-        // If it has a toJSON method, use it (e.g., Date objects, custom classes)
-        if (typeof response === 'object' && response !== null && 'toJSON' in response) {
-            return (response as { toJSON: () => unknown }).toJSON();
-        }
-
-        // Validate by round-tripping through JSON
-        // This catches malformed objects with extra braces, circular refs, etc.
-        const serialized = JSON.stringify(response);
-        
-        // This will throw on circular references or other serialization issues
-        return JSON.parse(serialized);
-    }
-
     private async complete(id: string, response: unknown): Promise<void> {
         // Debug: log what we're about to store
         console.log(`[PostgresServer] Storing response for ${id}:`, JSON.stringify(response).substring(0, 200));
         
-        let jsonValue: unknown;
+        let jsonValue: string | null;
         try {
-            jsonValue = this.serializeResponse(response);
+            jsonValue = toJsonbParam(response);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             this.logger.error(`Failed to serialize response for ${id}: ${response}`, error);
@@ -194,7 +153,7 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
                 SET status = 'completed', response = $2, updated_at = now()
                 WHERE id = $1
             `,
-            [id, jsonValue ?? null],
+            [id, jsonValue],
         );
     }
 
@@ -205,7 +164,7 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
                 SET status = 'failed', error = $2, updated_at = now()
                 WHERE id = $1
             `,
-            [id, this.serializeError(error)],
+            [id, toJsonbParam(this.serializeError(error))],
         );
     }
 

--- a/common/src/postgres-transport/postgres-transport.ts
+++ b/common/src/postgres-transport/postgres-transport.ts
@@ -35,6 +35,21 @@ export function createTransportPool(): Pool {
     });
 }
 
+export function toJsonbParam(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+
+    let jsonValue: unknown = value;
+    if (typeof value === "string") {
+        try {
+            jsonValue = JSON.parse(value);
+        } catch {
+            jsonValue = value;
+        }
+    }
+
+    return JSON.stringify(JSON.parse(JSON.stringify(jsonValue)));
+}
+
 export abstract class PostgresTransportBase {
     protected readonly logger: Logger;
 


### PR DESCRIPTION

## Summary
- bind Postgres RPC payloads, responses, errors, and event payloads as JSON text before writing `jsonb` columns
- fixes `GetAllScrims`, whose handler returns a top-level JavaScript array that `pg` otherwise sends as a PostgreSQL array literal
- delete failed RPC queue rows after the client observes the failure
- replace the stale standalone serialization script with smoke coverage for the actual `toJsonbParam` helper

## Root cause
Production deployments come from `origin/main`, and current `origin/main` still passes the validated `GetAllScrims` response array directly as the `$2` value in:

```sql
UPDATE sprocket.platform_rpc_queue
SET status = 'completed', response = $2
```

`node-postgres` treats JavaScript arrays as PostgreSQL array parameters, not JSON text. Casting that value into `jsonb` fails with `invalid input syntax for type json`, so callers see the RPC fail or time out while waiting for a completed response.

## Production reproduction
Against the live `prod-matchmaking` queue, a synthetic `GetAllScrims` row transitioned to `failed` in about 450 ms with:

```text
invalid input syntax for type json
at PostgresServer.complete (/app/common/lib/postgres-transport/postgres-server.js:136:9)
```

The underlying scrim persistence query was fast at the time: 3 active scrims, base query about 6 ms, players about 5 ms, games about 3 ms. So this is not a slow `findAll` query; it is the RPC response write.

## Validation
- `npm run build --workspace=common`
- `npx ts-node common/src/postgres-transport/postgres-server.serialization.spec.ts`
- verified in prod DB that an array param fails as `jsonb`, while the helper-style JSON string casts to a JSON array successfully
