### PR TITLE
Fix forced Docker image builds

### DIFF
--- a/clients/discord-bot/src/marshal/marshal.ts
+++ b/clients/discord-bot/src/marshal/marshal.ts
@@ -49,9 +49,7 @@ export abstract class Marshal {
             // Do things
             cms.registerCommand({
                 ...meta,
-                // We kinda need to act on faith here, if the implementer has decorated an unsafe function, we can't tell until runtime.
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-                function: Reflect.get(this, meta.functionName).bind(this) as CommandFunction,
+                function: this.getBoundFunction<CommandFunction>(meta.functionName),
             });
             this._logger.debug(`Registered Command ${meta.spec.name}`);
         });
@@ -71,9 +69,7 @@ export abstract class Marshal {
             // Do things
             cms.registerNotFoundCommand({
                 ...meta,
-                // We kinda need to act on faith here, if the implementer has decorated an unsafe function, we can't tell until runtime.
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-                function: Reflect.get(this, meta.functionName).bind(this),
+                function: this.getBoundFunction(meta.functionName),
             });
         });
     }
@@ -89,9 +85,7 @@ export abstract class Marshal {
         const {data} = parseResult;
 
         data.forEach(meta => {
-            // We kinda need to act on faith here, if the implementer has decorated an unsafe function, we can't tell until runtime.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-            const f = Reflect.get(this, meta.functionName).bind(this) as EventFunction;
+            const f = this.getBoundFunction<EventFunction>(meta.functionName);
             // Do things
             this.botClient.on(
                 meta.spec.event,
@@ -103,5 +97,13 @@ export abstract class Marshal {
             );
             this._logger.debug(`Registered Event ${meta.spec.event}`);
         });
+    }
+
+    private getBoundFunction<TFunction extends (...args: any[]) => unknown>(functionName: string): TFunction {
+        const handler = Reflect.get(this, functionName) as unknown;
+        if (typeof handler !== "function") {
+            throw new Error(`Marshal handler ${functionName} is not a function`);
+        }
+        return handler.bind(this) as TFunction;
     }
 }

--- a/clients/image-generation-frontend/package.json
+++ b/clients/image-generation-frontend/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
-    "@sveltejs/kit": "^1.0.0-next.156",
+    "@sveltejs/kit": "1.0.0-next.405",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "autoprefixer": "^10.3.3",
@@ -28,10 +28,11 @@
     "svelte-preprocess": "^4.10.0",
     "tailwindcss": "^2.2.8",
     "tslib": "^2.3.1",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.2",
+    "vite": "3.2.11"
   },
   "dependencies": {
-    "@sveltejs/adapter-node": "^1.0.0-next.43",
+    "@sveltejs/adapter-node": "1.0.0-next.86",
     "@types/knex": "^0.16.1",
     "@types/minio": "^7.0.10",
     "knex": "^0.95.10",

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
@@ -9,10 +9,11 @@ import type {
     ScrimSettings,
 } from "@sprocketbot/common";
 import {PostgresService, ScrimStatus} from "@sprocketbot/common";
+import type {QueryResult, QueryResultRow} from "pg";
 import {v4} from "uuid";
 
 type DbClient = {
-    query<T = any>(text: string, values?: unknown[]): Promise<{rows: T[]}>;
+    query<T extends QueryResultRow = QueryResultRow>(text: string, values?: unknown[]): Promise<QueryResult<T>>;
 };
 
 interface ScrimRow {

--- a/microservices/server-analytics-service/package.json
+++ b/microservices/server-analytics-service/package.json
@@ -44,6 +44,7 @@
     "@nestjs/testing": "^8.2.3",
     "@types/config": "0.0.38",
     "@types/jest": "^26.0.23",
+    "@types/node": "^16.11.47",
     "typescript": "^4.3.2"
   }
 }

--- a/microservices/submission-service/src/replay-submission/persistence/replay-submission-postgres.repository.ts
+++ b/microservices/submission-service/src/replay-submission/persistence/replay-submission-postgres.repository.ts
@@ -11,9 +11,10 @@ import type {
     Task,
 } from "@sprocketbot/common";
 import {PostgresService, ReplaySubmissionType} from "@sprocketbot/common";
