### PR TITLE
fix: revert submission service response to delegate to Zod

### DIFF
--- a/common/src/service-connectors/submission/submission.service.ts
+++ b/common/src/service-connectors/submission/submission.service.ts
@@ -38,31 +38,11 @@ export class SubmissionService {
 
             const response = (await lastValueFrom(rx)) as unknown;
 
-            // Debug: log the raw response type to help diagnose issues
-            this.logger.debug(`Raw response for ${endpoint}: ${JSON.stringify(response).substring(0, 200)}`);
-
-            // Handle case where response might be wrapped or incorrect
-            let output: unknown;
-            if (Array.isArray(response)) {
-                output = response;
-            } else if (response && typeof response === 'object' && 'data' in response) {
-                // Handle { data: [...] } wrapper
-                output = (response as {data: unknown}).data;
-            } else if (response && typeof response === 'object' && Object.keys(response).length === 0) {
-                // Handle empty object {} - treat as empty array
-                this.logger.debug(`Received empty object {}, treating as empty array for ${endpoint}`);
-                output = [];
-            } else if (response === null || response === undefined) {
-                output = [];
-            } else {
-                throw new Error(`Unexpected response type: ${typeof response}`);
-            }
-
-            const parsed = outputSchema.parse(output);
-            this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(parsed).substring(0, 100)}...)`);
+            const output = outputSchema.parse(response);
+            this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(output).substring(0, 100)}...)`);
             return {
                 status: ResponseStatus.SUCCESS,
-                data: parsed,
+                data: output,
             };
         } catch (e) {
             this.logger.warn(`| < (${rid}) - | \`${endpoint}\` failed ${(e as Error).message}`);

--- a/microservices/submission-service/src/replay-submission/submission-service-response-handling.spec.ts
+++ b/microservices/submission-service/src/replay-submission/submission-service-response-handling.spec.ts
@@ -1,0 +1,71 @@
+import {of} from "rxjs";
+import {
+    ResponseStatus,
+    SubmissionEndpoint,
+    SubmissionService,
+} from "@sprocketbot/common";
+
+function makeService(returnValue: unknown): SubmissionService {
+    const mockClient = {
+        send: jest.fn().mockReturnValue(of(returnValue)),
+    };
+    return new SubmissionService(mockClient as any);
+}
+
+describe("SubmissionService.send", () => {
+    describe("CanSubmitReplays — returns an object", () => {
+        it("succeeds and returns the parsed object when canSubmit is true", async () => {
+            const service = makeService({canSubmit: true});
+            const result = await service.send(SubmissionEndpoint.CanSubmitReplays, {
+                submissionId: "sub-1",
+                memberId: 1,
+                userId: 1,
+            });
+            expect(result.status).toBe(ResponseStatus.SUCCESS);
+            if (result.status === ResponseStatus.SUCCESS) {
+                expect(result.data).toEqual({canSubmit: true});
+            }
+        });
+
+        it("succeeds and returns reason when canSubmit is false", async () => {
+            const service = makeService({canSubmit: false, reason: "Not a participant"});
+            const result = await service.send(SubmissionEndpoint.CanSubmitReplays, {
+                submissionId: "sub-1",
+                memberId: 1,
+                userId: 1,
+            });
+            expect(result.status).toBe(ResponseStatus.SUCCESS);
+            if (result.status === ResponseStatus.SUCCESS) {
+                expect(result.data).toEqual({canSubmit: false, reason: "Not a participant"});
+            }
+        });
+    });
+
+    describe("SubmitReplays — returns a string array", () => {
+        it("succeeds and returns the task id array", async () => {
+            const taskIds = ["task-uuid-1", "task-uuid-2"];
+            const service = makeService(taskIds);
+            const result = await service.send(SubmissionEndpoint.SubmitReplays, {
+                submissionId: "sub-1",
+                filepaths: [{minioPath: "replays/abc.replay", originalFilename: "game1.replay"}],
+                creatorId: 1,
+            });
+            expect(result.status).toBe(ResponseStatus.SUCCESS);
+            if (result.status === ResponseStatus.SUCCESS) {
+                expect(result.data).toEqual(taskIds);
+            }
+        });
+    });
+
+    describe("invalid responses — Zod rejects bad shapes", () => {
+        it("returns an error when the transport returns an unexpected shape", async () => {
+            const service = makeService({unexpected: "shape"});
+            const result = await service.send(SubmissionEndpoint.CanSubmitReplays, {
+                submissionId: "sub-1",
+                memberId: 1,
+                userId: 1,
+            });
+            expect(result.status).toBe(ResponseStatus.ERROR);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Seen on two of the mailbox tickets from Jgarret779 and warstog, when submitting they get an unexpected response type object error. 
- Cause: Replacing outputScehma.parse(response) with a large try catch block, which after looking at previous commits was done by Hermes Agents. Would throw an unexpected response type: object error whenever a non string array object was returned e.g CanSubmitReplays.
- According to claude this revert is safe due to the implementation of toJsonbParam() fixing the issue that the hermes agents were tackling to begin with.

## Tests
- Unit test added in 'submission-service-response-handling.spec.ts' that mocks the submission service
- Tests for 3 behaviours: Zod rejects bad shapes, CanSubmitReplays returns the correct object shape and the service sees it as a success, SubmitReplays returns a string array of tasks id's and the service sees it.
- Ran the tests with the old implementation , which fails and returns the unexpected response type:object error
- Ran them with the zod based implementation and they all pass.