### PR TITLE
[codex] fix core healthcheck reboot loop

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -8,6 +8,6 @@ ENTRYPOINT npm run test --workspace=core
 
 FROM $BASE_IMAGE AS app_image
 RUN npm run build --workspace=core
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=15s --timeout=30s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3001/healthz',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 ENTRYPOINT node /app/core/dist/main.js

--- a/core/src/main.ts
+++ b/core/src/main.ts
@@ -2,6 +2,7 @@ import {ValidationPipe} from "@nestjs/common";
 import {HttpAdapterHost, NestFactory} from "@nestjs/core";
 import {AllExceptionsFilter, config, PostgresServer} from "@sprocketbot/common";
 import {ht} from "date-fns/locale";
+import {Request, Response} from "express";
 import {writeFile} from "fs/promises";
 import {SpelunkerModule} from "nestjs-spelunker";
 
@@ -24,7 +25,12 @@ async function bootstrap(): Promise<void> {
         logger: config.logger.levels,
     });
 
+    app.getHttpAdapter().getInstance().get("/healthz", (_req: Request, res: Response) => {
+        res.status(200).json({status: "ok"});
+    });
+
     app.use(corsPreflightMiddleware);
+
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.core_queue}),
     });


### PR DESCRIPTION
## Summary

Fix the core service healthcheck loop by making the container check more tolerant and moving the `/healthz` response onto a direct Express route.

## Root Cause

The Docker healthcheck allowed only 5 seconds for `/healthz`, and the route was served through the normal NestJS request path. Under load or during startup, that made a lightweight liveness check depend on the full app request pipeline and could cause the container to be marked unhealthy and restarted.

## Changes

- Increase `core/Dockerfile` healthcheck timeout from 5 seconds to 30 seconds.
- Register a direct Express `GET /healthz` handler in `core/src/main.ts` before global Nest pipes and exception filters are attached.
- Leave the existing Nest health controller in place as a fallback route.

## Validation

- `npm run build --workspace=common`
- `npm run build --workspace=core`