### PR TITLE
[codex] Fix scrim replay upload response handling

### DIFF
--- a/common/src/service-connectors/submission/submission.service.spec.ts
+++ b/common/src/service-connectors/submission/submission.service.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Submission connector response-shape smoke tests.
+ *
+ * Run with: npx ts-node common/src/service-connectors/submission/submission.service.spec.ts
+ */
+
+import type {ClientProxy} from "@nestjs/microservices";
+import {of} from "rxjs";
+
+import {ResponseStatus} from "../../global.types";
+import {SubmissionEndpoint} from "./submission.types";
+import {SubmissionService} from "./submission.service";
+
+let passed = 0;
+let failed = 0;
+const tests: Array<Promise<void>> = [];
+
+function runTest(name: string, fn: () => Promise<void>): void {
+    tests.push(fn()
+        .then(() => {
+            console.log(`PASS ${name}`);
+            passed++;
+        })
+        .catch(error => {
+            console.error(`FAIL ${name}`);
+            console.error(`  ${error}`);
+            failed++;
+        }));
+}
+
+function createService(response: unknown): SubmissionService {
+    const client = {
+        send: () => of(response),
+    } as unknown as ClientProxy;
+
+    return new SubmissionService(client);
+}
+
+function assertSuccess<T>(value: {status: ResponseStatus; data?: T; error?: Error;}): T {
+    if (value.status !== ResponseStatus.SUCCESS) {
+        throw new Error(`Expected success but got ${value.error?.message}`);
+    }
+    return value.data as T;
+}
+
+console.log("\n=== Submission Connector Response Tests ===\n");
+
+runTest("accepts object responses for CanSubmitReplays success", async () => {
+    const service = createService({canSubmit: true});
+    const result = await service.send(SubmissionEndpoint.CanSubmitReplays, {
+        submissionId: "scrim-test",
+        memberId: 123,
+        userId: 456,
+    });
+
+    const data = assertSuccess(result);
+    if (data.canSubmit !== true) throw new Error("Expected canSubmit true");
+});
+
+runTest("accepts object responses for CanSubmitReplays rejection", async () => {
+    const service = createService({canSubmit: false, reason: "not your submission"});
+    const result = await service.send(SubmissionEndpoint.CanSubmitReplays, {
+        submissionId: "scrim-test",
+        memberId: 123,
+        userId: 456,
+    });
+
+    const data = assertSuccess(result);
+    if (data.canSubmit !== false || data.reason !== "not your submission") {
+        throw new Error(`Unexpected rejection payload ${JSON.stringify(data)}`);
+    }
+});
+
+runTest("accepts array responses for SubmitReplays task ids", async () => {
+    const service = createService(["task-1", "task-2"]);
+    const result = await service.send(SubmissionEndpoint.SubmitReplays, {
+        submissionId: "scrim-test",
+        creatorId: 456,
+        filepaths: [
+            {minioPath: "replays/one.replay", originalFilename: "one.replay"},
+            {minioPath: "replays/two.replay", originalFilename: "two.replay"},
+        ],
+    });
+
+    const data = assertSuccess(result);
+    if (data.length !== 2 || data[0] !== "task-1" || data[1] !== "task-2") {
+        throw new Error(`Unexpected task ids ${JSON.stringify(data)}`);
+    }
+});
+
+Promise.all(tests).then(() => {
+    console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);
+    if (failed > 0) process.exit(1);
+}).catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/common/src/service-connectors/submission/submission.service.ts
+++ b/common/src/service-connectors/submission/submission.service.ts
@@ -9,7 +9,7 @@ import {v4 as uuidv4} from "uuid";
 import type {MicroserviceRequestOptions} from "../../global.types";
 import {CommonClient, ResponseStatus} from "../../global.types";
 import type {
-    SubmissionEndpoint, SubmissionInput, SubmissionResponse,
+    SubmissionEndpoint, SubmissionInput, SubmissionOutput, SubmissionResponse,
 } from "./submission.types";
 import {SubmissionSchemas} from "./submission.types";
 
@@ -38,27 +38,22 @@ export class SubmissionService {
 
             const response = (await lastValueFrom(rx)) as unknown;
 
-            // Debug: log the raw response type to help diagnose issues
-            this.logger.debug(`Raw response for ${endpoint}: ${JSON.stringify(response).substring(0, 200)}`);
+            const initialParse = outputSchema.safeParse(response);
+            let parsed: SubmissionOutput<E>;
 
-            // Handle case where response might be wrapped or incorrect
-            let output: unknown;
-            if (Array.isArray(response)) {
-                output = response;
-            } else if (response && typeof response === 'object' && 'data' in response) {
-                // Handle { data: [...] } wrapper
-                output = (response as {data: unknown}).data;
-            } else if (response && typeof response === 'object' && Object.keys(response).length === 0) {
-                // Handle empty object {} - treat as empty array
+            if (initialParse.success) {
+                parsed = initialParse.data as SubmissionOutput<E>;
+            } else if (response && typeof response === "object" && "data" in response) {
+                parsed = outputSchema.parse((response as {data: unknown}).data) as SubmissionOutput<E>;
+            } else if (!initialParse.success && response && typeof response === "object" && Object.keys(response).length === 0) {
                 this.logger.debug(`Received empty object {}, treating as empty array for ${endpoint}`);
-                output = [];
-            } else if (response === null || response === undefined) {
-                output = [];
+                parsed = outputSchema.parse([]) as SubmissionOutput<E>;
+            } else if (!initialParse.success && (response === null || response === undefined)) {
+                parsed = outputSchema.parse([]) as SubmissionOutput<E>;
             } else {
-                throw new Error(`Unexpected response type: ${typeof response}`);
+                throw initialParse.error;
             }
 
-            const parsed = outputSchema.parse(output);
             this.logger.verbose(`| < (${rid}) - | \`${endpoint}\` (${JSON.stringify(parsed).substring(0, 100)}...)`);
             return {
                 status: ResponseStatus.SUCCESS,

--- a/microservices/replay-parse-service/Dockerfile
+++ b/microservices/replay-parse-service/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
         python3-dev \
+        protobuf-compiler \
         curl \
         git && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \


### PR DESCRIPTION
## Summary

Fixes scrim replay uploads failing with `Unexpected response type: object` before replay parsing starts.

## Root Cause

`SubmissionService.send()` normalized submission-service responses by response shape before applying the endpoint schema. `CanSubmitReplays` legitimately returns object payloads like `{ canSubmit: true }`, but the connector only accepted arrays, `{ data: ... }` wrappers, empty objects, or nullish values. That caused core to reject a valid upload authorization response before `SubmitReplays` or the parser ran.

## Changes

- Parse raw submission-service responses through the endpoint output schema first.
- Preserve compatibility for legacy `{ data: ... }`, empty object, and nullish fallback responses.
- Add an executable connector smoke spec for `CanSubmitReplays` object responses and `SubmitReplays` task-id arrays.
- Add `protobuf-compiler` to the replay-parse-service Docker build dependencies so `sprocket-rl-parser` can build during the root workspace build.

## Validation

- `npx ts-node common/src/service-connectors/submission/submission.service.spec.ts`
- `npm run build`

Notes: validation was run in the available local runtime, Node `v26.0.0` / npm `11.12.1`. The repo-documented Node 18 runtime was not available through local `nvm` in this shell.
