### PR TITLE
Limit Postgres connection pools

### DIFF
--- a/clients/image-generation-frontend/src/utils/postgres-rpc.ts
+++ b/clients/image-generation-frontend/src/utils/postgres-rpc.ts
@@ -4,9 +4,20 @@ import config from '../config';
 
 const { Pool } = pg;
 
+const postgresPoolSize = Number(process.env.POSTGRES_POOL_SIZE ?? config.knex.pool_size ?? 1);
+const applicationName = String(
+  process.env.POSTGRES_APPLICATION_NAME
+    ?? process.env.SPROCKET_SERVICE_NAME
+    ?? 'image-generation-frontend',
+).replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 63);
+
 const pool = new Pool({
   ...config.knex,
   ssl: false,
+  max: postgresPoolSize,
+  idleTimeoutMillis: Number(process.env.POSTGRES_POOL_IDLE_TIMEOUT_MS ?? 10000),
+  connectionTimeoutMillis: Number(process.env.POSTGRES_POOL_CONNECTION_TIMEOUT_MS ?? 5000),
+  application_name: `${applicationName}.rpc`.slice(0, 63),
 });
 
 export async function postgresRpcRequest(

--- a/clients/image-generation-frontend/src/utils/server/knex.ts
+++ b/clients/image-generation-frontend/src/utils/server/knex.ts
@@ -1,16 +1,24 @@
 import KnexClient from 'knex';
 import config from '$src/config';
 
+const postgresPoolSize = Number(process.env.POSTGRES_POOL_SIZE ?? config.knex.pool_size ?? 1);
+const applicationName = String(
+  process.env.POSTGRES_APPLICATION_NAME
+    ?? process.env.SPROCKET_SERVICE_NAME
+    ?? 'image-generation-frontend',
+).replace(/[^a-zA-Z0-9_.:-]/g, '_').slice(0, 63);
+
 export const knexClient = KnexClient({
   client: 'pg',
   connection: {
     ...config.knex,
     ssl: false,
+    application_name: `${applicationName}.knex`.slice(0, 63),
   },
   asyncStackTraces: true,
   debug: false,
   pool: {
-    min: 2,
-    max: 2,
+    min: 0,
+    max: postgresPoolSize,
   },
 });

--- a/common/src/postgres-transport/postgres-client.ts
+++ b/common/src/postgres-transport/postgres-client.ts
@@ -2,6 +2,7 @@ import {ClientProxy} from "@nestjs/microservices";
 import type {ReadPacket, WritePacket} from "@nestjs/microservices";
 import {randomUUID} from "crypto";
 
+import {closeSharedPostgresPool} from "../postgres";
 import {
     PostgresTransportBase,
     PostgresTransportOptions,
@@ -30,7 +31,7 @@ export class PostgresClientProxy extends ClientProxy {
     }
 
     async close(): Promise<void> {
-        await this.transport.pool.end();
+        await closeSharedPostgresPool();
         this.connected = false;
     }
 

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -2,6 +2,7 @@ import type {CustomTransportStrategy, ReadPacket, WritePacket} from "@nestjs/mic
 import {Server} from "@nestjs/microservices/server/server";
 import {BaseRpcContext} from "@nestjs/microservices/ctx-host/base-rpc.context";
 
+import {closeSharedPostgresPool} from "../postgres";
 import {
     PostgresTransportBase,
     PostgresTransportOptions,
@@ -42,7 +43,7 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
 
     async close(): Promise<void> {
         this.stopped = true;
-        await this.transport.pool.end();
+        await closeSharedPostgresPool();
     }
 
     private async poll(): Promise<void> {

--- a/common/src/postgres-transport/postgres-transport.ts
+++ b/common/src/postgres-transport/postgres-transport.ts
@@ -3,9 +3,8 @@ import {ClientProxy} from "@nestjs/microservices";
 import type {ReadPacket, WritePacket} from "@nestjs/microservices";
 import {Server} from "@nestjs/microservices/server/server";
 import type {Pool, PoolClient, QueryResultRow} from "pg";
-import {Pool as PgPool} from "pg";
 
-import {config} from "../util";
+import {buildPostgresPoolConfig, getSharedPostgresPool} from "../postgres";
 
 export interface PostgresTransportOptions {
     queue: string;
@@ -22,18 +21,10 @@ export interface RpcQueueRow extends QueryResultRow {
 }
 
 export function createTransportPool(): Pool {
-    return new PgPool({
-        host: config.db.host,
-        port: config.db.port,
-        user: config.db.username,
-        password: config.db.password,
-        database: config.db.database,
-        ssl: config.db.host === "postgres" || config.db.host === "localhost"
-            ? false
-            : {rejectUnauthorized: false},
-        max: config.db.pool_size,
-    });
+    return getSharedPostgresPool();
 }
+
+export const createTransportPoolConfig = buildPostgresPoolConfig;
 
 export function toJsonbParam(value: unknown): string | null {
     if (value === null || value === undefined) return null;
@@ -57,8 +48,6 @@ export abstract class PostgresTransportBase {
 
     readonly pollIntervalMs: number;
 
-    private _pool?: Pool;
-
     protected constructor(name: string, options: PostgresTransportOptions) {
         this.logger = new Logger(name);
         this.queue = options.queue;
@@ -66,8 +55,7 @@ export abstract class PostgresTransportBase {
     }
 
     get pool(): Pool {
-        if (!this._pool) this._pool = createTransportPool();
-        return this._pool;
+        return createTransportPool();
     }
 
     async ensureSchema(): Promise<void> {

--- a/common/src/postgres/index.ts
+++ b/common/src/postgres/index.ts
@@ -1,2 +1,3 @@
 export * from "./postgres.module";
 export * from "./postgres.service";
+export * from "./pool";

--- a/common/src/postgres/pool.ts
+++ b/common/src/postgres/pool.ts
@@ -1,0 +1,57 @@
+import type {PoolConfig} from "pg";
+import {Pool} from "pg";
+
+import {config} from "../util";
+
+let sharedPool: Pool | undefined;
+let sharedPoolEnding: Promise<void> | undefined;
+
+function serviceName(): string {
+    return process.env.SPROCKET_SERVICE_NAME
+        || process.env.SERVICE_NAME
+        || process.env.npm_package_name
+        || "sprocket";
+}
+
+function applicationName(role: string): string {
+    const raw = `${config.db.application_name || serviceName()}.${role}`;
+    return raw.replace(/[^a-zA-Z0-9_.:-]/g, "_").slice(0, 63);
+}
+
+export function buildPostgresPoolConfig(role: string): PoolConfig {
+    return {
+        host: config.db.host,
+        port: config.db.port,
+        user: config.db.username,
+        password: config.db.password,
+        database: config.db.database,
+        ssl: config.db.host === "postgres" || config.db.host === "localhost"
+            ? false
+            : {rejectUnauthorized: false},
+        max: config.db.pool_size,
+        idleTimeoutMillis: config.db.pool_idle_timeout_ms,
+        connectionTimeoutMillis: config.db.pool_connection_timeout_ms,
+        application_name: applicationName(role),
+    };
+}
+
+export function getSharedPostgresPool(): Pool {
+    if (!sharedPool) {
+        sharedPool = new Pool(buildPostgresPoolConfig("common"));
+    }
+    return sharedPool;
+}
+
+export async function closeSharedPostgresPool(): Promise<void> {
+    if (!sharedPool) {
+        if (sharedPoolEnding) await sharedPoolEnding;
+        return;
+    }
+
+    const pool = sharedPool;
+    sharedPool = undefined;
+    sharedPoolEnding = pool.end().finally(() => {
+        sharedPoolEnding = undefined;
+    });
+    await sharedPoolEnding;
+}

--- a/common/src/postgres/postgres.service.ts
+++ b/common/src/postgres/postgres.service.ts
@@ -1,26 +1,12 @@
 import {Injectable, OnModuleDestroy} from "@nestjs/common";
-import {config} from "../util";
-import {Pool, PoolClient, QueryResult, QueryResultRow} from "pg";
+import type {Pool, PoolClient, QueryResult, QueryResultRow} from "pg";
+
+import {closeSharedPostgresPool, getSharedPostgresPool} from "./pool";
 
 @Injectable()
 export class PostgresService implements OnModuleDestroy {
-    private _pool?: Pool;
-
     private get pool(): Pool {
-        if (!this._pool) {
-            this._pool = new Pool({
-                host: config.db.host,
-                port: config.db.port,
-                user: config.db.username,
-                password: config.db.password,
-                database: config.db.database,
-                ssl: config.db.host === "postgres" || config.db.host === "localhost"
-                    ? false
-                    : {rejectUnauthorized: false},
-                max: config.db.pool_size,
-            });
-        }
-        return this._pool;
+        return getSharedPostgresPool();
     }
 
     query<T extends QueryResultRow = QueryResultRow>(
@@ -46,6 +32,6 @@ export class PostgresService implements OnModuleDestroy {
     }
 
     async onModuleDestroy(): Promise<void> {
-        await this._pool?.end();
+        await closeSharedPostgresPool();
     }
 }

--- a/common/src/util/config.ts
+++ b/common/src/util/config.ts
@@ -109,6 +109,23 @@ export const config = {
         get pool_size(): number {
             return ConfigResolver.getNumberConfig("POSTGRES_POOL_SIZE", "db.pool_size", 1);
         },
+        get pool_idle_timeout_ms(): number {
+            return ConfigResolver.getNumberConfig("POSTGRES_POOL_IDLE_TIMEOUT_MS", "db.pool_idle_timeout_ms", 10000);
+        },
+        get pool_connection_timeout_ms(): number {
+            return ConfigResolver.getNumberConfig(
+                "POSTGRES_POOL_CONNECTION_TIMEOUT_MS",
+                "db.pool_connection_timeout_ms",
+                5000,
+            );
+        },
+        get application_name(): string {
+            return ConfigResolver.getConfig(
+                "POSTGRES_APPLICATION_NAME",
+                "db.application_name",
+                process.env.SPROCKET_SERVICE_NAME || process.env.SERVICE_NAME || "",
+            );
+        },
     },
     gql: {
         get url(): string {

--- a/core/src/database/database.module.ts
+++ b/core/src/database/database.module.ts
@@ -48,6 +48,11 @@ const modules = [
                   },
         extra: {
             max: config.db.pool_size,
+            idleTimeoutMillis: config.db.pool_idle_timeout_ms,
+            connectionTimeoutMillis: config.db.pool_connection_timeout_ms,
+            application_name: `${config.db.application_name || "sprocket-core"}.typeorm`
+                .replace(/[^a-zA-Z0-9_.:-]/g, "_")
+                .slice(0, 63),
         },
     }),
 ];

--- a/infra/platform/src/microservices/SprocketService.ts
+++ b/infra/platform/src/microservices/SprocketService.ts
@@ -168,6 +168,7 @@ export class SprocketService extends pulumi.ComponentResource {
                     ],
                     env: {
                         NODE_ENV: "production",
+                        SPROCKET_SERVICE_NAME: name,
                         ...environment,
                         ...(args.env ?? {})
                     },

--- a/microservices/replay-parse-service/src/main.py
+++ b/microservices/replay-parse-service/src/main.py
@@ -33,6 +33,9 @@ def connect_db():
         user=config["db"]["username"],
         password=config["db"]["password"],
         dbname=config["db"]["database"],
+        application_name=os.environ.get("POSTGRES_APPLICATION_NAME")
+        or os.environ.get("SPROCKET_SERVICE_NAME")
+        or "replay-parse-service",
     )
 
 


### PR DESCRIPTION
## Summary

- Reuse one bounded shared `pg.Pool` per Node process for common Postgres service and RPC transport paths.
- Apply pool timeouts and `application_name` labels to common pools, TypeORM, image-generation frontend pools, platform service env, and the Python replay parser.
- Cap image-generation frontend pg/knex pools with `POSTGRES_POOL_SIZE`, defaulting to 1, and avoid holding a minimum of 2 idle knex connections.

## Root Cause

`POSTGRES_POOL_SIZE` limited an individual pool, but several Sprocket processes could create multiple independent pools: TypeORM, direct `PostgresService`, RPC transport server/client pools, and standalone frontend pg/knex pools. Across deployed services and replicas, idle pooled sessions could still exhaust the hosted Postgres connection limit. Rows showing `query = 'COMMIT'` are likely idle pooled sessions whose last statement was a transaction commit, so they still count against the DB cap.

## Validation

- `npm run build --workspace=common`
- `npm run build --workspace=core`
- `npm run build --workspace=microservices/matchmaking-service`
- `npm run build --workspace=microservices/submission-service`
- `npm run build --workspace=microservices/notification-service`
- `npm run build --workspace=microservices/server-analytics-service`
- `npm run build --workspace=microservices/image-generation-service`
- `npm run build --workspace=clients/image-generation-frontend` (passes with pre-existing Svelte a11y warnings)
- `python3 -m py_compile microservices/replay-parse-service/src/main.py`
- `npx tsc -p infra/platform/tsconfig.json --noEmit --skipLibCheck`
- `git diff --check`

## Follow-up Check After Deploy

```sql
select application_name, state, query, count(*)
from pg_stat_activity
where datname = 'sprocket_main'
group by application_name, state, query
order by count(*) desc;
```

This should make any remaining connection pressure attributable by service/pool source.