### PR TITLE
[codex] Fix GraphQL CORS handling

### DIFF
--- a/clients/web/src/hooks.ts
+++ b/clients/web/src/hooks.ts
@@ -1,5 +1,5 @@
 import type {GetSession, Handle} from "@sveltejs/kit";
-import {constants, loadConfig} from "$lib/utils";
+import {apiUrl, constants, loadConfig} from "$lib/utils";
 import {add} from "date-fns";
 
 interface refreshPayload {
@@ -126,7 +126,7 @@ export const handle: Handle = async ({event, resolve}) => {
                         // Access token exists in cookies, see if we can
                         // refresh it.
                         const result = await doAuthRefresh(
-                            `http://${config.client.gqlUrl}/refresh`,
+                            apiUrl(config.client, "/refresh"),
                             currentCookies,
                         );
                         if (result) {
@@ -141,7 +141,7 @@ export const handle: Handle = async ({event, resolve}) => {
                     // No access token exists in cookies, see if we can
                     // refresh it anyway.
                     const result = await doAuthRefresh(
-                        `http://${config.client.gqlUrl}/refresh`,
+                        apiUrl(config.client, "/refresh"),
                         currentCookies,
                     );
                     if (result) {

--- a/clients/web/src/lib/api/client.ts
+++ b/clients/web/src/lib/api/client.ts
@@ -9,6 +9,7 @@ import {
     subscriptionExchange,
 } from "@urql/core";
 import {multipartFetchExchange} from "@urql/exchange-multipart-fetch";
+import {apiUrl, wsApiUrl} from "$lib/utils";
 
 let clientAvailable: CallableFunction;
 
@@ -24,10 +25,8 @@ export function initializeClient(sessionInput: App.Session): void {
         sessionData = d;
     });
 
-    const {secure, gqlUrl} = sessionData.config;
-
     const wsClient = browser
-        ? new SubscriptionClient(`ws${secure ? "s" : ""}://${gqlUrl}/graphql`, {
+        ? new SubscriptionClient(wsApiUrl(sessionData.config, "/graphql"), {
             minTimeout: 10000,
             reconnect: true,
             lazy: true,
@@ -36,7 +35,7 @@ export function initializeClient(sessionInput: App.Session): void {
         : null;
 
     client = new Client({
-        url: `http${secure ? "s" : ""}://${gqlUrl}/graphql`,
+        url: apiUrl(sessionData.config, "/graphql"),
         exchanges: [
             dedupExchange,
             cacheExchange,

--- a/clients/web/src/lib/utils/apiUrl.ts
+++ b/clients/web/src/lib/utils/apiUrl.ts
@@ -1,0 +1,27 @@
+import type {Config} from "./types";
+
+const withLeadingSlash = (path: string): string => path.startsWith("/") ? path : `/${path}`;
+
+export const apiUrl = (
+    clientConfig: Config["client"],
+    path: string,
+): string => {
+    const normalizedPath = withLeadingSlash(path);
+    const configuredUrl = clientConfig.gqlUrl.trim().replace(/\/+$/, "");
+
+    if (configuredUrl.includes("://")) {
+        const url = new URL(configuredUrl);
+        const basePath = url.pathname === "/graphql" ? "" : url.pathname.replace(/\/+$/, "");
+        url.pathname = `${basePath}${normalizedPath}`;
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+    }
+
+    return `http${clientConfig.secure ? "s" : ""}://${configuredUrl}${normalizedPath}`;
+};
+
+export const wsApiUrl = (
+    clientConfig: Config["client"],
+    path: string,
+): string => apiUrl(clientConfig, path).replace(/^http/, "ws");

--- a/clients/web/src/lib/utils/index.ts
+++ b/clients/web/src/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./constants";
 export * from "./extractJwt";
 export * from "./types";
 export * from "./config";
+export * from "./apiUrl";

--- a/core/src/app.module.ts
+++ b/core/src/app.module.ts
@@ -56,6 +56,7 @@ import {UtilModule} from "./util/util.module";
                 return {req};
             },
             tracing: true,
+            cors: false,
 
             // https://stackoverflow.com/questions/63991157/how-do-i-upload-multiple-files-with-nestjs-graphql
             uploads: false,

--- a/core/src/cors.ts
+++ b/core/src/cors.ts
@@ -1,0 +1,117 @@
+import type {CorsOptions} from "@nestjs/common/interfaces/external/cors-options.interface";
+import {config} from "@sprocketbot/common";
+import type {NextFunction, Request, Response} from "express";
+
+const CORS_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+const CORS_ALLOWED_HEADERS = [
+    "Accept",
+    "Apollo-Require-Preflight",
+    "Authorization",
+    "Content-Type",
+    "X-Apollo-Operation-Name",
+    "X-Requested-With",
+];
+
+const DEFAULT_ALLOWED_ORIGINS = [
+    "https://sprocket.mlesports.gg",
+    "https://www.sprocket.mlesports.gg",
+    "https://app.sprocket.gg",
+    "https://dev.sprocket.mlesports.gg",
+    "https://staging.sprocket.mlesports.gg",
+    "https://sprocket.spr.ocket.cloud",
+    "https://dev.sprocket.spr.ocket.cloud",
+    "https://staging.sprocket.spr.ocket.cloud",
+    "http://localhost:3000",
+    "http://localhost:8080",
+    "http://localhost:5173",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:8080",
+    "http://127.0.0.1:5173",
+];
+
+const OWNED_ORIGIN_PATTERNS = [
+    /^https:\/\/([a-z0-9-]+\.)?sprocket\.mlesports\.gg$/i,
+    /^https:\/\/([a-z0-9-]+\.)?sprocket\.spr\.ocket\.cloud$/i,
+    /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/i,
+];
+
+const normalizeOrigin = (origin: string): string => {
+    const trimmed = origin.trim().replace(/\/+$/, "");
+    if (!trimmed) return "";
+    if (trimmed.includes("://")) return trimmed;
+    if (trimmed.startsWith("localhost") || trimmed.startsWith("127.0.0.1")) return `http://${trimmed}`;
+    return `https://${trimmed}`;
+};
+
+const configuredAllowedOrigins = (): string[] => {
+    const origins = new Set(DEFAULT_ALLOWED_ORIGINS);
+    origins.add(normalizeOrigin(config.web.url));
+
+    for (const origin of (process.env.CORS_ALLOWED_ORIGINS ?? "").split(",")) {
+        const normalized = normalizeOrigin(origin);
+        if (normalized) origins.add(normalized);
+    }
+
+    return [...origins].filter(Boolean);
+};
+
+const isAllowedOrigin = (origin: string): boolean => {
+    const normalized = normalizeOrigin(origin);
+    return configuredAllowedOrigins().includes(normalized)
+        || OWNED_ORIGIN_PATTERNS.some(pattern => pattern.test(normalized));
+};
+
+const resolveOrigin = (origin: string | undefined): string | undefined => {
+    if (!origin) return undefined;
+    return isAllowedOrigin(origin) ? normalizeOrigin(origin) : undefined;
+};
+
+const appendVaryOrigin = (res: Response): void => {
+    const existing = res.getHeader("Vary");
+    if (!existing) {
+        res.setHeader("Vary", "Origin");
+        return;
+    }
+
+    const values = Array.isArray(existing) ? existing.join(",") : String(existing);
+    if (!values.toLowerCase().split(",").map(v => v.trim()).includes("origin")) {
+        res.setHeader("Vary", `${values}, Origin`);
+    }
+};
+
+export const corsOptions: CorsOptions = {
+    origin: (origin, callback): void => {
+        if (!origin) {
+            callback(null, true);
+            return;
+        }
+
+        callback(null, resolveOrigin(origin) ?? false);
+    },
+    credentials: true,
+    allowedHeaders: CORS_ALLOWED_HEADERS,
+    methods: CORS_METHODS,
+    maxAge: 86400,
+    optionsSuccessStatus: 204,
+};
+
+export const corsPreflightMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+    const allowedOrigin = resolveOrigin(req.headers.origin);
+
+    if (allowedOrigin) {
+        res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+        res.setHeader("Access-Control-Allow-Credentials", "true");
+        appendVaryOrigin(res);
+    }
+
+    res.setHeader("Access-Control-Allow-Methods", CORS_METHODS.join(","));
+    res.setHeader("Access-Control-Allow-Headers", CORS_ALLOWED_HEADERS.join(","));
+    res.setHeader("Access-Control-Max-Age", "86400");
+
+    if (req.method === "OPTIONS") {
+        res.status(204).send();
+        return;
+    }
+
+    next();
+};

--- a/core/src/main.ts
+++ b/core/src/main.ts
@@ -6,6 +6,7 @@ import {writeFile} from "fs/promises";
 import {SpelunkerModule} from "nestjs-spelunker";
 
 import {AppModule} from "./app.module";
+import {corsOptions, corsPreflightMiddleware} from "./cors";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function writeDepGraph(app: Awaited<ReturnType<typeof NestFactory.create>>): Promise<void> {
@@ -23,15 +24,11 @@ async function bootstrap(): Promise<void> {
         logger: config.logger.levels,
     });
 
+    app.use(corsPreflightMiddleware);
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.core_queue}),
     });
-    app.enableCors({
-        origin: true,
-        credentials: true,
-        allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
-        methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    });
+    app.enableCors(corsOptions);
     app.useGlobalPipes(new ValidationPipe());
 
     const httpAdapter = app.get(HttpAdapterHost);

--- a/reports/agent-harness-progress.md
+++ b/reports/agent-harness-progress.md
@@ -197,6 +197,10 @@ For Sprocket specifically, the highest-value initial target is not full autonomy
 46. Lane-contract update on March 13, 2026:
    - machine-readable lane contracts now exist under `environments/` for `local-dev`, `main-prod`, and planned `v15-beta`;
    - `scripts/harness/verify-lane.sh` now resolves lane-aware Tier 0 / Tier 1 / verify-all workflows using those contracts and surfaces missing-profile or not-yet-operational lane status explicitly.
+47. CORS diagnosis and harness update on June 28, 2026:
+   - hosted `main-prod` GraphQL responses were observed returning `access-control-allow-origin: *` with credentials enabled, which browsers reject for credential-capable frontend requests;
+   - `core` now centralizes CORS handling, disables Apollo's wildcard GraphQL CORS layer, reflects allowed Sprocket origins explicitly, and answers `OPTIONS` before GraphQL routing;
+   - `scripts/harness/check-api.sh` now has a CORS mode that checks both the main API response and browser-style preflight, and the hosted main/dev/staging Tier 0 profiles enable it.
 
 ## Agreed Direction
 

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -87,6 +87,8 @@ Optional:
 - `HARNESS_AUTH_HEADER`
 - `HARNESS_EXPECTED_API_STATUSES` default `200,400,401,403,405`
 - `HARNESS_EXPECTED_API_MARKER`
+- `HARNESS_CHECK_CORS_PREFLIGHT` default `false`; when `true`, sends an `Origin` header on the API check and verifies both response CORS headers and an `OPTIONS` preflight
+- `HARNESS_CORS_ORIGIN`; defaults to `HARNESS_WEB_URL` when unset
 
 Example:
 
@@ -94,6 +96,8 @@ Example:
 HARNESS_ENV_NAME=main-prod \
 HARNESS_API_URL=https://api.sprocket.example.com/graphql \
 HARNESS_EXPECTED_API_STATUSES=200,400,401,403,405 \
+HARNESS_CHECK_CORS_PREFLIGHT=true \
+HARNESS_CORS_ORIGIN=https://sprocket.example.com \
 bash ./scripts/harness/check-api.sh
 ```
 

--- a/scripts/harness/check-api.sh
+++ b/scripts/harness/check-api.sh
@@ -15,10 +15,14 @@ API_METHOD="${HARNESS_API_METHOD:-GET}"
 EXPECTED_MARKER="${HARNESS_EXPECTED_API_MARKER:-}"
 CONTENT_TYPE="${HARNESS_CONTENT_TYPE:-application/json}"
 AUTH_HEADER="${HARNESS_AUTH_HEADER:-}"
+CHECK_CORS_PREFLIGHT="${HARNESS_CHECK_CORS_PREFLIGHT:-false}"
+CORS_ORIGIN="${HARNESS_CORS_ORIGIN:-${HARNESS_WEB_URL:-}}"
 API_URL="$(harness_normalize_url "${HARNESS_API_URL}")"
 
 HEADERS_FILE="${STEP_DIR}/headers.txt"
 BODY_FILE="${STEP_DIR}/body.txt"
+PREFLIGHT_HEADERS_FILE="${STEP_DIR}/preflight-headers.txt"
+PREFLIGHT_BODY_FILE="${STEP_DIR}/preflight-body.txt"
 
 CURL_ARGS=(
   -sS
@@ -31,6 +35,10 @@ CURL_ARGS=(
 
 if [[ -n "${AUTH_HEADER}" ]]; then
   CURL_ARGS+=(-H "${AUTH_HEADER}")
+fi
+
+if [[ "${CHECK_CORS_PREFLIGHT}" == "true" && -n "${CORS_ORIGIN}" ]]; then
+  CURL_ARGS+=(-H "Origin: ${CORS_ORIGIN}")
 fi
 
 if [[ -n "${HARNESS_API_BODY_FILE:-}" ]]; then
@@ -67,6 +75,75 @@ if [[ -n "${EXPECTED_MARKER}" ]] && ! grep -Fq "${EXPECTED_MARKER}" "${BODY_FILE
   exit 1
 fi
 
+if [[ "${CHECK_CORS_PREFLIGHT}" == "true" ]]; then
+  if [[ -z "${CORS_ORIGIN}" ]]; then
+    harness_write_summary "${STEP_DIR}/summary.txt" \
+      "status=fail" \
+      "reason=missing_cors_origin" \
+      "url=${API_URL}"
+    printf "API CORS preflight failed: HARNESS_CORS_ORIGIN or HARNESS_WEB_URL is required\n" >&2
+    exit 1
+  fi
+
+  if ! grep -Eiq "^access-control-allow-origin: ${CORS_ORIGIN//./\\.}\r?$" "${HEADERS_FILE}"; then
+    harness_write_summary "${STEP_DIR}/summary.txt" \
+      "status=fail" \
+      "reason=missing_cors_response_allow_origin" \
+      "url=${API_URL}" \
+      "origin=${CORS_ORIGIN}" \
+      "status_code=${API_STATUS}"
+    printf "API CORS response failed: missing access-control-allow-origin for %s\n" "${CORS_ORIGIN}" >&2
+    exit 1
+  fi
+
+  PREFLIGHT_META="$(curl \
+    -sS \
+    --max-time "${TIMEOUT_SECONDS}" \
+    -X OPTIONS \
+    -H "Origin: ${CORS_ORIGIN}" \
+    -H "Access-Control-Request-Method: POST" \
+    -H "Access-Control-Request-Headers: content-type,authorization" \
+    -D "${PREFLIGHT_HEADERS_FILE}" \
+    -o "${PREFLIGHT_BODY_FILE}" \
+    -w '%{http_code}|%{time_total}|%{url_effective}' \
+    "${API_URL}")"
+  IFS='|' read -r PREFLIGHT_STATUS PREFLIGHT_TIME PREFLIGHT_EFFECTIVE_URL <<< "${PREFLIGHT_META}"
+
+  if [[ "${PREFLIGHT_STATUS}" != "204" ]]; then
+    harness_write_summary "${STEP_DIR}/summary.txt" \
+      "status=fail" \
+      "reason=unexpected_cors_preflight_status" \
+      "url=${API_URL}" \
+      "origin=${CORS_ORIGIN}" \
+      "status_code=${PREFLIGHT_STATUS}" \
+      "expected_status=204"
+    printf "API CORS preflight failed: expected 204, got %s\n" "${PREFLIGHT_STATUS}" >&2
+    exit 1
+  fi
+
+  if ! grep -Eiq "^access-control-allow-origin: ${CORS_ORIGIN//./\\.}\r?$" "${PREFLIGHT_HEADERS_FILE}"; then
+    harness_write_summary "${STEP_DIR}/summary.txt" \
+      "status=fail" \
+      "reason=missing_cors_allow_origin" \
+      "url=${API_URL}" \
+      "origin=${CORS_ORIGIN}" \
+      "status_code=${PREFLIGHT_STATUS}"
+    printf "API CORS preflight failed: missing access-control-allow-origin for %s\n" "${CORS_ORIGIN}" >&2
+    exit 1
+  fi
+
+  if ! grep -Eiq "^access-control-allow-headers: .*authorization" "${PREFLIGHT_HEADERS_FILE}"; then
+    harness_write_summary "${STEP_DIR}/summary.txt" \
+      "status=fail" \
+      "reason=missing_cors_authorization_header" \
+      "url=${API_URL}" \
+      "origin=${CORS_ORIGIN}" \
+      "status_code=${PREFLIGHT_STATUS}"
+    printf "API CORS preflight failed: authorization is not allowed\n" >&2
+    exit 1
+  fi
+fi
+
 harness_write_summary "${STEP_DIR}/summary.txt" \
   "status=pass" \
   "url=${API_URL}" \
@@ -74,6 +151,8 @@ harness_write_summary "${STEP_DIR}/summary.txt" \
   "status_code=${API_STATUS}" \
   "effective_url=${API_EFFECTIVE_URL}" \
   "time_seconds=${API_TIME}" \
+  "cors_preflight_checked=${CHECK_CORS_PREFLIGHT}" \
+  "cors_origin=${CORS_ORIGIN:-none}" \
   "marker_checked=${EXPECTED_MARKER:-none}"
 
 printf "check-api passed for %s (%s %s)\n" "${API_URL}" "${API_METHOD}" "${API_STATUS}"

--- a/scripts/harness/env/main-dev.env
+++ b/scripts/harness/env/main-dev.env
@@ -19,5 +19,7 @@ HARNESS_API_URL=https://api.dev.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_WEB_STATUSES=200,302
 HARNESS_EXPECTED_WEB_MARKER="Sign in with Discord"
 HARNESS_EXPECTED_API_STATUSES=200,400,401,403,405
+HARNESS_CHECK_CORS_PREFLIGHT=true
+HARNESS_CORS_ORIGIN=https://dev.sprocket.mlesports.gg
 HARNESS_DEPENDENCY_URLS=web=https://dev.sprocket.mlesports.gg,api=https://api.dev.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_DEPENDENCY_STATUSES=200,302,400,405

--- a/scripts/harness/env/main-prod.env
+++ b/scripts/harness/env/main-prod.env
@@ -4,5 +4,7 @@ HARNESS_API_URL=https://api.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_WEB_STATUSES=200,302
 HARNESS_EXPECTED_WEB_MARKER="Sign in with Discord"
 HARNESS_EXPECTED_API_STATUSES=200,400,401,403,405
+HARNESS_CHECK_CORS_PREFLIGHT=true
+HARNESS_CORS_ORIGIN=https://sprocket.mlesports.gg
 HARNESS_DEPENDENCY_URLS=web=https://sprocket.mlesports.gg,api=https://api.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_DEPENDENCY_STATUSES=200,302,400,405

--- a/scripts/harness/env/main-staging.env
+++ b/scripts/harness/env/main-staging.env
@@ -5,5 +5,7 @@ HARNESS_API_URL=https://api.staging.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_WEB_STATUSES=200,302
 HARNESS_EXPECTED_WEB_MARKER="Sign in with Discord"
 HARNESS_EXPECTED_API_STATUSES=200,400,401,403,405
+HARNESS_CHECK_CORS_PREFLIGHT=true
+HARNESS_CORS_ORIGIN=https://staging.sprocket.mlesports.gg
 HARNESS_DEPENDENCY_URLS=web=https://staging.sprocket.mlesports.gg,api=https://api.staging.sprocket.mlesports.gg/graphql
 HARNESS_EXPECTED_DEPENDENCY_STATUSES=200,302,400,405


### PR DESCRIPTION
## Summary

Fixes frontend CORS failures by moving core GraphQL CORS handling to one explicit policy instead of allowing Apollo/Nest layers to emit conflicting headers.

## Root Cause

Hosted `main-prod` GraphQL responses were observed returning `access-control-allow-origin: *` while credentials were enabled. Browsers reject that combination for credential-capable requests, so some authenticated frontend calls could fail even when the API itself returned a valid GraphQL response.

## Changes

- Added centralized core CORS policy and preflight middleware.
- Disabled Apollo GraphQL's wildcard CORS layer.
- Reflected only allowed Sprocket/local origins and allowed auth/upload-related request headers.
- Made web API URL construction tolerate both host-only and full URL `CLIENT_GQL_URL` values.
- Added Tier 0 harness CORS checks for both the main API response and browser-style `OPTIONS` preflight.
- Enabled those CORS checks in main/dev/staging hosted Tier 0 profiles.
- Documented the diagnosis in the harness progress log.

## Validation

- `npm run build --workspace=core`
- `npm run build --workspace=clients/web` (passes with existing Svelte warnings)
- `bash -n scripts/harness/check-api.sh`
- `git diff --check`
- `npm run verify:tier0 -- main-prod` now fails against current production with `missing_cors_response_allow_origin`, proving the harness catches the existing deployed wildcard CORS regression before this fix is deployed.