### PR TITLE
[codex] Speed up scrim list reads

### DIFF
--- a/common/src/service-connectors/matchmaking/schemas/scrim/GetAllScrims.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/GetAllScrims.schema.ts
@@ -1,9 +1,14 @@
 import {z} from "zod";
 
 import {ScrimSchema} from "../../types";
+import {ScrimStatus} from "../../types/ScrimStatus.enum";
 
 export const GetAllScrims_Request = z.object({
+    organizationId: z.number().optional(),
+    status: z.nativeEnum(ScrimStatus).optional(),
     skillGroupId: z.number().optional(),
+    skillGroupIds: z.array(z.number()).optional(),
+    lfs: z.boolean().optional(),
 });
 
 export const GetAllScrims_Response = z.array(ScrimSchema);

--- a/core/migrations/1779600000000-ScrimQueueReadIndexes.ts
+++ b/core/migrations/1779600000000-ScrimQueueReadIndexes.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ScrimQueueReadIndexes1779600000000 implements MigrationInterface {
+  name = 'ScrimQueueReadIndexes1779600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_scrim_queue_org_status_created" ON "sprocket"."scrim_queue" ("organization_id", "status", "created_at")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_scrim_queue_org_lfs_status_created" ON "sprocket"."scrim_queue" ("organization_id", "settings_lfs", "status", "created_at")',
+    );
+    await queryRunner.query(
+      'CREATE INDEX IF NOT EXISTS "IDX_scrim_queue_org_competitive_skill_status" ON "sprocket"."scrim_queue" ("organization_id", "settings_competitive", "skill_group_id", "status")',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX IF EXISTS "sprocket"."IDX_scrim_queue_org_competitive_skill_status"');
+    await queryRunner.query('DROP INDEX IF EXISTS "sprocket"."IDX_scrim_queue_org_lfs_status_created"');
+    await queryRunner.query('DROP INDEX IF EXISTS "sprocket"."IDX_scrim_queue_org_status_created"');
+  }
+}

--- a/core/src/scrim/scrim.management/scrim.management.resolver.ts
+++ b/core/src/scrim/scrim.management/scrim.management.resolver.ts
@@ -25,7 +25,7 @@ export class ScrimManagementResolver {
         nullable: true,
     })
     skillGroupId: number): Promise<IScrim[]> {
-        return this.scrimService.getAllScrims(skillGroupId);
+        return this.scrimService.getAllScrims({skillGroupId});
     }
 
     @Mutation(() => Scrim)

--- a/core/src/scrim/scrim.mod.resolver.ts
+++ b/core/src/scrim/scrim.mod.resolver.ts
@@ -87,9 +87,10 @@ export class ScrimModuleResolver {
     ): Promise<Scrim[]> {
         if (!user.currentOrganizationId) throw new GraphQLError("Player is not connected to an organization");
 
-        const scrims = await this.scrimService.getAllScrims();
-        if (status) return scrims.filter(s => s.status === status) as Scrim[];
-        return scrims.filter(s => s.organizationId === user.currentOrganizationId) as Scrim[];
+        return this.scrimService.getAllScrims({
+            organizationId: user.currentOrganizationId,
+            status,
+        }) as Promise<Scrim[]>;
     }
 
     @Query(() => [Scrim])
@@ -109,11 +110,14 @@ export class ScrimModuleResolver {
             where: {member: {user: {id: user.userId} } },
             relations: ["member", "skillGroup"],
         });
-        const scrims = await this.scrimService.getAllScrims();
+        const skillGroupIds = players.map(p => p.skillGroupId);
+        const scrims = await this.scrimService.getAllScrims({
+            organizationId: user.currentOrganizationId,
+            status,
+            skillGroupIds,
+        });
 
-        return scrims.filter(s => s.organizationId === user.currentOrganizationId
-        && (!s.settings.competitive || players.some(p => s.skillGroupId === p.skillGroupId))
-        && s.status === status) as Scrim[];
+        return scrims.filter(s => !s.settings.competitive || skillGroupIds.includes(s.skillGroupId)) as Scrim[];
     }
 
     @Query(() => [Scrim])
