### PR TITLE
fix: add bom_download_run_id input to prod deploy workflow

### DIFF
--- a/.github/workflows/cd-deploy-prod.yml
+++ b/.github/workflows/cd-deploy-prod.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: ''
+      bom_download_run_id:
+        description: 'Build run ID to download BOM from (for image tag resolution)'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: prod-deploy
@@ -52,4 +57,5 @@ jobs:
       git_sha: ${{ github.event.inputs.git_sha }}
       deploy_profile: prod_cd
       prod_confirm: ${{ github.event.inputs.confirm }}
+      bom_download_run_id: ${{ github.event.inputs.bom_download_run_id }}
     secrets: inherit


### PR DESCRIPTION
## Summary
Adds the `bom_download_run_id` input parameter to the CD Deploy Production workflow so that it can download the BOM from a build run and use the correct image SHAs.

This fixes the issue where production deploys use stale cached image tags instead of the newly built images from recent commits.

## Changes
- `.github/workflows/cd-deploy-prod.yml`: Added `bom_download_run_id` input parameter

## Usage
To deploy a specific build run's images:
```
Workflow_dispatch with bom_download_run_id = <build-run-id>
```

Closes: N/A (follow-up to PR #780)