+import type {QueryResult, QueryResultRow} from "pg";
 
 type DbClient = {
-    query<T = any>(text: string, values?: unknown[]): Promise<{rows: T[]}>;
+    query<T extends QueryResultRow = QueryResultRow>(text: string, values?: unknown[]): Promise<QueryResult<T>>;
 };
 type CompatibleSubmission = ReplaySubmission | EnhancedReplaySubmission;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,7 +217,7 @@
       "name": "~TODO~",
       "version": "0.0.1",
       "dependencies": {
-        "@sveltejs/adapter-node": "^1.0.0-next.43",
+        "@sveltejs/adapter-node": "1.0.0-next.86",
         "@types/knex": "^0.16.1",
         "@types/minio": "^7.0.10",
         "knex": "^0.95.10",
@@ -230,7 +230,7 @@
       "devDependencies": {
         "@commitlint/cli": "^12.1.4",
         "@commitlint/config-conventional": "^12.1.4",
-        "@sveltejs/kit": "^1.0.0-next.156",
+        "@sveltejs/kit": "1.0.0-next.405",
         "@typescript-eslint/eslint-plugin": "^5.10.1",
         "@typescript-eslint/parser": "^5.10.1",
         "autoprefixer": "^10.3.3",
@@ -245,7 +245,8 @@
         "svelte-preprocess": "^4.10.0",
         "tailwindcss": "^2.2.8",
         "tslib": "^2.3.1",
-        "typescript": "^4.4.2"
+        "typescript": "^4.4.2",
+        "vite": "3.2.11"
       }
     },
     "clients/image-generation-frontend/node_modules/@commitlint/cli": {
@@ -358,6 +359,12 @@
       "engines": {
         "node": ">=v10"
       }
+    },
+    "clients/image-generation-frontend/node_modules/@sveltejs/adapter-node": {
+      "version": "1.0.0-next.86",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.86.tgz",
+      "integrity": "sha512-VfKcFukVEPoAdm8tVGkFLyDDMZe+9HLFW7X/9Ch/UrSCHo3/HyOfYt/slmh+sjGXYjIBAtTjacrIfcMdYh744g==",
+      "license": "MIT"
     },
     "clients/image-generation-frontend/node_modules/eslint-plugin-svelte3": {
       "version": "4.0.0",
@@ -475,30 +482,6 @@
         "ts-jest": "29.0.1",
         "tslib": "^2.3.1",
         "typescript": "~4.6.2",
-        "vite": "^3.0.0"
-      }
-    },
-    "clients/web/node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.405",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.405.tgz",
-      "integrity": "sha512-jHSa74F7k+hC+0fof75g/xm/+1M5sM66Qt6v8eLLMSgjkp36Lb5xOioBhbl6w0NYoE5xysLsBWuu+yHytfvCBA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.1",
-        "chokidar": "^3.5.3",
-        "sade": "^1.8.1",
-        "tiny-glob": "^0.2.9"
-      },
-      "bin": {
-        "svelte-kit": "svelte-kit.js"
-      },
-      "engines": {
-        "node": ">=16.9"
-      },
-      "peerDependencies": {
-        "svelte": "^3.44.0",
         "vite": "^3.0.0"
       }
     },
@@ -1788,6 +1771,7 @@
         "@nestjs/testing": "^8.2.3",
         "@types/config": "0.0.38",
         "@types/jest": "^26.0.23",
+        "@types/node": "^16.11.47",
         "typescript": "^4.3.2"
       }
     },
@@ -1910,6 +1894,13 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "microservices/server-analytics-service/node_modules/@types/node": {
+      "version": "16.11.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.47.tgz",
+      "integrity": "sha512-fpP+jk2zJ4VW66+wAMFoBJlx1bxmBKx4DUFf68UHgdGCOuyUTDlLWqsaNPJh7xhNDykyJ9eIzAygilP/4WoN8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "microservices/server-analytics-service/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3772,16 +3763,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@gar/promise-retry": {
@@ -6737,13 +6718,6 @@
         "@noble/hashes": "^1.1.5"
       }
     },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -7046,6 +7020,7 @@
       "version": "25.0.8",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.8.tgz",
       "integrity": "sha512-ZEZWTK5n6Qde0to4vS9Mr5x/0UZoqCxPVR9KRUjU4kA2sO7GEUn1fop0DAwpO6z0Nw/kJON9bDmSxdWxO/TT1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -7071,6 +7046,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7081,6 +7057,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -7100,6 +7077,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -7109,6 +7087,7 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7121,6 +7100,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
       "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.0"
@@ -7141,6 +7121,7 @@
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
       "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -7165,6 +7146,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
       "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -7352,6 +7334,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.3.1.tgz",
       "integrity": "sha512-A0VgRQDCDPzdLNoiAbcOxGw4zT1Mc+n1LwT1OmO350R7WxrEqdMUChPPOd1iMfIDWlP4ie6E2d/WQf5es2d4Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