@@ -121,8 +125,10 @@ export class ScrimModuleResolver {
     async getLFSScrims(@CurrentUser() user: UserPayload): Promise<Scrim[]> {
         if (!user.currentOrganizationId) throw new GraphQLError("User is not connected to an organization");
 
-        const scrims = await this.scrimService.getAllScrims();
-        return scrims.filter(s => s.organizationId === user.currentOrganizationId && s.settings.lfs) as Scrim[];
+        return this.scrimService.getAllScrims({
+            organizationId: user.currentOrganizationId,
+            lfs: true,
+        }) as Promise<Scrim[]>;
     }
 
     @Query(() => Scrim, {nullable: true})

--- a/core/src/scrim/scrim.service.ts
+++ b/core/src/scrim/scrim.service.ts
@@ -9,6 +9,7 @@ import type {
     CreateLFSScrimRequest,
     CreateScrimOptions,
     JoinScrimOptions,
+    MatchmakingInput,
     Scrim as IScrim,
     ScrimMetrics as IScrimMetrics,
 } from "@sprocketbot/common";
@@ -27,6 +28,7 @@ import {PlayerStatLine} from "$db/scheduling/player_stat_line/player_stat_line.m
 
 import {GameSkillGroupService} from "../franchise";
 import {FranchiseService} from "../franchise/franchise";
+import {GameModeService} from "../game";
 import {MledbFinalizationService} from "../mledb";
 import {MemberService} from "../organization";
 import {ScrimPubSub} from "./constants";
@@ -42,6 +44,7 @@ export class ScrimService {
         private readonly matchmakingService: MatchmakingService,
         private readonly eventsService: EventsService,
         private readonly gameSkillGroupService: GameSkillGroupService,
+        private readonly gameModeService: GameModeService,
         private readonly memberService: MemberService,
         private readonly franchiseService: FranchiseService,
         private readonly mleScrimService: MledbFinalizationService,
@@ -66,12 +69,10 @@ export class ScrimService {
         return "scrims.lfs";
     }
 
-    async getAllScrims(skillGroupId?: number): Promise<IScrim[]> {
-        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetAllScrims, {
-            skillGroupId,
-        });
+    async getAllScrims(filters: MatchmakingInput<MatchmakingEndpoint.GetAllScrims> = {}): Promise<IScrim[]> {
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.GetAllScrims, filters);
 
-        if (result.status === ResponseStatus.SUCCESS) return result.data;
+        if (result.status === ResponseStatus.SUCCESS) return this.hydrateScrimMetadata(result.data);
         throw result.error;
     }
 
@@ -293,5 +294,28 @@ export class ScrimService {
                 }
             });
         });
+    }
+
+    private async hydrateScrimMetadata(scrims: IScrim[]): Promise<IScrim[]> {
+        const gameModeIds = Array.from(new Set(scrims.map(scrim => scrim.gameModeId)));
+        const skillGroupIds = Array.from(new Set(scrims.map(scrim => scrim.skillGroupId)));
+
+        const [gameModes, skillGroups] = await Promise.all([
+            Promise.all(gameModeIds.map(id => this.gameModeService.getGameModeById(id, {
+                relations: ["game"],
+            }))),
+            Promise.all(skillGroupIds.map(id => this.gameSkillGroupService.getGameSkillGroupById(id, {
+                relations: ["profile"],
+            }))),
+        ]);
+
+        const gameModesById = new Map(gameModes.map(gameMode => [gameMode.id, gameMode]));
+        const skillGroupsById = new Map(skillGroups.map(skillGroup => [skillGroup.id, skillGroup]));
+
+        return scrims.map(scrim => ({
+            ...scrim,
+            gameMode: gameModesById.get(scrim.gameModeId),
+            skillGroup: skillGroupsById.get(scrim.skillGroupId),
+        }));
     }
 }

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
@@ -224,6 +224,25 @@ describe("ScrimPostgresRepository", () => {
         expect(query.mock.calls[3][0]).not.toContain("SELECT g.scrim_id");
     });
 
