### PR TITLE
Harden auth session identity validation

### DIFF
--- a/clients/web/src/hooks.ts
+++ b/clients/web/src/hooks.ts
@@ -3,6 +3,8 @@ import {
     apiUrl, constants, loadConfig,
 } from "$lib/utils";
 
+type SessionJwtPayload = App.Locals["user"] & {exp?: number;};
+
 interface refreshPayload {
     cookies: string[];
     cookiesString: string;
@@ -11,6 +13,39 @@ interface refreshPayload {
 }
 
 const ONE_WEEK_COOKIE = "Path=/;SameSite=Lax;Max-Age=604800";
+
+const isPositiveSafeInteger = (value: unknown): value is number => (
+    typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value > 0
+);
+
+const isValidSessionUser = (value: unknown): value is SessionJwtPayload => {
+    if (!value || typeof value !== "object") return false;
+
+    const candidate = value as Partial<SessionJwtPayload>;
+    return isPositiveSafeInteger(candidate.userId)
+        && typeof candidate.username === "string"
+        && candidate.username.trim().length > 0
+        && isPositiveSafeInteger(candidate.currentOrganizationId)
+        && Array.isArray(candidate.orgTeams)
+        && candidate.orgTeams.every(orgTeam => Number.isInteger(orgTeam) && orgTeam >= 0);
+};
+
+const decodeJwtPayload = (rawToken: string): SessionJwtPayload | null => {
+    const payloadSegment = rawToken.split(".")[1];
+    if (!payloadSegment) return null;
+
+    try {
+        const base64 = payloadSegment.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+        const payload = JSON.parse(Buffer.from(padded, "base64").toString()) as unknown;
+        return isValidSessionUser(payload) ? payload : null;
+    } catch (e) {
+        console.error("Failed to decode session token:", e);
+        return null;
+    }
+};
 
 const parseCookieHeader = (currentCookies: string): Map<string, string> => {
     const cookies = new Map<string, string>();
@@ -28,6 +63,12 @@ const serializeCookieHeader = (cookies: Map<string, string>): string => Array
     .join("; ");
 
 const buildSetCookie = (name: string, value: string): string => `${name}=${value};${ONE_WEEK_COOKIE}`;
+
+const setSessionFromToken = (rawToken: string): SessionJwtPayload | null => {
+    const token = decodeJwtPayload(rawToken);
+    if (!token) return null;
+    return token;
+};
 
 const doAuthRefresh = async (
     refreshUrl: string,
@@ -58,6 +99,11 @@ const doAuthRefresh = async (
             const tokens = await res.json();
             const access_token = tokens.access_token;
             const new_refresh_token = tokens.refresh_token;
+
+            if (!setSessionFromToken(access_token) || typeof new_refresh_token !== "string" || new_refresh_token.length === 0) {
+                console.error("Auth refresh returned invalid session tokens");
+                return null;
+            }
 
             cookies.set(constants.auth_cookie_key, access_token);
             cookies.set(constants.refresh_token_cookie_key, new_refresh_token);
@@ -95,16 +141,14 @@ export const handle: Handle = async ({event, resolve}) => {
                     ?.split("=")[1];
 
                 if (rawToken) {
-                    // Get the meat out of the JWT (the middle third, separated
-                    // by ".")
-                    const token = JSON.parse(Buffer.from(rawToken.split(".")[1], "base64").toString());
+                    const token = setSessionFromToken(rawToken);
 
                     // Check if JWT has expired
                     const now = new Date();
-                    const exp = new Date(token.exp * 1000);
+                    const exp = new Date((token?.exp ?? 0) * 1000);
                     const remaining = exp.getTime() - now.getTime();
 
-                    if (remaining > 0) {
+                    if (token && remaining > 0) {
                         // Just refresh the session with current data
                         event.locals.user = token;
                         event.locals.token = rawToken;
@@ -119,8 +163,11 @@ export const handle: Handle = async ({event, resolve}) => {
                             event.request.headers.set("cookie", result.cookiesString);
                             newCookies = result.cookies;
                             // Refresh the session as well
-                            event.locals.user = JSON.parse(Buffer.from(result.accessToken.split(".")[1], "base64").toString());
-                            event.locals.token = result.accessToken;
+                            const refreshedUser = setSessionFromToken(result.accessToken);
+                            if (refreshedUser) {
+                                event.locals.user = refreshedUser;
+                                event.locals.token = result.accessToken;
+                            }
                         }
                     }
                 } else {
@@ -134,8 +181,11 @@ export const handle: Handle = async ({event, resolve}) => {
                         event.request.headers.set("cookie", result.cookiesString);
                         newCookies = result.cookies;
                         // Refresh the session as well
-                        event.locals.user = JSON.parse(Buffer.from(result.accessToken.split(".")[1], "base64").toString());
-                        event.locals.token = result.accessToken;
+                        const refreshedUser = setSessionFromToken(result.accessToken);
+                        if (refreshedUser) {
+                            event.locals.user = refreshedUser;
+                            event.locals.token = result.accessToken;
+                        }
                     }
                 }
             }

--- a/core/src/identity/auth/gql-auth-guard/gql-jwt-guard.spec.ts
+++ b/core/src/identity/auth/gql-auth-guard/gql-jwt-guard.spec.ts
@@ -1,0 +1,63 @@
+import type {ExecutionContext} from "@nestjs/common";
+
+import {GqlJwtGuard} from "./gql-jwt-guard";
+
+const makeContext = (req: unknown): ExecutionContext => ({
+    getArgs: () => [null, null, {req}, null],
+    getArgByIndex: (index: number) => [null, null, {req}, null][index],
+    getClass: jest.fn(),
+    getHandler: jest.fn(),
+    getType: jest.fn(),
+    switchToHttp: jest.fn(),
+    switchToRpc: jest.fn(),
+    switchToWs: jest.fn(),
+}) as unknown as ExecutionContext;
+
+describe("GqlJwtGuard", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalEnableTestMode = process.env.ENABLE_TEST_MODE;
+    const authGuardPrototype = Object.getPrototypeOf(GqlJwtGuard.prototype);
+
+    afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+        if (typeof originalEnableTestMode === "undefined") {
+            delete process.env.ENABLE_TEST_MODE;
+        } else {
+            process.env.ENABLE_TEST_MODE = originalEnableTestMode;
+        }
+        jest.restoreAllMocks();
+    });
+
+    it("only injects a non-admin test user in Jest test mode", () => {
+        process.env.NODE_ENV = "test";
+        process.env.ENABLE_TEST_MODE = "true";
+        const req: {headers: Record<string, string>; user?: unknown;} = {
+            headers: {"x-test-mode": "true"},
+        };
+
+        const result = new GqlJwtGuard().canActivate(makeContext(req));
+
+        expect(result).toBe(true);
+        expect(req.user).toEqual({
+            userId: 1,
+            username: "test-user",
+            currentOrganizationId: 2,
+            orgTeams: [],
+        });
+    });
+
+    it("does not synthesize a user outside Jest test mode", () => {
+        process.env.NODE_ENV = "production";
+        process.env.ENABLE_TEST_MODE = "true";
+        const superCanActivate = jest.spyOn(authGuardPrototype, "canActivate").mockReturnValue(false);
+        const req: {headers: Record<string, string>; user?: unknown;} = {
+            headers: {"x-test-mode": "true"},
+        };
+
+        const result = new GqlJwtGuard().canActivate(makeContext(req));
+
+        expect(result).toBe(false);
+        expect(req.user).toBeUndefined();
+        expect(superCanActivate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/core/src/identity/auth/gql-auth-guard/gql-jwt-guard.ts
+++ b/core/src/identity/auth/gql-auth-guard/gql-jwt-guard.ts
@@ -1,19 +1,25 @@
 import type {ExecutionContext} from "@nestjs/common";
-import {Injectable} from "@nestjs/common";
+import {Injectable, Logger} from "@nestjs/common";
 import {GqlExecutionContext} from "@nestjs/graphql";
 import {AuthGuard} from "@nestjs/passport";
 
 @Injectable()
 export class GqlJwtGuard extends AuthGuard("jwt") {
+    private readonly logger = new Logger(GqlJwtGuard.name);
+
     getRequest(context: ExecutionContext): unknown {
         const ctx = GqlExecutionContext.create(context);
         return ctx.getContext().req;
     }
 
+    private isTestBypassEnabled(): boolean {
+        return process.env.ENABLE_TEST_MODE === "true" && process.env.NODE_ENV === "test";
+    }
+
     canActivate(context: ExecutionContext): boolean | Promise<boolean> {
-    // Allow bypassing auth in test mode for local development
-    // IMPORTANT: This should ONLY be enabled in local development, never in production
-        if (process.env.ENABLE_TEST_MODE === "true") {
+    // Allow bypassing auth only in automated Jest-style test mode.
+    // IMPORTANT: This must never synthesize a user in a deployed runtime.
+        if (this.isTestBypassEnabled()) {
             const ctx = GqlExecutionContext.create(context);
             const req = ctx.getContext().req;
 
@@ -21,12 +27,15 @@ export class GqlJwtGuard extends AuthGuard("jwt") {
             if (req.headers["x-test-mode"] === "true") {
                 // Inject a mock user for testing purposes
                 req.user = {
-                    id: 1,
+                    userId: 1,
                     username: "test-user",
-                    orgTeams: ["MLEDB_ADMIN", "LEAGUE_OPERATIONS"],
+                    currentOrganizationId: 2,
+                    orgTeams: [],
                 };
                 return true;
             }
+        } else if (process.env.ENABLE_TEST_MODE === "true") {
+            this.logger.error("ENABLE_TEST_MODE ignored because NODE_ENV is not test");
         }
 
         // Default to standard JWT authentication

--- a/core/src/identity/auth/oauth/oauth.controller.ts
+++ b/core/src/identity/auth/oauth/oauth.controller.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenException,
     Get,
     Logger,
+    UnauthorizedException,
     Request,
     Response,
     UseGuards,
@@ -79,9 +80,6 @@ export class OauthController {
             const tokens = await this.authService.refreshTokens(payload, "");
             return tokens;
         }
-        return {
-            access_token: "",
-            refresh_token: "",
-        };
+        throw new UnauthorizedException("Refresh token is not bound to a Discord authentication account");
     }
 }

--- a/core/src/identity/auth/oauth/strategies/oauth.jwt.refresh.strategy.ts
+++ b/core/src/identity/auth/oauth/strategies/oauth.jwt.refresh.strategy.ts
@@ -4,6 +4,7 @@ import {config} from "@sprocketbot/common";
 import {ExtractJwt, Strategy} from "passport-jwt";
 
 import type {AuthPayload, UserPayload} from "../types";
+import {validateUserPayload} from "../validated-user-payload";
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
@@ -17,11 +18,6 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh"
     }
 
     async validate(payload: AuthPayload): Promise<UserPayload> {
-        return {
-            userId: payload.userId,
-            username: payload.username,
-            currentOrganizationId: payload.currentOrganizationId,
-            orgTeams: payload.orgTeams ?? [],
-        };
+        return validateUserPayload(payload, "JWT refresh token");
     }
 }

--- a/core/src/identity/auth/oauth/strategies/oauth.jwt.strategy.ts
+++ b/core/src/identity/auth/oauth/strategies/oauth.jwt.strategy.ts
@@ -4,6 +4,7 @@ import {config} from "@sprocketbot/common";
 import {ExtractJwt, Strategy} from "passport-jwt";
 
 import type {AuthPayload, UserPayload} from "../types";
+import {validateUserPayload} from "../validated-user-payload";
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -16,11 +17,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     async validate(payload: AuthPayload): Promise<UserPayload> {
-        return {
-            userId: payload.userId,
-            username: payload.username,
-            currentOrganizationId: payload.currentOrganizationId,
-            orgTeams: payload.orgTeams ?? [],
-        };
+        return validateUserPayload(payload, "JWT access token");
     }
 }

--- a/core/src/identity/auth/oauth/validated-user-payload.spec.ts
+++ b/core/src/identity/auth/oauth/validated-user-payload.spec.ts
@@ -1,0 +1,50 @@
+import {UnauthorizedException} from "@nestjs/common";
+
+import {MLE_OrganizationTeam} from "../../../database/mledb";
+import {validateUserPayload} from "./validated-user-payload";
+
+describe("validateUserPayload", () => {
+    it("accepts a real Sprocket user payload", () => {
+        expect(validateUserPayload({
+            sub: "discord-123",
+            username: "Actual User",
+            userId: 42,
+            currentOrganizationId: 2,
+            orgTeams: [MLE_OrganizationTeam.LEAGUE_OPERATIONS],
+        }, "test")).toEqual({
+            username: "Actual User",
+            userId: 42,
+            currentOrganizationId: 2,
+            orgTeams: [MLE_OrganizationTeam.LEAGUE_OPERATIONS],
+        });
+    });
+
+    it("rejects sentinel user ids", () => {
+        expect(() => validateUserPayload({
+            sub: "dev",
+            username: "MLE DEV USER",
+            userId: -1,
+            currentOrganizationId: 2,
+            orgTeams: [MLE_OrganizationTeam.MLEDB_ADMIN],
+        }, "test")).toThrow(UnauthorizedException);
+    });
+
+    it("rejects string org-team fallbacks", () => {
+        expect(() => validateUserPayload({
+            sub: "test-user",
+            username: "test-user",
+            userId: 1,
+            currentOrganizationId: 2,
+            orgTeams: ["MLEDB_ADMIN"] as unknown as MLE_OrganizationTeam[],
+        }, "test")).toThrow(UnauthorizedException);
+    });
+
+    it("defaults missing org teams to no elevated access", () => {
+        expect(validateUserPayload({
+            sub: "discord-123",
+            username: "Actual User",
+            userId: 42,
+            currentOrganizationId: 2,
+        }, "test").orgTeams).toEqual([]);
+    });
+});

--- a/core/src/identity/auth/oauth/validated-user-payload.ts
+++ b/core/src/identity/auth/oauth/validated-user-payload.ts
@@ -1,0 +1,46 @@
+import {UnauthorizedException} from "@nestjs/common";
+
+import {MLE_OrganizationTeam} from "../../../database/mledb";
+import type {AuthPayload, UserPayload} from "./types";
+
+const validOrganizationTeams = new Set(
+    Object.values(MLE_OrganizationTeam).filter((value): value is number => typeof value === "number"),
+);
+
+const isPositiveSafeInteger = (value: unknown): value is number => (
+    typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value > 0
+);
+
+export function validateUserPayload(payload: Partial<AuthPayload>, source: string): UserPayload {
+    if (!isPositiveSafeInteger(payload.userId)) {
+        throw new UnauthorizedException(`${source} payload has an invalid userId`);
+    }
+
+    if (typeof payload.username !== "string" || payload.username.trim().length === 0) {
+        throw new UnauthorizedException(`${source} payload has an invalid username`);
+    }
+
+    if (
+        typeof payload.currentOrganizationId !== "undefined"
+        && !isPositiveSafeInteger(payload.currentOrganizationId)
+    ) {
+        throw new UnauthorizedException(`${source} payload has an invalid organization`);
+    }
+
+    const orgTeams = payload.orgTeams ?? [];
+    if (
+        !Array.isArray(orgTeams)
+        || orgTeams.some(orgTeam => !Number.isInteger(orgTeam) || !validOrganizationTeams.has(orgTeam))
+    ) {
+        throw new UnauthorizedException(`${source} payload has invalid org teams`);
+    }
+
+    return {
+        userId: payload.userId,
+        username: payload.username,
+        currentOrganizationId: payload.currentOrganizationId,
+        orgTeams,
+    };
+}

--- a/core/src/mledb/mledb-player/mle-organization-team.guard.ts
+++ b/core/src/mledb/mledb-player/mle-organization-team.guard.ts
@@ -45,9 +45,13 @@ export function MLEOrganizationTeamGuard(organizationTeams: OrganizationTeamGuar
             const ctx = GqlExecutionContext.create(context);
             const req = ctx.getContext().req;
 
-            // Allow bypassing org team check in test mode for local development
-            // IMPORTANT: This should ONLY be enabled in local development, never in production
-            if (process.env.ENABLE_TEST_MODE === "true" && req.headers["x-test-mode"] === "true") {
+            // Allow bypassing org-team checks only in automated Jest-style test mode.
+            // IMPORTANT: This must never bypass authorization in a deployed runtime.
+            if (
+                process.env.ENABLE_TEST_MODE === "true"
+                && process.env.NODE_ENV === "test"
+                && req.headers["x-test-mode"] === "true"
+            ) {
                 // Test mode user already has all org teams injected by GqlJwtGuard
                 return true;
             }


### PR DESCRIPTION
## Summary

Harden the Sprocket auth/session path so invalid or sentinel identities cannot be synthesized or preserved as privileged users.

Changes:
- Restrict GraphQL test auth bypass to `ENABLE_TEST_MODE=true` plus `NODE_ENV=test`.
- Stop the test bypass from injecting admin org-team privileges.
- Validate access and refresh JWT payloads before accepting them as Sprocket user sessions.
- Reject sentinel `userId` values such as `-1`, blank usernames, invalid org-team values, and invalid organization IDs.
- Make `/refresh` return unauthorized when a refresh token cannot bind to a Discord auth account.
- Harden SvelteKit session decoding so malformed/stale/dev cookies do not populate `event.locals.user`.

## Root Cause

The recurring MLE Dev User failure was privilege synthesis rather than only a hard-coded display-name bug. A deployed runtime could honor `ENABLE_TEST_MODE=true` with `x-test-mode: true`, bypass GraphQL auth/org-team guards, and preserve malformed or sentinel JWT/session payloads. That allowed a user to be treated like an elevated synthetic identity instead of their real account.

## Validation

Passed locally:

```bash
npm run test --workspace=core -- --runTestsByPath src/identity/auth/oauth/validated-user-payload.spec.ts src/identity/auth/gql-auth-guard/gql-jwt-guard.spec.ts --coverage=false
npm run build --workspace=core
git diff --cached --check
```

Also ran scoped whitespace validation before commit.

## Remaining Gap

I did not run a full browser OAuth callback against a live backend. The remaining proof gap is end-to-end verification through Discord login, callback cookie write, refresh behavior, and GraphQL `me` from the real SvelteKit frontend path.