@@ -7364,87 +7347,27 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.30.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.4.tgz",
-      "integrity": "sha512-JSQIQT6XvdchCRQEm7BABxPC56WP5RYVONAi+09S8tmzeP43fBsRlr95bFmsTQM2RHBldfgQk+jgdnsKI75daA==",
+      "version": "1.0.0-next.405",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.405.tgz",
+      "integrity": "sha512-jHSa74F7k+hC+0fof75g/xm/+1M5sM66Qt6v8eLLMSgjkp36Lb5xOioBhbl6w0NYoE5xysLsBWuu+yHytfvCBA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^2.5.0",
-        "@types/cookie": "^0.5.1",
-        "cookie": "^0.5.0",
-        "devalue": "^4.3.1",
-        "esm-env": "^1.0.0",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.0",
-        "mrmime": "^1.0.1",
+        "@sveltejs/vite-plugin-svelte": "^1.0.1",
+        "chokidar": "^3.5.3",
         "sade": "^1.8.1",
-        "set-cookie-parser": "^2.6.0",
-        "sirv": "^2.0.2",
-        "tiny-glob": "^0.2.9",
-        "undici": "^5.28.3"
+        "tiny-glob": "^0.2.9"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": "^16.14 || >=18"
+        "node": ">=16.9"
       },
       "peerDependencies": {
-        "svelte": "^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0",
-        "vite": "^4.0.0"
-      }
-    },
-    "node_modules/@sveltejs/kit/node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.5.3.tgz",
-      "integrity": "sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
-        "debug": "^4.3.4",
-        "deepmerge": "^4.3.1",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.3",
-        "svelte-hmr": "^0.15.3",
-        "vitefu": "^0.2.4"
-      },
-      "engines": {
-        "node": "^14.18.0 || >= 16"
-      },
-      "peerDependencies": {
-        "svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0",
-        "vite": "^4.0.0"
-      }
-    },
-    "node_modules/@sveltejs/kit/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sveltejs/kit/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
+        "svelte": "^3.44.0",
+        "vite": "^3.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -7467,42 +7390,6 @@
       "peerDependencies": {
         "svelte": "^3.44.0",
         "vite": "^3.0.0"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-1.0.4.tgz",
-      "integrity": "sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^14.18.0 || >= 16"
-      },
-      "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^2.2.0",
-        "svelte": "^3.54.0 || ^4.0.0",
-        "vite": "^4.0.0"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte-inspector/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte/node_modules/debug": {
@@ -7750,13 +7637,6 @@
       "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
       "license": "MIT"
     },
-    "node_modules/@types/cookie": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
-      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -7824,6 +7704,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -8269,6 +8150,7 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sass": {
@@ -10992,6 +10874,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-func": {
@@ -11937,13 +11820,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/devalue": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
-      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -13024,13 +12900,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/esm-env": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -13135,6 +13004,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -15367,6 +15237,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-negative-zero": {
@@ -15445,6 +15316,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
       "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -18333,16 +18205,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mrmime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -20854,6 +20716,7 @@
       "version": "3.30.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
       "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -21179,13 +21042,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -21494,31 +21350,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
-    },
-    "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/sirv/node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -22758,16 +22589,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -23289,19 +23110,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## Summary

Fixes the forced `Autobuild Docker Containers` workflow failures exposed by rebuilding every image, including the original `discord-bot` image failure.

## Root Cause

The manual all-image build path surfaced several latent workspace build issues that path-filtered runs could skip:

- `discord-bot` failed TypeScript compilation because `Reflect.get(...).bind(this)` was inferred as `unknown` under the current compiler/types.
- `matchmaking-service` and `submission-service` used local `DbClient` query typings that no longer matched `PostgresService`/`pg` query results.
- `server-analytics-service` inherited the root Node 26 typings even though that workspace still builds with older TypeScript.
- `image-generation-frontend` drifted to an incompatible SvelteKit/Vite pair through loose dependency ranges.

## Changes

- Adds a typed marshal handler binding helper for `discord-bot` decorators/events.
- Aligns local `DbClient` helper types with `pg` `QueryResult`/`QueryResultRow` in matchmaking and submission repositories.
- Pins `server-analytics-service` to compatible Node typings.
- Pins `image-generation-frontend` SvelteKit/Vite/adapter versions to the compatible stack already used by this repo generation.
- Updates `package-lock.json` for those dependency pins.

## Validation

- `npx tsc -p clients/discord-bot/tsconfig.build.json --noEmit`
- `npx tsc -p microservices/matchmaking-service/tsconfig.build.json --noEmit`
- `npx tsc -p microservices/submission-service/tsconfig.build.json --noEmit`
- `npx tsc -p microservices/server-analytics-service/tsconfig.build.json --noEmit`
- `npm run build --workspace=clients/image-generation-frontend`
- `npm run build --workspace=clients/web`
- `npm run build --workspace=core`
- `npm run build --workspaces --if-present` reached all JS/TS/Svelte workspace builds locally and stopped only at `replay-parse-service` because local Docker was unavailable.
- Full forced GitHub image build passed: https://github.com/SprocketBot/sprocket/actions/runs/29387627262