+    it("pushes scrim list filters into the Postgres query", async () => {
+        const query = jest.fn().mockResolvedValue({rows: []});
+        const repo = new ScrimPostgresRepository({query} as any);
+
+        await repo.findAll({
+            organizationId: 2,
+            status: ScrimStatus.PENDING,
+            skillGroupIds: [4, 5],
+            lfs: false,
+        });
+
+        expect(query).toHaveBeenCalledTimes(1);
+        expect(query.mock.calls[0][0]).toContain("status = $1");
+        expect(query.mock.calls[0][0]).toContain("organization_id = $2");
+        expect(query.mock.calls[0][0]).toContain("settings_lfs = $3");
+        expect(query.mock.calls[0][0]).toContain("(settings_competitive = false OR skill_group_id = ANY($4::int[]))");
+        expect(query.mock.calls[0][1]).toEqual([ScrimStatus.PENDING, 2, false, [4, 5]]);
+    });
+
     it("updates status in the scrim table and stamps popped time for popped scrims", async () => {
         const query = jest.fn().mockResolvedValue({rows: []});
         const repo = new ScrimPostgresRepository({query} as any);

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
@@ -1,6 +1,8 @@
 import {Injectable} from "@nestjs/common";
 import type {
     CreateScrimOptions,
+    MatchmakingEndpoint,
+    MatchmakingInput,
     Scrim,
     ScrimGame,
     ScrimPlayer,
@@ -162,20 +164,45 @@ export class ScrimPostgresRepository {
         return this.hydrate(result.rows[0]);
     }
 
-    async findAll(skillGroupId?: number): Promise<Scrim[]> {
+    async findAll(filters: MatchmakingInput<MatchmakingEndpoint.GetAllScrims> = {}): Promise<Scrim[]> {
         // Filter at DB level using indexes - only load active scrims
         // This dramatically reduces data transfer and eliminates N+1 queries
         // Use the existing status and skill_group_id indexes
-        let query = `SELECT * FROM sprocket.scrim_queue 
-             WHERE status IN ('PENDING', 'POPPED', 'IN_PROGRESS')`;
+        let query = "SELECT * FROM sprocket.scrim_queue WHERE ";
         const params: unknown[] = [];
-        
-        // Filter by skill_group_id at DB level to use index
-        if (skillGroupId !== undefined) {
-            query += ` AND (skill_group_id = $1 OR settings_competitive = false)`;
-            params.push(skillGroupId);
+        const predicates: string[] = [];
+
+        if (filters.status) {
+            params.push(filters.status);
+            predicates.push(`status = $${params.length}`);
+        } else {
+            predicates.push("status IN ('PENDING', 'POPPED', 'IN_PROGRESS')");
         }
-        
+
+        if (filters.organizationId !== undefined) {
+            params.push(filters.organizationId);
+            predicates.push(`organization_id = $${params.length}`);
+        }
+
+        if (filters.lfs !== undefined) {
+            params.push(filters.lfs);
+            predicates.push(`settings_lfs = $${params.length}`);
+        }
+
+        const skillGroupIds = Array.from(new Set([
+            ...(filters.skillGroupId !== undefined ? [filters.skillGroupId] : []),
+            ...(filters.skillGroupIds ?? []),
+        ]));
+        if (filters.skillGroupId !== undefined || filters.skillGroupIds !== undefined) {
+            if (skillGroupIds.length > 0) {
+                params.push(skillGroupIds);
+                predicates.push(`(settings_competitive = false OR skill_group_id = ANY($${params.length}::int[]))`);
+            } else {
+                predicates.push("settings_competitive = false");
+            }
+        }
+
+        query += predicates.join(" AND ");
         query += ` ORDER BY created_at ASC`;
         
         const result = await this.postgres.query<ScrimRow>(query, params);

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -1,6 +1,8 @@
 import {Injectable} from "@nestjs/common";
 import type {
     CreateScrimOptions,
+    MatchmakingEndpoint,
+    MatchmakingInput,
     Scrim,
     ScrimGame,
     ScrimPlayer,
@@ -68,8 +70,8 @@ export class ScrimCrudService {
         return this.repository.findById(id);
     }
 
-    async getAllScrims(skillGroupId?: number): Promise<Scrim[]> {
-        return this.repository.findAll(skillGroupId);
+    async getAllScrims(filters: MatchmakingInput<MatchmakingEndpoint.GetAllScrims> = {}): Promise<Scrim[]> {
+        return this.repository.findAll(filters);
     }
 
     async getScrimsForClockCheck(): Promise<Scrim[]> {

--- a/microservices/matchmaking-service/src/scrim/scrim.controller.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.controller.ts
@@ -40,7 +40,7 @@ export class ScrimController {
     @MessagePattern(MatchmakingEndpoint.GetAllScrims)
     async getAllScrims(@Payload() payload: unknown): Promise<Scrim[]> {
         const data = MatchmakingSchemas.GetAllScrims.input.parse(payload);
-        return this.scrimCrudService.getAllScrims(data.skillGroupId);
+        return this.scrimCrudService.getAllScrims(data);
     }
 
     @MessagePattern(MatchmakingEndpoint.GetScrim)

--- a/reports/scrim-list-latency-2026-06-28.md
+++ b/reports/scrim-list-latency-2026-06-28.md
@@ -1,0 +1,52 @@
+# Scrim List Latency Diagnosis - 2026-06-28
+
+## Problem
+
+After moving scrim queue state from Redis to Postgres, `/scrims` could sit on loading states or take multiple seconds to complete `getAvailableScrims`, `getAllScrims`, or `getActiveScrims`.
+
+## Diagnosis
+
+The initial Postgres repository work had already removed the worst N+1 relation hydration inside matchmaking, but the cross-service read contract was still Redis-shaped:
+
+- core could only ask matchmaking for `GetAllScrims` with an optional single `skillGroupId`
+- `getAvailableScrims`, `getAllScrims`, and `getLFSScrims` fetched all active scrims and filtered by organization, status, LFS, and player skill group in core
+- GraphQL then resolved `gameMode`, `gameMode.game`, `skillGroup`, and `skillGroup.profile` per returned scrim unless those objects were preloaded
+
+That meant the frontend route could pay for unrelated active scrims from other organizations, plus resolver fanout, before rendering the landing page.
+
+## Change
+
+The scrim read contract now accepts Postgres-friendly filters:
+
+- `organizationId`
+- `status`
+- `skillGroupId`
+- `skillGroupIds`
+- `lfs`
+
+Core passes those filters at the matchmaking boundary, and matchmaking applies them directly in `sprocket.scrim_queue`. Core also preloads unique `gameMode.game` and `skillGroup.profile` metadata for scrim-list responses to avoid per-row GraphQL field-resolution queries.
+
+The follow-up migration `1779600000000-ScrimQueueReadIndexes` adds compound indexes for the new read shapes.
+
+## Validation
+
+Commands run:
+
+```bash
+npm run build --workspace=common
+npm run build --workspace=core
+npm run build --workspace=microservices/matchmaking-service
+npm run test --workspace=microservices/matchmaking-service -- scrim-postgres.repository.spec.ts --runInBand
+```
+
+The focused repository spec now asserts that filtered scrim list reads are pushed into the generated Postgres query.
+
+## Next Check
+
+After deploy, capture actual hosted timings for:
+
+- `getAvailableScrims(status: PENDING)`
+- `getCurrentScrim`
+- `getScrimMetrics`
+
+If responses are still slow, the next likely targets are the guards/current-user query set and scrim metrics aggregation.

--- a/reports/scrim-list-latency-2026-06-28.md
+++ b/reports/scrim-list-latency-2026-06-28.md
@@ -41,6 +41,28 @@ npm run test --workspace=microservices/matchmaking-service -- scrim-postgres.rep
 
 The focused repository spec now asserts that filtered scrim list reads are pushed into the generated Postgres query.
 
+## Local Timing Check
+
+After opening the PR, a localhost Docker Postgres timing check was run against a throwaway `sprocket_bench_codex` database on port `5434`.
+
+Seed shape:
+
+- 50,000 active `sprocket.scrim_queue` rows
+- 200,000 `sprocket.scrim_queue_player` rows
+- 200 organizations
+- filtered read target: organization `42`, status `PENDING`, skill groups `[2, 4, 6]`
+
+Repository-shaped timings included the primary scrim query plus the batched player and game child-row queries.
+
+| Read shape | Rows returned | Player rows loaded | Median time |
+| --- | ---: | ---: | ---: |
+| old broad active-scrims read | 50,000 | 200,000 | 539.03 ms |
+| new filtered read | 83 | 332 | 2.59 ms |
+
+Observed median speedup for this seeded dataset: `208x`.
+
+This is not a full GraphQL/browser timing because it does not include auth guards, current-user loading, GraphQL serialization, or frontend rendering. It does validate the main Postgres read-shape improvement locally.
+
 ## Next Check
 
 After deploy, capture actual hosted timings for:


### PR DESCRIPTION
## Summary

- push scrim-list filters from core into the matchmaking Postgres query path
- add compound indexes for common scrim-list read shapes
- preload unique scrim metadata in core so GraphQL list responses avoid per-row resolver fanout
- record the latency diagnosis and local timing check in reports/scrim-list-latency-2026-06-28.md

## Root Cause

The Postgres-backed scrim queue still had a Redis-shaped read contract. Core fetched broad active-scrim sets from matchmaking, then filtered by organization, status, LFS, and player skill group in memory. The returned list also triggered per-scrim metadata lookups through GraphQL field resolvers.

## Local Timing Check

Against a throwaway Docker Postgres database on localhost:5434 with 50,000 active scrims and 200,000 player rows:

| Read shape | Rows returned | Player rows loaded | Median time |
| --- | ---: | ---: | ---: |
| old broad active-scrims read | 50,000 | 200,000 | 539.03 ms |
| new filtered read | 83 | 332 | 2.59 ms |

Observed median speedup for this seeded repository-shaped read: 208x.

This is not a full GraphQL/browser timing; it validates the main Postgres read-shape improvement before hosted end-to-end timing.

## Validation

- npm run build --workspace=common
- npm run build --workspace=core
- npm run build --workspace=microservices/matchmaking-service
- npm run test --workspace=microservices/matchmaking-service -- scrim-postgres.repository.spec.ts --runInBand
- git diff --check

Note: the targeted Jest run still emits the existing node-config NODE_ENV=test warning, but the suite passes.
