### PR TITLE
[codex] Fix Elo consumer dependency injection

### DIFF
--- a/core/src/elo/elo.consumer.spec.ts
+++ b/core/src/elo/elo.consumer.spec.ts
@@ -1,0 +1,32 @@
+import "reflect-metadata";
+
+import {PostgresService} from "@sprocketbot/common";
+
+jest.mock("../franchise", () => ({
+    PlayerService: class PlayerService {},
+}));
+jest.mock("../game", () => ({
+    GameFeatureService: class GameFeatureService {},
+    GameService: class GameService {},
+}));
+jest.mock("../organization", () => ({
+    OrganizationService: class OrganizationService {},
+}));
+jest.mock("./elo-connector", () => ({
+    EloConnectorService: class EloConnectorService {},
+    EloEndpoint: {
+        CalculateSalaries: "calculate-salaries",
+        CompactGraph: "compact-graph",
+    },
+}));
+
+import {EloConsumer} from "./elo.consumer";
+
+describe("EloConsumer", () => {
+    it("emits constructor metadata for Nest dependency injection", () => {
+        const paramTypes = Reflect.getMetadata("design:paramtypes", EloConsumer) as unknown[];
+
+        expect(paramTypes).toHaveLength(7);
+        expect(paramTypes[6]).toBe(PostgresService);
+    });
+});

--- a/core/src/elo/elo.consumer.ts
+++ b/core/src/elo/elo.consumer.ts
@@ -1,4 +1,4 @@
-import {Logger, OnApplicationBootstrap, OnModuleDestroy} from "@nestjs/common";
+import {Injectable, Logger, OnApplicationBootstrap, OnModuleDestroy} from "@nestjs/common";
 import {AnalyticsEndpoint, AnalyticsService, PostgresService} from "@sprocketbot/common";
 
 import {FeatureCode} from "$db/game/feature/feature.enum";
@@ -13,6 +13,7 @@ export const WEEKLY_SALARIES_JOB_NAME = "weeklySalaries";
 // Configurable via WEEKLY_SALARIES_INTERVAL_MS env var (default: 1 hour)
 const WEEKLY_SALARIES_INTERVAL_MS = parseInt(process.env.WEEKLY_SALARIES_INTERVAL_MS || "3600000", 10);
 
+@Injectable()
 export class EloConsumer implements OnApplicationBootstrap, OnModuleDestroy {
     private readonly logger = new Logger(EloConsumer.name);
 


### PR DESCRIPTION
## Summary

Fixes the core service log spam:

`ERROR [EloConsumer] PostgresService not injected - this is a configuration error. Check that PostgresModule is imported`

Root cause: `EloConsumer` was registered as a Nest provider, and `EloModule` already imported `PostgresModule`, but `EloConsumer` itself was missing `@Injectable()`. Without that decorator, TypeScript/Nest did not emit constructor dependency metadata for the consumer, so Nest could instantiate it with undefined constructor parameters.

## Changes

- Adds `@Injectable()` to `EloConsumer`.
- Adds a focused regression spec asserting that `EloConsumer` emits constructor metadata and that the `PostgresService` constructor dependency is present.

## Validation

- `npm run test --workspace=core -- --runTestsByPath src/elo/elo.consumer.spec.ts --runInBand`
- `npm run build --workspace=core`