### PR TITLE
Fix Postgres connection lifecycle

### DIFF
--- a/apps/monolith/src/main.ts
+++ b/apps/monolith/src/main.ts
@@ -28,36 +28,46 @@ async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(MonolithModule, {
         logger: config.logger.levels,
     });
+    app.enableShutdownHooks();
 
-    app.getHttpAdapter().getInstance().get("/healthz", (_req: Request, res: Response) => {
-        res.status(200).json({
-            status: "ok",
-            runtime: "monolith",
-            services: CONSUMERS.map(({name}) => name),
+    try {
+        app.getHttpAdapter().getInstance().get("/healthz", (_req: Request, res: Response) => {
+            res.status(200).json({
+                status: "ok",
+                runtime: "monolith",
+                services: CONSUMERS.map(({name}) => name),
+            });
         });
-    });
 
-    app.use(corsPreflightMiddleware);
-    app.enableCors(corsOptions);
-    app.useGlobalPipes(new ValidationPipe());
+        app.use(corsPreflightMiddleware);
+        app.enableCors(corsOptions);
+        app.useGlobalPipes(new ValidationPipe());
 
-    const httpAdapter = app.get(HttpAdapterHost);
-    app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
+        const httpAdapter = app.get(HttpAdapterHost);
+        app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
 
-    for (const {name, queue} of CONSUMERS) {
-        app.connectMicroservice({
-            strategy: new PostgresServer({queue}),
-        });
+        for (const {name, queue} of CONSUMERS) {
+            app.connectMicroservice({
+                strategy: new PostgresServer({queue}),
+            });
+            // eslint-disable-next-line no-console
+            console.log(`Connected ${name} Postgres RPC consumer on queue '${queue}'`);
+        }
+
+        const port = 3001;
+        await app.startAllMicroservices();
+        await app.listen(port);
         // eslint-disable-next-line no-console
-        console.log(`Connected ${name} Postgres RPC consumer on queue '${queue}'`);
+        console.log(`Sprocket monolith listening at http://localhost:${port}`);
+    } catch (error) {
+        await app.close();
+        throw error;
     }
-
-    const port = 3001;
-    await app.startAllMicroservices();
-    await app.listen(port);
-    // eslint-disable-next-line no-console
-    console.log(`Sprocket monolith listening at http://localhost:${port}`);
 }
 
-// eslint-disable-next-line no-console
-bootstrap().catch(console.error);
+bootstrap().catch(error => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    // eslint-disable-next-line no-undef
+    process.exit(1);
+});

--- a/clients/discord-bot/src/app.module.ts
+++ b/clients/discord-bot/src/app.module.ts
@@ -1,5 +1,5 @@
 import {Module} from "@nestjs/common";
-import {CoreModule} from "@sprocketbot/common";
+import {CoreModule, PostgresModule} from "@sprocketbot/common";
 
 import {CommandsModule} from "./commands/commands.module";
 import {DiscordModule} from "./discord/discord.module";
@@ -14,6 +14,7 @@ import {SprocketEventsModule} from "./sprocket-events/sprocket-events.module";
 @Module({
     imports: [
         GlobalModule,
+        PostgresModule,
         CoreModule,
         MarshalModule,
         DiscordModule,

--- a/clients/discord-bot/src/main.ts
+++ b/clients/discord-bot/src/main.ts
@@ -12,6 +12,7 @@ async function bootstrap(): Promise<void> {
         logger: config.logger.levels,
         strategy: new PostgresServer({queue: config.transport.bot_queue}),
     });
+    app.enableShutdownHooks();
 
     const httpAdapter = app.get(HttpAdapterHost);
     app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));

--- a/clients/image-generation-frontend/src/utils/postgres-rpc.ts
+++ b/clients/image-generation-frontend/src/utils/postgres-rpc.ts
@@ -17,6 +17,10 @@ const pool = new Pool({
   max: postgresPoolSize,
   idleTimeoutMillis: Number(process.env.POSTGRES_POOL_IDLE_TIMEOUT_MS ?? 10000),
   connectionTimeoutMillis: Number(process.env.POSTGRES_POOL_CONNECTION_TIMEOUT_MS ?? 5000),
+  maxLifetimeSeconds: Number(process.env.POSTGRES_POOL_MAX_LIFETIME_SECONDS ?? 300),
+  idle_in_transaction_session_timeout: Number(
+    process.env.POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS ?? 60000,
+  ),
   application_name: `${applicationName}.rpc`.slice(0, 63),
 });
 

--- a/clients/image-generation-frontend/src/utils/server/knex.ts
+++ b/clients/image-generation-frontend/src/utils/server/knex.ts
@@ -13,6 +13,9 @@ export const knexClient = KnexClient({
   connection: {
     ...config.knex,
     ssl: false,
+    idle_in_transaction_session_timeout: Number(
+      process.env.POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS ?? 60000,
+    ),
     application_name: `${applicationName}.knex`.slice(0, 63),
   },
   asyncStackTraces: true,
@@ -20,5 +23,6 @@ export const knexClient = KnexClient({
   pool: {
     min: 0,
     max: postgresPoolSize,
+    idleTimeoutMillis: Number(process.env.POSTGRES_POOL_IDLE_TIMEOUT_MS ?? 10000),
   },
 });

--- a/common/src/postgres-transport/postgres-client.ts
+++ b/common/src/postgres-transport/postgres-client.ts
@@ -2,7 +2,6 @@ import {ClientProxy} from "@nestjs/microservices";
 import type {ReadPacket, WritePacket} from "@nestjs/microservices";
 import {randomUUID} from "crypto";
 
-import {closeSharedPostgresPool} from "../postgres";
 import {
     PostgresTransportBase,
     PostgresTransportOptions,
@@ -31,7 +30,6 @@ export class PostgresClientProxy extends ClientProxy {
     }
 
     async close(): Promise<void> {
-        await closeSharedPostgresPool();
         this.connected = false;
     }
 

--- a/common/src/postgres-transport/postgres-server.ts
+++ b/common/src/postgres-transport/postgres-server.ts
@@ -2,7 +2,6 @@ import type {CustomTransportStrategy, ReadPacket, WritePacket} from "@nestjs/mic
 import {Server} from "@nestjs/microservices/server/server";
 import {BaseRpcContext} from "@nestjs/microservices/ctx-host/base-rpc.context";
 
-import {closeSharedPostgresPool} from "../postgres";
 import {
     PostgresTransportBase,
     PostgresTransportOptions,
@@ -43,7 +42,6 @@ export class PostgresServer extends Server implements CustomTransportStrategy {
 
     async close(): Promise<void> {
         this.stopped = true;
-        await closeSharedPostgresPool();
     }
 
     private async poll(): Promise<void> {

--- a/common/src/postgres/pool.spec.ts
+++ b/common/src/postgres/pool.spec.ts
@@ -1,0 +1,38 @@
+const mockPoolConstructor = jest.fn();
+
+jest.mock("pg", () => ({
+    Pool: mockPoolConstructor,
+}));
+
+jest.mock("../util", () => ({
+    config: {
+        db: {
+            host: "db.example.test",
+            port: 5432,
+            username: "sprocket",
+            password: "secret",
+            database: "sprocket",
+            pool_size: 1,
+            pool_idle_timeout_ms: 10000,
+            pool_connection_timeout_ms: 5000,
+            pool_max_lifetime_seconds: 300,
+            idle_in_transaction_timeout_ms: 60000,
+            application_name: "monolith",
+        },
+    },
+}));
+
+import {buildPostgresPoolConfig} from "./pool";
+
+describe("buildPostgresPoolConfig", () => {
+    it("bounds and expires managed database sessions", () => {
+        expect(buildPostgresPoolConfig("common")).toMatchObject({
+            max: 1,
+            idleTimeoutMillis: 10000,
+            connectionTimeoutMillis: 5000,
+            maxLifetimeSeconds: 300,
+            idle_in_transaction_session_timeout: 60000,
+            application_name: "monolith.common",
+        });
+    });
+});

--- a/common/src/postgres/pool.ts
+++ b/common/src/postgres/pool.ts
@@ -31,6 +31,8 @@ export function buildPostgresPoolConfig(role: string): PoolConfig {
         max: config.db.pool_size,
         idleTimeoutMillis: config.db.pool_idle_timeout_ms,
         connectionTimeoutMillis: config.db.pool_connection_timeout_ms,
+        maxLifetimeSeconds: config.db.pool_max_lifetime_seconds,
+        idle_in_transaction_session_timeout: config.db.idle_in_transaction_timeout_ms,
         application_name: applicationName(role),
     };
 }

--- a/common/src/postgres/postgres.service.spec.ts
+++ b/common/src/postgres/postgres.service.spec.ts
@@ -1,0 +1,18 @@
+const mockCloseSharedPostgresPool = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("./pool", () => ({
+    closeSharedPostgresPool: mockCloseSharedPostgresPool,
+    getSharedPostgresPool: jest.fn(),
+}));
+
+import {PostgresService} from "./postgres.service";
+
+describe("PostgresService lifecycle", () => {
+    it("closes the process pool in the final application-shutdown phase", async () => {
+        const service = new PostgresService();
+
+        await service.onApplicationShutdown();
+
+        expect(mockCloseSharedPostgresPool).toHaveBeenCalledTimes(1);
+    });
+});

--- a/common/src/postgres/postgres.service.ts
+++ b/common/src/postgres/postgres.service.ts
@@ -1,10 +1,11 @@
-import {Injectable, OnModuleDestroy} from "@nestjs/common";
+import {Injectable} from "@nestjs/common";
+import type {OnApplicationShutdown} from "@nestjs/common";
 import type {Pool, PoolClient, QueryResult, QueryResultRow} from "pg";
 
 import {closeSharedPostgresPool, getSharedPostgresPool} from "./pool";
 
 @Injectable()
-export class PostgresService implements OnModuleDestroy {
+export class PostgresService implements OnApplicationShutdown {
     private get pool(): Pool {
         return getSharedPostgresPool();
     }
@@ -31,7 +32,7 @@ export class PostgresService implements OnModuleDestroy {
         }
     }
 
-    async onModuleDestroy(): Promise<void> {
+    async onApplicationShutdown(): Promise<void> {
         await closeSharedPostgresPool();
     }
 }

--- a/common/src/util/config.ts
+++ b/common/src/util/config.ts
@@ -122,6 +122,20 @@ export const config = {
                 5000,
             );
         },
+        get pool_max_lifetime_seconds(): number {
+            return ConfigResolver.getNumberConfig(
+                "POSTGRES_POOL_MAX_LIFETIME_SECONDS",
+                "db.pool_max_lifetime_seconds",
+                300,
+            );
+        },
+        get idle_in_transaction_timeout_ms(): number {
+            return ConfigResolver.getNumberConfig(
+                "POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS",
+                "db.idle_in_transaction_timeout_ms",
+                60000,
+            );
+        },
         get application_name(): string {
             return ConfigResolver.getConfig(
                 "POSTGRES_APPLICATION_NAME",

--- a/core/src/database/database.module.ts
+++ b/core/src/database/database.module.ts
@@ -50,6 +50,8 @@ const modules = [
             max: config.db.pool_size,
             idleTimeoutMillis: config.db.pool_idle_timeout_ms,
             connectionTimeoutMillis: config.db.pool_connection_timeout_ms,
+            maxLifetimeSeconds: config.db.pool_max_lifetime_seconds,
+            idle_in_transaction_session_timeout: config.db.idle_in_transaction_timeout_ms,
             application_name: `${config.db.application_name || "sprocket-core"}.typeorm`
                 .replace(/[^a-zA-Z0-9_.:-]/g, "_")
                 .slice(0, 63),

--- a/core/src/franchise/player/player.service.ts
+++ b/core/src/franchise/player/player.service.ts
@@ -369,12 +369,12 @@ export class PlayerService {
         const skillGroup = await this.skillGroupService.getGameSkillGroupById(skillGroupId);
 
         const runner = this.dataSource.createQueryRunner();
-        await runner.connect();
-        await runner.startTransaction();
 
         let player: Player;
 
         try {
+            await runner.connect();
+            await runner.startTransaction();
             const mlePlayer = await this.mle_playerRepository.findOne({
                 where: {mleid},
             });
@@ -423,11 +423,11 @@ export class PlayerService {
                 await this.syncRosterAuthorityAfterMleSave(mleAfter.id);
             }
         } catch (e) {
-            await runner.rollbackTransaction();
+            if (runner.isTransactionActive) await runner.rollbackTransaction();
             this.logger.error(e);
             throw e;
         } finally {
-            await runner.release();
+            if (!runner.isReleased) await runner.release();
         }
 
         return player;
@@ -1168,6 +1168,8 @@ export class PlayerService {
             this.logger.log(`Started database transaction`);
         } catch (e) {
             this.logger.error(`Failed to start transaction: ${e instanceof Error ? e.message : String(e)}`);
+            if (runner.isTransactionActive) await runner.rollbackTransaction();
+            if (!runner.isReleased) await runner.release();
             throw e;
         }
 
@@ -1424,13 +1426,13 @@ export class PlayerService {
             this.logger.error(`Stack trace: ${e instanceof Error ? e.stack : "N/A"}`);
 
             this.logger.log(`Rolling back transaction...`);
-            await runner.rollbackTransaction();
+            if (runner.isTransactionActive) await runner.rollbackTransaction();
             this.logger.log(`Transaction rolled back`);
 
             return e instanceof Error ? e.message : String(e);
         } finally {
             this.logger.log(`Releasing query runner...`);
-            await runner.release();
+            if (!runner.isReleased) await runner.release();
             this.logger.log(`Query runner released`);
         }
     }

--- a/core/src/main.ts
+++ b/core/src/main.ts
@@ -24,6 +24,7 @@ async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {
         logger: config.logger.levels,
     });
+    app.enableShutdownHooks();
 
     app.getHttpAdapter().getInstance().get("/healthz", (_req: Request, res: Response) => {
         res.status(200).json({status: "ok"});

--- a/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
+++ b/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
@@ -73,11 +73,10 @@ export class RocketLeagueFinalizationService {
         scrim: Scrim,
     ): Promise<SaveScrimFinalizationReturn> {
         const qr = this.dataSource.createQueryRunner();
-
-        await qr.connect();
-        await qr.startTransaction();
-        const em = qr.manager;
         try {
+            await qr.connect();
+            await qr.startTransaction();
+            const em = qr.manager;
             const gameMode = await em.findOneByOrFail(GameMode, {id: scrim.gameModeId});
 
             const scrimMeta = em.create(ScrimMeta);
@@ -144,10 +143,10 @@ export class RocketLeagueFinalizationService {
             };
 
             this.logger.error(`Failed to save LFS scrim! ${(e as Error).message} | ${JSON.stringify(errorPayload)}`);
-            await qr.rollbackTransaction();
+            if (qr.isTransactionActive) await qr.rollbackTransaction();
             throw e;
         } finally {
-            await qr.release();
+            if (!qr.isReleased) await qr.release();
         }
     }
 
@@ -156,11 +155,10 @@ export class RocketLeagueFinalizationService {
         scrim: Scrim,
     ): Promise<SaveScrimFinalizationReturn> {
         const qr = this.dataSource.createQueryRunner();
-
-        await qr.connect();
-        await qr.startTransaction();
-        const em = qr.manager;
         try {
+            await qr.connect();
+            await qr.startTransaction();
+            const em = qr.manager;
             // Before saving, check if scrim is competitive or not
             const isCompetitive = scrim.settings.competitive;
 
@@ -203,20 +201,19 @@ export class RocketLeagueFinalizationService {
             };
 
             this.logger.error(`Failed to save scrim! ${(e as Error).message} | ${JSON.stringify(errorPayload)}`);
-            await qr.rollbackTransaction();
+            if (qr.isTransactionActive) await qr.rollbackTransaction();
             throw e;
         } finally {
-            await qr.release();
+            if (!qr.isReleased) await qr.release();
         }
     }
 
     async finalizeMatch(submission: MatchReplaySubmission): Promise<SaveMatchFinalizationReturn> {
         const qr = this.dataSource.createQueryRunner();
-
-        await qr.connect();
-        await qr.startTransaction();
-        const em = qr.manager;
         try {
+            await qr.connect();
+            await qr.startTransaction();
+            const em = qr.manager;
             const match = await this.matchService.getMatchById(submission.matchId, {
                 matchParent: {fixture: {homeFranchise: {organization: true} } },
                 gameMode: true,
@@ -235,10 +232,10 @@ export class RocketLeagueFinalizationService {
             };
 
             this.logger.error(`Failed to save match! ${(e as Error).message} | ${JSON.stringify(errorPayload)}`);
-            await qr.rollbackTransaction();
+            if (qr.isTransactionActive) await qr.rollbackTransaction();
             throw e;
         } finally {
-            await qr.release();
+            if (!qr.isReleased) await qr.release();
         }
     }
 

--- a/core/src/scheduling/match/match.resolver.ts
+++ b/core/src/scheduling/match/match.resolver.ts
@@ -1,6 +1,6 @@
 import { Logger, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, ResolveField, Resolver, Root } from '@nestjs/graphql';
-import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import {
   EventsService,
   EventTopic,
@@ -10,7 +10,7 @@ import {
   SubmissionEndpoint,
   SubmissionService,
 } from '@sprocketbot/common';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { Franchise } from '$db/franchise/franchise/franchise.model';
 import { GameSkillGroup } from '$db/franchise/game_skill_group/game_skill_group.model';
@@ -60,7 +60,6 @@ export class MatchResolver {
     private readonly seriesReplayRepo: Repository<MLE_SeriesReplay>,
     @InjectRepository(SeriesToMatchParent)
     private readonly seriesToMatchParentRepo: Repository<SeriesToMatchParent>,
-    @InjectDataSource() private readonly dataSource: DataSource,
   ) {}
 
   @Query(() => Match)
@@ -172,11 +171,9 @@ export class MatchResolver {
     @Args('winningTeamId', { nullable: true }) winningTeamId?: number,
     @Args('numReplays', { nullable: true }) numReplays?: number,
   ): Promise<string> {
-    // Perform NCPs in a single transaction
-    const qr = this.dataSource.createQueryRunner();
-    await qr.connect();
-    await qr.startTransaction();
-
+    // These service/repository calls are not bound to a QueryRunner. Holding
+    // one here would reserve the only TypeORM connection without enclosing
+    // the work in its transaction.
     try {
       this.logger.verbose(
         `Marking series ${matchId} as NCP:${isNcp}. Winning team ID: ${winningTeamId}, with ${numReplays} replays.`,
@@ -217,15 +214,11 @@ export class MatchResolver {
         team.franchise.profile.title,
       );
 
-      await qr.commitTransaction();
       this.logger.verbose(`Successfully marked series ${matchId} NCP:${isNcp}`);
       return 'NCP marked successfully';
     } catch (e) {
       this.logger.error(`Failed to mark series ${matchId} NCP. Got error ${e}`);
-      await qr.rollbackTransaction();
       throw e;
-    } finally {
-      await qr.release();
     }
   }
 
@@ -242,11 +235,6 @@ export class MatchResolver {
     @Args('isNcp') isNcp: boolean,
     @Args('winningTeamId', { nullable: true }) winningTeamId: number,
   ): Promise<string> {
-    // Perform NCPs in a single transaction
-    const qr = this.dataSource.createQueryRunner();
-    await qr.connect();
-    await qr.startTransaction();
-
     try {
       this.logger.verbose(
         `Marking replays ${roundIds} as NCP:${isNcp}. Winning team ID: ${winningTeamId}`,
@@ -302,15 +290,11 @@ export class MatchResolver {
       // Save round NCPs to MLEDB schema
       await this.mledbMatchService.markReplaysNcp(mleReplayIds, isNcp, winningMLETeam);
 
-      await qr.commitTransaction();
       this.logger.verbose(`Successfully marked replays ${roundIds} NCP:${isNcp}`);
       return 'NCP marked successfully';
     } catch (e) {
       this.logger.error(`Failed to mark replays ${roundIds} NCP. Got error ${e}`);
-      await qr.rollbackTransaction();
       throw e;
-    } finally {
-      await qr.release();
     }
   }
 

--- a/core/src/scheduling/schedule-group/schedule-group.service.spec.ts
+++ b/core/src/scheduling/schedule-group/schedule-group.service.spec.ts
@@ -1,0 +1,49 @@
+import {ScheduleGroupService} from "./schedule-group.service";
+import type {RawFixture} from "./schedule-groups.types";
+
+function repositoryMock(): {
+    create: jest.Mock;
+    merge: jest.Mock;
+    save: jest.Mock;
+    insert: jest.Mock;
+    findOneOrFail: jest.Mock;
+} {
+    return {
+        create: jest.fn((value: object) => ({...value})),
+        merge: jest.fn((target: object, value: object) => Object.assign(target, value)),
+        save: jest.fn(async (value: object) => value),
+        insert: jest.fn(async () => undefined),
+        findOneOrFail: jest.fn(),
+    };
+}
+
+describe("ScheduleGroupService.createSeasonSchedule", () => {
+    it("does not reserve an unrelated QueryRunner connection", async () => {
+        const scheduleGroupRepo = repositoryMock();
+        const seasonRepo = repositoryMock();
+        seasonRepo.create.mockReturnValue({matches: [] });
+        const matchRepo = repositoryMock();
+        const seasonBridgeRepo = repositoryMock();
+        const matchBridgeRepo = repositoryMock();
+        const scheduleFixtureService = {createScheduleFixture: jest.fn()};
+        const skillGroupRepo = repositoryMock();
+        const service = new ScheduleGroupService(
+            scheduleGroupRepo as never,
+            seasonRepo as never,
+            matchRepo as never,
+            seasonBridgeRepo as never,
+            matchBridgeRepo as never,
+            scheduleFixtureService as never,
+            skillGroupRepo as never,
+        );
+
+        const result = await service.createSeasonSchedule(42, [] as unknown as RawFixture);
+
+        expect(result).toHaveLength(1);
+        expect(seasonBridgeRepo.insert).toHaveBeenCalledWith({
+            scheduleGroupId: undefined,
+            seasonNumber: 42,
+        });
+        expect(scheduleFixtureService.createScheduleFixture).not.toHaveBeenCalled();
+    });
+});

--- a/core/src/scheduling/schedule-group/schedule-group.service.ts
+++ b/core/src/scheduling/schedule-group/schedule-group.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from "@nestjs/common";
 import {InjectRepository} from "@nestjs/typeorm";
 import type {FindOptionsWhere} from "typeorm";
 import {
-    DataSource, Raw, Repository,
+    Raw, Repository,
 } from "typeorm";
 
 import {GameSkillGroup} from "$db/franchise/game_skill_group/game_skill_group.model";
@@ -32,7 +32,6 @@ export class ScheduleGroupService {
     private readonly m2sgRepo: Repository<MatchToScheduleGroup>,
     private readonly scheduleFixtureService: ScheduleFixtureService,
     @InjectRepository(GameSkillGroup) private gameSkillGroupRepository: Repository<GameSkillGroup>,
-    private readonly dataSource: DataSource,
     ) {}
 
     async getScheduleGroups(
@@ -64,7 +63,7 @@ export class ScheduleGroupService {
         return this.scheduleGroupRepo.find({
             where: conditions,
             relations: [
-                "type", 
+                "type",
                 "game",
                 "childGroups",
                 "childGroups.fixtures",
@@ -80,17 +79,15 @@ export class ScheduleGroupService {
         season_number: number,
         parsedFixtures: RawFixture,
     ): Promise<ScheduleGroup[]> {
-    // Some bookkeeping structures
+        // This workflow spans injected repositories and services. An unbound
+        // QueryRunner here only reserves a connection; it does not make those
+        // repository calls transactional and can deadlock a one-connection pool.
+        // Some bookkeeping structures
         const sgs: ScheduleGroup[] = [];
         const sgMap: Map<string, ScheduleGroup> = new Map();
         const mmMap: Map<string, MLE_Match> = new Map();
         const sfMap: Map<string, ScheduleFixture[]> = new Map();
         const mfMap: Map<string, MLE_Fixture[]> = new Map();
-
-        // First, we do this all as one transaction
-        const runner = this.dataSource.createQueryRunner();
-        await runner.connect();
-        await runner.startTransaction();
 
         // Create the season schedule group
         const season_description = `Season ${season_number}`;
@@ -218,9 +215,6 @@ export class ScheduleGroupService {
             scheduleGroupId: season.id,
             seasonNumber: season_number,
         });
-
-        // We're done touching the DB at this point, so we can commit the transaction.
-        await runner.commitTransaction();
 
         // Finally, build just a list of the schedule groups we've created to
         // send back

--- a/microservices/image-generation-service/src/app.module.ts
+++ b/microservices/image-generation-service/src/app.module.ts
@@ -1,10 +1,11 @@
 import {Module} from "@nestjs/common";
+import {PostgresModule} from "@sprocketbot/common";
 
 import {HealthController} from "./health.controller";
 import {ImageGenerationModule} from "./image-generation/image-generation.module";
 
 @Module({
-    imports: [ImageGenerationModule],
+    imports: [ImageGenerationModule, PostgresModule],
     providers: [],
     controllers: [HealthController],
 })

--- a/microservices/image-generation-service/src/main.ts
+++ b/microservices/image-generation-service/src/main.ts
@@ -7,6 +7,7 @@ const HEALTH_PORT = 3014;
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {logger: config.logger.levels});
+    app.enableShutdownHooks();
 
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.image_generation_queue}),

--- a/microservices/matchmaking-service/src/main.ts
+++ b/microservices/matchmaking-service/src/main.ts
@@ -7,6 +7,7 @@ const HEALTH_PORT = 3010;
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {logger: config.logger.levels});
+    app.enableShutdownHooks();
 
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.matchmaking_queue}),

--- a/microservices/notification-service/src/app.module.ts
+++ b/microservices/notification-service/src/app.module.ts
@@ -1,4 +1,5 @@
 import {Module} from "@nestjs/common";
+import {PostgresModule} from "@sprocketbot/common";
 
 import {HealthController} from "./health.controller";
 
@@ -17,6 +18,7 @@ import {SubmissionModule} from "./submission/submission.module";
         MatchModule,
         NotificationModule,
         PlayerModule,
+        PostgresModule,
     ],
     controllers: [HealthController],
 })

--- a/microservices/notification-service/src/main.ts
+++ b/microservices/notification-service/src/main.ts
@@ -7,6 +7,7 @@ const HEALTH_PORT = 3011;
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {logger: config.logger.levels});
+    app.enableShutdownHooks();
 
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.notification_queue}),

--- a/microservices/server-analytics-service/src/app.module.ts
+++ b/microservices/server-analytics-service/src/app.module.ts
@@ -1,10 +1,11 @@
 import {Module} from "@nestjs/common";
+import {PostgresModule} from "@sprocketbot/common";
 
 import {AnalyticsModule} from "./analytics/analytics.module";
 import {HealthController} from "./health.controller";
 
 @Module({
-    imports: [AnalyticsModule],
+    imports: [AnalyticsModule, PostgresModule],
     controllers: [HealthController],
 })
 export class AppModule {}

--- a/microservices/server-analytics-service/src/main.ts
+++ b/microservices/server-analytics-service/src/main.ts
@@ -9,6 +9,7 @@ const HEALTH_PORT = 3013;
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {logger: config.logger.levels});
+    app.enableShutdownHooks();
 
     app.connectMicroservice({
         strategy: new PostgresServer({queue}),

--- a/microservices/submission-service/src/main.ts
+++ b/microservices/submission-service/src/main.ts
@@ -7,6 +7,7 @@ const HEALTH_PORT = 3012;
 
 async function bootstrap(): Promise<void> {
     const app = await NestFactory.create(AppModule, {logger: config.logger.levels});
+    app.enableShutdownHooks();
 
     app.connectMicroservice({
         strategy: new PostgresServer({queue: config.transport.submission_queue}),


### PR DESCRIPTION
## Summary

- remove leaked and phantom TypeORM QueryRunner reservations that can exhaust or self-deadlock a one-connection pool
- close the shared Postgres pool after transport disposal and enable signal-aware shutdown across Postgres-backed runtimes
- rotate pooled sessions, enforce an idle-in-transaction timeout, and close partially started monolith consumers on bootstrap failure
- add regression coverage for pool configuration, shutdown lifecycle, and schedule generation

## Root cause

The monolith still has independent shared `pg` and TypeORM pools. Some workflows reserved a TypeORM QueryRunner while executing their actual queries through unrelated injected repositories. One schedule-generation path never released that runner at all, and with `POSTGRES_POOL_SIZE=1` the phantom transaction paths could wait for the same connection they had reserved.

Nest was also closing the process-wide shared pool during module destruction, before the monolith's Postgres transport servers were disposed. Partial startup failures could leave consumers polling after another consumer failed.

## Impact

Connection usage should stabilize at the expected per-process pool budget instead of growing from leaked runners or shutdown/startup races. Sessions are attributed as before, rotate after a finite lifetime, and PostgreSQL terminates sessions left idle in a transaction.

Emergency database cleanup tooling is intentionally excluded from this PR.

## Validation

- `npm run build --workspace=common`
- `npm run test --workspace=common -- --runInBand` (11 tests passed)
- `npm run build --workspace=core`
- `npm run test --workspace=core -- --runInBand --runTestsByPath src/scheduling/schedule-group/schedule-group.service.spec.ts --coverage=false`
- builds passed for monolith, Discord bot, image-generation frontend/service, matchmaking, notification, analytics, and submission workspaces
- `git diff --cached --check`

The image-generation frontend build still reports its existing Svelte accessibility warnings.