### PR TITLE
[codex] add admin end-to-end test scrims

### DIFF
--- a/clients/web/src/lib/api/mutations/scrims/CreateTestScrim.mutation.ts
+++ b/clients/web/src/lib/api/mutations/scrims/CreateTestScrim.mutation.ts
@@ -1,0 +1,33 @@
+import {gql} from "@urql/core";
+import {client} from "../../client";
+
+export interface CreateTestScrimResponse {
+    createTestScrim: {
+        id: string;
+        submissionId?: string;
+        testRunId?: string;
+        status: string;
+    };
+}
+
+export interface CreateTestScrimVariables {
+    gameModeId: number;
+    skillGroupId: number;
+}
+
+const mutationString = gql`
+  mutation ($gameModeId: Int!, $skillGroupId: Int!) {
+    createTestScrim(data: {gameModeId: $gameModeId, skillGroupId: $skillGroupId}) {
+      id
+      submissionId
+      testRunId
+      status
+    }
+  }
+`;
+
+export const createTestScrimMutation = async (vars: CreateTestScrimVariables): Promise<CreateTestScrimResponse> => {
+    const result = await client.mutation<CreateTestScrimResponse, CreateTestScrimVariables>(mutationString, vars).toPromise();
+    if (result.data) return result.data;
+    throw result.error as Error;
+};

--- a/clients/web/src/lib/api/mutations/scrims/index.ts
+++ b/clients/web/src/lib/api/mutations/scrims/index.ts
@@ -1,5 +1,6 @@
 export * from "./CheckIn.mutation";
 export * from "./CreateScrim.mutation";
+export * from "./CreateTestScrim.mutation";
 export * from "./CreateLFSScrim.mutation";
 export * from "./JoinScrim.mutation";
 export * from "./LeaveScrim.mutation";

--- a/clients/web/src/lib/components/atoms/FileInput.svelte
+++ b/clients/web/src/lib/components/atoms/FileInput.svelte
@@ -23,6 +23,7 @@
     export let files: RemovableFile[] = [];
     export let disabled: boolean | undefined = undefined;
     export let unique = true;
+    export let multiple = true;
 
     const onRemove = (file: File): void => {
         files = files.filter(f => f.name !== file.name);
@@ -50,7 +51,7 @@
 
 
 <!-- Hide the input so we can style the label -->
-<input class="sr-only" id="file-input" type="file" multiple files={filesToFileList(files)} on:change={onChange} disabled={disabled} />
+<input class="sr-only" id="file-input" type="file" multiple={multiple} files={filesToFileList(files)} on:change={onChange} disabled={disabled} />
 
 <label for="file-input" class:disabled>
     <span><FaUpload /></span>

--- a/clients/web/src/lib/components/molecules/scrims/TestScrimCreate.svelte
+++ b/clients/web/src/lib/components/molecules/scrims/TestScrimCreate.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+    import {createTestScrimMutation, type GamesAndModesValue} from "$lib/api";
+    import {gamesAndModes} from "$lib/api/queries/GamesAndModes.store";
+    import {Modal, toasts} from "$lib/components";
+
+    export let visible = false;
+    export let onCreated: (submissionId: string) => void;
+
+    let gameModeId: number | undefined;
+    let skillGroupId: number | undefined;
+    let creating = false;
+
+    $: games = $gamesAndModes?.data?.games ?? [];
+
+    async function create() {
+        if (!gameModeId || !skillGroupId) return;
+        creating = true;
+        try {
+            const result = await createTestScrimMutation({gameModeId, skillGroupId});
+            const submissionId = result.createTestScrim.submissionId;
+            if (!submissionId) throw new Error("Test scrim did not return a submission ID");
+            visible = false;
+            onCreated(submissionId);
+        } catch (error) {
+            toasts.pushToast({status: "error", content: error instanceof Error ? error.message : "Failed to create test scrim"});
+        } finally {
+            creating = false;
+        }
+    }
+
+    let games: GamesAndModesValue["games"] = [];
+</script>
+
+<Modal title="Create Test Scrim" bind:visible id="create-test-scrim-modal">
+    <form slot="body" on:submit|preventDefault={create} class="space-y-4">
+        <label class="form-control">
+            <span class="label-text">Game mode</span>
+            <select class="select select-bordered" bind:value={gameModeId} required>
+                <option value={undefined} disabled selected>Select a mode</option>
+                {#each games as game}
+                    <optgroup label={game.title}>
+                        {#each game.modes as mode}
+                            <option value={mode.id}>{mode.description}</option>
+                        {/each}
+                    </optgroup>
+                {/each}
+            </select>
+        </label>
+        <label class="form-control">
+            <span class="label-text">Skill group ID</span>
+            <input class="input input-bordered" type="number" min="1" bind:value={skillGroupId} required />
+            <span class="text-xs opacity-70">Use the Rocket League skill group for this test.</span>
+        </label>
+        <button class="btn btn-primary" disabled={creating || !gameModeId || !skillGroupId}>Create and upload replay</button>
+    </form>
+</Modal>

--- a/clients/web/src/lib/components/molecules/scrims/index.ts
+++ b/clients/web/src/lib/components/molecules/scrims/index.ts
@@ -1,4 +1,5 @@
 export {default as ScrimTable} from "./ScrimTable.svelte";
+export {default as TestScrimCreate} from "./TestScrimCreate.svelte";
 export {default as ScrimCard} from "./ScrimCard.svelte";
 export {default as ScrimFullIndicator} from "./ScrimFullIndicator.svelte";
 export {default as AdminScrimTable} from "./AdminScrimTable.svelte";

--- a/clients/web/src/lib/components/organisms/scrims/modals/UploadReplaysModal.svelte
+++ b/clients/web/src/lib/components/organisms/scrims/modals/UploadReplaysModal.svelte
@@ -10,6 +10,7 @@ import type {RemovableFile} from "../../../atoms/FileInput.svelte";
 
     export let visible: boolean = true;
     export let submissionId: string;
+    export let single = false;
 
     $: console.log("UploadReplaysModal: visible changed to:", visible);
     $: console.log("UploadReplaysModal: submissionId changed to:", submissionId);
@@ -63,7 +64,7 @@ import type {RemovableFile} from "../../../atoms/FileInput.svelte";
             {/each}
         {/if}
         <div class="actions">
-            <FileInput label="Upload" bind:files />
+            <FileInput label="Upload" bind:files multiple={!single} />
 
             {#if files?.length}
                 <button on:click={handleSubmit} class="btn btn-primary">

--- a/clients/web/src/routes/admin/index.svelte
+++ b/clients/web/src/routes/admin/index.svelte
@@ -5,6 +5,8 @@
         AdminScrimTable,
         AdminSettings,
         AdminSubmissionTable,
+        TestScrimCreate,
+        UploadReplaysModal,
         DashboardCard,
         DashboardLayout,
     } from "$lib/components";
@@ -24,6 +26,17 @@
     };
 </script>
 
+<script lang="ts">
+    let testScrimModalVisible = false;
+    let testUploadVisible = false;
+    let testSubmissionId = "";
+
+    function onTestScrimCreated(submissionId: string) {
+        testSubmissionId = submissionId;
+        testUploadVisible = true;
+    }
+</script>
+
 <DashboardLayout>
     <DashboardCard
         title="Admin Settings"
@@ -40,6 +53,13 @@
         <div class=" flex justify-center">
             <AdminScrimTable />
         </div>
+    </DashboardCard>
+    <DashboardCard
+        title="End-to-End Test Scrim"
+        class="col-span-6 xl:col-span-5 row-span-1"
+    >
+        <p class="mb-4 text-sm opacity-80">Create an isolated one-replay scrim and run the production parser and finalizer.</p>
+        <button class="btn btn-warning" on:click={() => { testScrimModalVisible = true }}>Create Test Scrim</button>
     </DashboardCard>
     <DashboardCard
         title="Submission Management"
@@ -66,3 +86,8 @@
         </div>
     </DashboardCard>
 </DashboardLayout>
+
+<TestScrimCreate bind:visible={testScrimModalVisible} onCreated={onTestScrimCreated} />
+{#if testSubmissionId}
+    <UploadReplaysModal bind:visible={testUploadVisible} submissionId={testSubmissionId} single />
+{/if}

--- a/common/src/service-connectors/core/core.types.ts
+++ b/common/src/service-connectors/core/core.types.ts
@@ -33,6 +33,7 @@ export enum CoreEndpoint {
     GetGameByGameMode = "GetGameByGameMode",
     GetNicknameByDiscordUser = "GetNicknameByDiscordUser",
     UpsertReportCardAsset = "UpsertReportCardAsset",
+    ProvisionTestReplayPlayers = "ProvisionTestReplayPlayers",
 }
 
 export const CoreSchemas = {
@@ -151,6 +152,10 @@ export const CoreSchemas = {
     [CoreEndpoint.UpsertReportCardAsset]: {
         input: Schemas.UpsertReportCardAsset_Request,
         output: Schemas.UpsertReportCardAsset_Response,
+    },
+    [CoreEndpoint.ProvisionTestReplayPlayers]: {
+        input: Schemas.ProvisionTestReplayPlayers_Request,
+        output: Schemas.ProvisionTestReplayPlayers_Response,
     },
 };
 

--- a/common/src/service-connectors/core/schemas/ProvisionTestReplayPlayers.schema.ts
+++ b/common/src/service-connectors/core/schemas/ProvisionTestReplayPlayers.schema.ts
@@ -1,0 +1,19 @@
+import {z} from "zod";
+
+const Player = z.object({
+    platform: z.string(),
+    platformAccountId: z.string(),
+    name: z.string(),
+});
+
+export const ProvisionTestReplayPlayers_Request = z.object({
+    testRunId: z.string().uuid(),
+    organizationId: z.number(),
+    skillGroupId: z.number(),
+    players: z.array(Player),
+});
+
+export const ProvisionTestReplayPlayers_Response = z.array(Player.extend({
+    userId: z.number(),
+    playerId: z.number(),
+}));

--- a/common/src/service-connectors/core/schemas/index.ts
+++ b/common/src/service-connectors/core/schemas/index.ts
@@ -27,3 +27,4 @@ export * from "./GetUserByAuthAccount.schema";
 export * from "./GetUsersLastScrim.schema";
 export * from "./MemberRestriction.schema";
 export * from "./UpsertReportCardAsset.schema";
+export * from "./ProvisionTestReplayPlayers.schema";

--- a/common/src/service-connectors/matchmaking/matchmaking.types.ts
+++ b/common/src/service-connectors/matchmaking/matchmaking.types.ts
@@ -18,6 +18,8 @@ export enum MatchmakingEndpoint {
     CancelScrim = "CancelScrim",
     SetScrimLocked = "SetScrimLocked",
     UpdateLFSScrimPlayers = "UpdateLFSScrimPlayers",
+    CreateTestScrim = "CreateTestScrim",
+    UpdateTestScrimPlayers = "UpdateTestScrimPlayers",
 }
 
 export const MatchmakingSchemas = {
@@ -76,6 +78,14 @@ export const MatchmakingSchemas = {
     [MatchmakingEndpoint.UpdateLFSScrimPlayers]: {
         input: Schemas.UpdateLFSScrimPlayers_Request,
         output: Schemas.UpdateLFSScrimPlayers_Response,
+    },
+    [MatchmakingEndpoint.CreateTestScrim]: {
+        input: Schemas.CreateTestScrim_Request,
+        output: Schemas.CreateTestScrim_Response,
+    },
+    [MatchmakingEndpoint.UpdateTestScrimPlayers]: {
+        input: Schemas.UpdateTestScrimPlayers_Request,
+        output: Schemas.UpdateTestScrimPlayers_Response,
     },
 };
 

--- a/common/src/service-connectors/matchmaking/schemas/scrim/CreateTestScrim.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/CreateTestScrim.schema.ts
@@ -1,0 +1,16 @@
+import {z} from "zod";
+
+import {ScrimSchema, ScrimSettingsSchema} from "../../types";
+
+export const CreateTestScrim_Request = z.object({
+    authorId: z.number(),
+    organizationId: z.number(),
+    gameModeId: z.number(),
+    skillGroupId: z.number(),
+    settings: ScrimSettingsSchema,
+    testRunId: z.string().uuid(),
+});
+
+export const CreateTestScrim_Response = ScrimSchema;
+
+export type CreateTestScrimRequest = z.infer<typeof CreateTestScrim_Request>;

--- a/common/src/service-connectors/matchmaking/schemas/scrim/UpdateTestScrimPlayers.schema.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/UpdateTestScrimPlayers.schema.ts
@@ -1,0 +1,14 @@
+import {z} from "zod";
+
+import {ScrimGameSchema, ScrimPlayerSchema} from "../../types";
+
+export const UpdateTestScrimPlayers_Request = z.object({
+    scrimId: z.string().uuid(),
+    testRunId: z.string().uuid(),
+    players: z.array(ScrimPlayerSchema),
+    games: z.array(ScrimGameSchema),
+});
+
+export const UpdateTestScrimPlayers_Response = z.boolean();
+
+export type UpdateTestScrimPlayersRequest = z.infer<typeof UpdateTestScrimPlayers_Request>;

--- a/common/src/service-connectors/matchmaking/schemas/scrim/index.ts
+++ b/common/src/service-connectors/matchmaking/schemas/scrim/index.ts
@@ -12,3 +12,5 @@ export * from "./JoinScrim.schema";
 export * from "./LeaveScrim.schema";
 export * from "./SetScrimLocked.schema";
 export * from "./UpdateLFSScrimPlayers.schema";
+export * from "./CreateTestScrim.schema";
+export * from "./UpdateTestScrimPlayers.schema";

--- a/common/src/service-connectors/matchmaking/types/Scrim.ts
+++ b/common/src/service-connectors/matchmaking/types/Scrim.ts
@@ -20,6 +20,7 @@ export const ScrimSchema = z.object({
     gameModeId: z.number(),
     skillGroupId: z.number(),
     submissionId: z.string().optional(),
+    testRunId: z.string().uuid().optional(),
     timeoutJobId: z.number().optional(),
     /** When set, ungrouped players cannot join a team scrim until this instant (teammates may still join via group code). */
     groupInviteOpensAt: DateSchema.optional(),

--- a/core/migrations/1779700000000-TestScrimRun.ts
+++ b/core/migrations/1779700000000-TestScrimRun.ts
@@ -1,0 +1,21 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class TestScrimRun1779700000000 implements MigrationInterface {
+    name = "TestScrimRun1779700000000";
+
+    async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'ALTER TABLE "sprocket"."scrim_queue" ADD COLUMN IF NOT EXISTS "test_run_id" uuid',
+        );
+        await queryRunner.query(
+            'CREATE INDEX IF NOT EXISTS "IDX_scrim_queue_test_run_id" ON "sprocket"."scrim_queue" ("test_run_id")',
+        );
+    }
+
+    async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX IF EXISTS "sprocket"."IDX_scrim_queue_test_run_id"');
+        await queryRunner.query(
+            'ALTER TABLE "sprocket"."scrim_queue" DROP COLUMN IF EXISTS "test_run_id"',
+        );
+    }
+}

--- a/core/src/database/scheduling/test_replay_identity/test_replay_identity.model.ts
+++ b/core/src/database/scheduling/test_replay_identity/test_replay_identity.model.ts
@@ -1,0 +1,28 @@
+import {Column, Entity, Index} from "typeorm";
+
+import {BaseModel} from "../../base-model";
+
+@Entity({schema: "sprocket"})
+@Index(["testRunId", "platform", "platformAccountId"], {unique: true})
+export class TestReplayIdentity extends BaseModel {
+    @Column({type: "uuid", name: "test_run_id"})
+    testRunId: string;
+
+    @Column({type: "text"})
+    platform: string;
+
+    @Column({type: "text", name: "platform_account_id"})
+    platformAccountId: string;
+
+    @Column({name: "mapped_platform_account_id", type: "text"})
+    mappedPlatformAccountId: string;
+
+    @Column({name: "user_id"})
+    userId: number;
+
+    @Column({name: "player_id"})
+    playerId: number;
+
+    @Column({name: "mle_player_id"})
+    mlePlayerId: number;
+}

--- a/core/src/mledb/mledb-interface.module.ts
+++ b/core/src/mledb/mledb-interface.module.ts
@@ -15,6 +15,7 @@ import {MLE_Series} from "../database/mledb/Series.model";
 import {MLE_TeamRoleUsage} from "../database/mledb/TeamRoleUsage.model";
 import {SeriesToMatchParent} from "../database/mledb-bridge/series_to_match_parent.model";
 import {Match} from "../database/scheduling/match/match.model";
+import {TestReplayIdentity} from "../database/scheduling/test_replay_identity/test_replay_identity.model";
 import {FranchiseModule} from "../franchise";
 import {GameModule} from "../game";
 import {IdentityModule} from "../identity";
@@ -36,6 +37,7 @@ import {MledbPlayerPresentationResolver} from "./mledb-player/mledb-player.prese
 import {MledbPlayerAccountService} from "./mledb-player-account";
 import {MledbFinalizationService} from "./mledb-scrim";
 import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mledb-team-role-usage";
+import {TestScrimIdentityService} from "../replay-parse/test-scrim-identity.service";
 
 @Module({
     imports: [
@@ -52,6 +54,7 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
             RosterRole,
             RosterSlot,
             RosterRoleUsage,
+            TestReplayIdentity,
         ]),
         DatabaseModule,
         GameModule,
@@ -76,6 +79,7 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
         MledbNcpTeamRoleUsageService,
         MledbNcpTeamRoleUsageResolver,
         FormerPlayerScrimGuard,
+        TestScrimIdentityService,
     ],
     exports: [
         MledbMatchService,
@@ -83,6 +87,7 @@ import {MledbNcpTeamRoleUsageResolver, MledbNcpTeamRoleUsageService} from "./mle
         MledbPlayerAccountService,
         MledbFinalizationService,
         FormerPlayerScrimGuard,
+        TestScrimIdentityService,
     ],
     controllers: [MledbMatchController, MledbPlayerController],
 })

--- a/core/src/mledb/mledb-scrim/mledb-finalization.service.ts
+++ b/core/src/mledb/mledb-scrim/mledb-finalization.service.ts
@@ -48,6 +48,7 @@ import type {
     MatchReplaySubmission,
     ScrimReplaySubmission,
 } from "../../replay-parse";
+import {TestScrimIdentityService} from "../../replay-parse/test-scrim-identity.service";
 import {SprocketRatingService} from "../../sprocket-rating/sprocket-rating.service";
 import {MledbMatchService} from "../mledb-match/mledb-match.service";
 import {assignPlayerStats} from "./assign-player-stats";
@@ -71,6 +72,7 @@ export class MledbFinalizationService {
     private readonly userService: UserService,
     private readonly sprocketRatingService: SprocketRatingService,
     private readonly mleMatchService: MledbMatchService,
+    private readonly testScrimIdentityService: TestScrimIdentityService,
     ) {}
 
     async getLeagueAndMode(scrim: Scrim): Promise<{mode: GameMode; group: GameSkillGroup;}> {
@@ -167,7 +169,7 @@ export class MledbFinalizationService {
         await em.insert(MLE_Scrim, scrim);
         await em.insert(MLE_Series, series);
 
-        await this.saveSeries(submission as ReplaySubmission, submissionId, em, series);
+        await this.saveSeries(submission as ReplaySubmission, submissionId, em, series, scrimObject.testRunId);
 
         if (scrimObject.settings.competitive) {
             const playerEligibilities = await Promise.all(scrimObject.players.map(async p => {
@@ -197,6 +199,7 @@ export class MledbFinalizationService {
         submissionId: string,
         em: EntityManager,
         series: MLE_Series,
+        testRunId?: string,
     ): Promise<number> {
     // First; initialize all the arrays to save at the end.
         const coreStats: MLE_PlayerStatsCore[] = [];
@@ -238,7 +241,9 @@ export class MledbFinalizationService {
 
                 const playerAccount = await this.mlePlayerAccountRepository.findOneOrFail({
                     where: {
-                        platformId: p.id.id,
+                        platformId: testRunId
+                            ? await this.testScrimIdentityService.mapPlatformAccount(testRunId, p.id.platform, p.id.id) ?? p.id.id
+                            : p.id.id,
                         platform: p.id.platform.toUpperCase() as MLE_Platform,
                     },
                     relations: {

--- a/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
+++ b/core/src/replay-parse/finalization/rocket-league/rocket-league-finalization.service.ts
@@ -38,6 +38,7 @@ import type {
     SprocketRating,
     SprocketRatingInput,
 } from "../../../sprocket-rating/sprocket-rating.types";
+import {TestScrimIdentityService} from "../../test-scrim-identity.service";
 import type {
     LFSReplaySubmission,
     MatchReplaySubmission,
@@ -67,6 +68,7 @@ export class RocketLeagueFinalizationService {
         private readonly eligibilityService: EligibilityService,
         private readonly gameSkillGroupService: GameSkillGroupService,
     @InjectDataSource() private readonly dataSource: DataSource,
+        private readonly testScrimIdentityService: TestScrimIdentityService,
     ) {}
 
     async finalizeLFS(
@@ -180,7 +182,7 @@ export class RocketLeagueFinalizationService {
 
             // If it's competitive, calculate and save eligibility. Otherwise, don't.
             await em.insert(Match, match as QueryDeepPartialEntity<Match>);
-            await this.saveMatchDependents(submission, match, isCompetitive, em);
+            await this.saveMatchDependents(submission, match, isCompetitive, em, scrim.testRunId);
 
             const mledbScrim = await this.mledbFinalizationService.saveScrim(
                 submission,
@@ -246,6 +248,7 @@ export class RocketLeagueFinalizationService {
         match: Match,
         eligibility: boolean,
         em: EntityManager,
+        testRunId?: string,
     ): Promise<Player[]> {
         if (submission.items.some(i => i.progress?.status !== ProgressStatus.Complete)) {
             throw new Error(`Not all items have been completed. Finalization attempted too soon. ${JSON.stringify({
@@ -323,7 +326,7 @@ export class RocketLeagueFinalizationService {
             replay, parser, outputPath,
         }) => {
             // Get players
-            const {blue, orange} = await this._getBallchasingPlayers(replay);
+            const {blue, orange} = await this._getBallchasingPlayers(replay, testRunId);
 
             blue.forEach(p => uniquePlayers.set(p.player.id, p.player));
             orange.forEach(p => uniquePlayers.set(p.player.id, p.player));
@@ -461,7 +464,7 @@ export class RocketLeagueFinalizationService {
    * Looks up a set of players based on their ballchasing information
    * Noteworthy; this looks up sprocket players!
    */
-    async _getBallchasingPlayers(ballchasing: BallchasingResponse): Promise<{
+    async _getBallchasingPlayers(ballchasing: BallchasingResponse, testRunId?: string): Promise<{
         blue: Array<{player: Player; rawPlayer: BallchasingPlayer;}>;
         orange: Array<{player: Player; rawPlayer: BallchasingPlayer;}>;
     }> {
@@ -470,7 +473,9 @@ export class RocketLeagueFinalizationService {
             where: {
                 member: {
                     platformAccounts: {
-                        platformAccountId: p.id.id,
+                        platformAccountId: testRunId
+                            ? await this.testScrimIdentityService.mapPlatformAccount(testRunId, p.id.platform, p.id.id) ?? p.id.id
+                            : p.id.id,
                         platform: {
                             code: p.id.platform.toUpperCase(),
                         },

--- a/core/src/replay-parse/replay-parse.module.ts
+++ b/core/src/replay-parse/replay-parse.module.ts
@@ -27,6 +27,7 @@ import {ReplayParsePubSub} from "./replay-parse.constants";
 import {ReplayParseModResolver} from "./replay-parse.mod.resolver";
 import {ReplaySubmissionResolver, SubmissionRejectionResolver} from "./replay-parse.resolver";
 import {ReplayParseService} from "./replay-parse.service";
+import {TestScrimIdentityController} from "./test-scrim-identity.controller";
 
 @Module({
     imports: [
@@ -62,5 +63,6 @@ import {ReplayParseService} from "./replay-parse.service";
         FinalizationSubscriber,
         RocketLeagueFinalizationService,
     ],
+    controllers: [TestScrimIdentityController],
 })
 export class ReplayParseModule {}

--- a/core/src/replay-parse/test-scrim-identity.controller.ts
+++ b/core/src/replay-parse/test-scrim-identity.controller.ts
@@ -1,0 +1,17 @@
+import {Controller} from "@nestjs/common";
+import {MessagePattern, Payload} from "@nestjs/microservices";
+import type {CoreOutput} from "@sprocketbot/common";
+import {CoreEndpoint, CoreSchemas} from "@sprocketbot/common";
+
+import {TestScrimIdentityService} from "./test-scrim-identity.service";
+
+@Controller("test-scrim")
+export class TestScrimIdentityController {
+    constructor(private readonly service: TestScrimIdentityService) {}
+
+    @MessagePattern(CoreEndpoint.ProvisionTestReplayPlayers)
+    async provision(@Payload() payload: unknown): Promise<CoreOutput<CoreEndpoint.ProvisionTestReplayPlayers>> {
+        const data = CoreSchemas.ProvisionTestReplayPlayers.input.parse(payload);
+        return this.service.provision(data.testRunId, data.organizationId, data.skillGroupId, data.players);
+    }
+}

--- a/core/src/replay-parse/test-scrim-identity.service.ts
+++ b/core/src/replay-parse/test-scrim-identity.service.ts
@@ -1,0 +1,132 @@
+import {Injectable} from "@nestjs/common";
+import {InjectRepository} from "@nestjs/typeorm";
+import {createHash} from "crypto";
+import {DataSource, Repository} from "typeorm";
+
+import {GameSkillGroup} from "$db/franchise/game_skill_group/game_skill_group.model";
+import {Player} from "$db/franchise/player/player.model";
+import {Platform} from "$db/game/platform/platform.model";
+import {User} from "$db/identity/user/user.model";
+import {UserProfile} from "$db/identity/user_profile/user_profile.model";
+import type {MLE_Platform} from "$db/mledb";
+import {
+    League, MLE_Player, MLE_PlayerAccount, ModePreference, Timezone,
+} from "$db/mledb";
+import {PlayerToPlayer} from "$db/mledb-bridge/player_to_player.model";
+import {Member} from "$db/organization/member/member.model";
+import {MemberPlatformAccount} from "$db/organization/member_platform_account/member_platform_account.model";
+import {Organization} from "$db/organization/organization/organization.model";
+import {TestReplayIdentity} from "$db/scheduling/test_replay_identity/test_replay_identity.model";
+
+export interface TestReplayPlayerInput {
+    platform: string;
+    platformAccountId: string;
+    name: string;
+}
+
+export interface TestReplayPlayerOutput extends TestReplayPlayerInput {
+    userId: number;
+    playerId: number;
+}
+
+@Injectable()
+export class TestScrimIdentityService {
+    constructor(
+        @InjectRepository(TestReplayIdentity) private readonly identities: Repository<TestReplayIdentity>,
+        private readonly dataSource: DataSource,
+    ) {}
+
+    async provision(
+        testRunId: string,
+        organizationId: number,
+        skillGroupId: number,
+        inputs: TestReplayPlayerInput[],
+    ): Promise<TestReplayPlayerOutput[]> {
+        const unique = Array.from(new Map(inputs.map(input => [`${input.platform}:${input.platformAccountId}`, input])).values());
+        return Promise.all(unique.map(async input => {
+            const existing = await this.identities.findOne({
+                where: {
+                    testRunId,
+                    platform: input.platform,
+                    platformAccountId: input.platformAccountId,
+                },
+            });
+            if (existing) return {
+                ...input, userId: existing.userId, playerId: existing.playerId,
+            };
+
+            return this.dataSource.transaction(async manager => {
+                const hash = createHash("sha256").update(`${testRunId}:${input.platform}:${input.platformAccountId}`)
+                    .digest("hex");
+                const mappedPlatformAccountId = `test-${hash.slice(0, 24)}`;
+                const email = `${hash.slice(0, 24)}@test.invalid`;
+                const user = await manager.save(User, manager.create(User, {type: [] }));
+                await manager.save(UserProfile, manager.create(UserProfile, {
+                    user,
+                    email,
+                    displayName: `[TEST] ${input.name || hash.slice(0, 8)}`,
+                    description: `Synthetic replay identity for test run ${testRunId}`,
+                }));
+                const organization = await manager.findOneByOrFail(Organization, {id: organizationId});
+                const member = await manager.save(Member, manager.create(Member, {
+                    user, userId: user.id, organization, organizationId,
+                }));
+                const skillGroup = await manager.findOneByOrFail(GameSkillGroup, {id: skillGroupId});
+                const player = await manager.save(Player, manager.create(Player, {
+                    member,
+                    memberId: member.id,
+                    skillGroup,
+                    skillGroupId,
+                    salary: 0,
+                }));
+                const platform = await manager.findOneByOrFail(Platform, {code: input.platform.toUpperCase()});
+                await manager.save(MemberPlatformAccount, manager.create(MemberPlatformAccount, {
+                    member,
+                    platform,
+                    platformAccountId: mappedPlatformAccountId,
+                }));
+                const mlePlayer = await manager.save(MLE_Player, manager.create(MLE_Player, {
+                    mleid: -player.id,
+                    name: `[TEST] ${hash.slice(0, 16)}`,
+                    discordId: `test-${hash.slice(0, 24)}`,
+                    teamName: "TEST",
+                    league: League.UNKNOWN,
+                    modePreference: ModePreference.BOTH,
+                    timezone: Timezone.UNKNOWN,
+                    suspended: true,
+                }));
+                await manager.save(MLE_PlayerAccount, manager.create(MLE_PlayerAccount, {
+                    player: mlePlayer,
+                    platform: input.platform.toUpperCase() as MLE_Platform,
+                    platformId: mappedPlatformAccountId,
+                    tracker: null,
+                }));
+                await manager.save(PlayerToPlayer, manager.create(PlayerToPlayer, {
+                    mledPlayerId: mlePlayer.id,
+                    sprocketPlayerId: player.id,
+                }));
+                const identity = await manager.save(TestReplayIdentity, manager.create(TestReplayIdentity, {
+                    testRunId,
+                    platform: input.platform,
+                    platformAccountId: input.platformAccountId,
+                    mappedPlatformAccountId,
+                    userId: user.id,
+                    playerId: player.id,
+                    mlePlayerId: mlePlayer.id,
+                }));
+                return {
+                    ...input, userId: identity.userId, playerId: identity.playerId,
+                };
+            });
+        }));
+    }
+
+    async mapPlatformAccount(testRunId: string, platform: string, platformAccountId: string): Promise<string | undefined> {
+        const identity = await this.identities.findOne({
+            where: {
+                testRunId, platform, platformAccountId,
+            },
+        });
+        return identity?.mappedPlatformAccountId;
+    }
+}

--- a/core/src/scrim/scrim.mod.resolver.ts
+++ b/core/src/scrim/scrim.mod.resolver.ts
@@ -32,7 +32,7 @@ import {CreateScrimPlayerGuard, JoinScrimPlayerGuard} from "./scrim.guard";
 import {ScrimService} from "./scrim.service";
 import {ScrimToggleService} from "./scrim-toggle";
 import {
-    CreateLFSScrimInput, CreateScrimInput, Scrim, ScrimEvent,
+    CreateLFSScrimInput, CreateScrimInput, CreateTestScrimInput, Scrim, ScrimEvent,
 } from "./types";
 import {ScrimMetrics} from "./types/ScrimMetrics";
 
@@ -89,10 +89,11 @@ export class ScrimModuleResolver {
     ): Promise<Scrim[]> {
         if (!user.currentOrganizationId) throw new GraphQLError("Player is not connected to an organization");
 
-        return this.scrimService.getAllScrims({
+        const scrims = await this.scrimService.getAllScrims({
             organizationId: user.currentOrganizationId,
             status,
-        }) as Promise<Scrim[]>;
+        });
+        return scrims.filter(scrim => !scrim.testRunId) as Scrim[];
     }
 
     @Query(() => [Scrim])
@@ -192,6 +193,21 @@ export class ScrimModuleResolver {
                 createGroup: data.createGroup,
             },
         }) as Promise<Scrim>;
+    }
+
+    @Mutation(() => Scrim)
+    @UseGuards(MLEOrganizationTeamGuard(MLE_OrganizationTeam.MLEDB_ADMIN))
+    async createTestScrim(
+    @CurrentUser() user: UserPayload,
+    @Args("data") data: CreateTestScrimInput,
+    ): Promise<Scrim> {
+        if (!user.currentOrganizationId) throw new GraphQLError("User is not connected to an organization");
+        return this.scrimService.createTestScrim(
+            user.userId,
+            user.currentOrganizationId,
+            data.gameModeId,
+            data.skillGroupId,
+        ) as Promise<Scrim>;
     }
 
     @Mutation(() => Scrim)

--- a/core/src/scrim/scrim.service.ts
+++ b/core/src/scrim/scrim.service.ts
@@ -21,10 +21,12 @@ import {
     MatchmakingEndpoint,
     MatchmakingService,
     ResponseStatus,
+    ScrimMode,
     ScrimStatus,
 } from "@sprocketbot/common";
 import {PubSub} from "apollo-server-express";
 import {Repository} from "typeorm";
+import {v4 as uuid} from "uuid";
 
 import {PlayerStatLine} from "$db/scheduling/player_stat_line/player_stat_line.model";
 
@@ -118,6 +120,33 @@ export class ScrimService {
     async createScrim(data: CreateScrimOptions): Promise<IScrim> {
         const result = await this.matchmakingService.send(MatchmakingEndpoint.CreateScrim, data);
 
+        if (result.status === ResponseStatus.SUCCESS) return result.data;
+        throw result.error;
+    }
+
+    async createTestScrim(
+        authorId: number,
+        organizationId: number,
+        gameModeId: number,
+        skillGroupId: number,
+    ): Promise<IScrim> {
+        const gameMode = await this.gameModeService.getGameModeById(gameModeId);
+        const result = await this.matchmakingService.send(MatchmakingEndpoint.CreateTestScrim, {
+            authorId,
+            organizationId,
+            gameModeId,
+            skillGroupId,
+            testRunId: uuid(),
+            settings: {
+                teamSize: gameMode.teamSize,
+                teamCount: gameMode.teamCount,
+                mode: ScrimMode.TEAMS,
+                competitive: false,
+                observable: false,
+                lfs: false,
+                checkinTimeout: 0,
+            },
+        });
         if (result.status === ResponseStatus.SUCCESS) return result.data;
         throw result.error;
     }

--- a/core/src/scrim/types/CreateTestScrimInput.ts
+++ b/core/src/scrim/types/CreateTestScrimInput.ts
@@ -1,0 +1,10 @@
+import {Field, InputType, Int} from "@nestjs/graphql";
+
+@InputType()
+export class CreateTestScrimInput {
+    @Field(() => Int)
+    gameModeId: number;
+
+    @Field(() => Int)
+    skillGroupId: number;
+}

--- a/core/src/scrim/types/Scrim.ts
+++ b/core/src/scrim/types/Scrim.ts
@@ -65,6 +65,9 @@ export class Scrim implements IScrim {
     @Field(() => String, {nullable: true})
   submissionId?: string;
 
+    @Field(() => String, {nullable: true})
+  testRunId?: string;
+
     @Field(() => Date, {nullable: true})
   groupInviteOpensAt?: Date;
 

--- a/core/src/scrim/types/index.ts
+++ b/core/src/scrim/types/index.ts
@@ -3,6 +3,7 @@ import {ScrimMode, ScrimStatus} from "@sprocketbot/common";
 
 export * from "./CreateLFSScrimInput";
 export * from "./CreateScrimInput";
+export * from "./CreateTestScrimInput";
 export * from "./Scrim";
 export * from "./ScrimGame";
 export * from "./ScrimLobby";

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.spec.ts
@@ -4,6 +4,42 @@ import {ScrimMode, ScrimStatus} from "@sprocketbot/common";
 import {ScrimPostgresRepository} from "./scrim-postgres.repository";
 
 describe("ScrimPostgresRepository", () => {
+    it("creates an isolated in-progress test scrim with no public roster", async () => {
+        const client = {query: jest.fn().mockResolvedValue({rows: []})};
+        const transaction = jest.fn(async (cb: (value: typeof client) => Promise<unknown>) => cb(client));
+        const repo = new ScrimPostgresRepository({transaction} as unknown as PostgresService);
+        const testRunId = "00000000-0000-4000-8000-000000000002";
+
+        const scrim = await repo.createTestScrim({
+            authorId: 1,
+            organizationId: 2,
+            gameModeId: 3,
+            skillGroupId: 4,
+            testRunId,
+            settings: {
+                teamSize: 3,
+                teamCount: 2,
+                mode: ScrimMode.TEAMS,
+                competitive: false,
+                observable: false,
+                lfs: false,
+                checkinTimeout: 0,
+            },
+        });
+
+        expect(scrim).toMatchObject({
+            status: ScrimStatus.IN_PROGRESS,
+            testRunId,
+            submissionId: expect.stringMatching(/^scrim-test-/),
+            players: [],
+            games: [],
+        });
+        expect(client.query).toHaveBeenCalledWith(
+            expect.stringContaining("test_run_id"),
+            expect.arrayContaining([testRunId]),
+        );
+    });
+
     it("hydrates a scrim from typed Postgres relations", async () => {
         const query = jest.fn()
             .mockResolvedValueOnce({

--- a/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
+++ b/microservices/matchmaking-service/src/scrim/persistence/scrim-postgres.repository.ts
@@ -27,6 +27,7 @@ interface ScrimRow {
     game_mode_id: number;
     skill_group_id: number;
     submission_id?: string;
+    test_run_id?: string;
     timeout_job_id?: string;
     group_invite_opens_at?: Date;
     popped_at?: Date;
@@ -141,6 +142,27 @@ export class ScrimPostgresRepository {
             });
         }
 
+        await this.saveScrim(scrim);
+        return scrim;
+    }
+
+    async createTestScrim(options: Omit<CreateScrimOptions, "join"> & {testRunId: string;}): Promise<Scrim> {
+        const at = new Date();
+        const scrim: Scrim = {
+            id: v4(),
+            createdAt: at,
+            updatedAt: at,
+            status: ScrimStatus.IN_PROGRESS,
+            authorId: options.authorId,
+            organizationId: options.organizationId,
+            gameModeId: options.gameModeId,
+            skillGroupId: options.skillGroupId,
+            testRunId: options.testRunId,
+            submissionId: `scrim-test-${v4()}`,
+            players: [],
+            games: [],
+            settings: options.settings,
+        };
         await this.saveScrim(scrim);
         return scrim;
     }
@@ -433,6 +455,7 @@ export class ScrimPostgresRepository {
             gameModeId: row.game_mode_id,
             skillGroupId: row.skill_group_id,
             submissionId: row.submission_id ?? undefined,
+            testRunId: row.test_run_id ?? undefined,
             timeoutJobId: row.timeout_job_id ? Number(row.timeout_job_id) : undefined,
             groupInviteOpensAt: row.group_invite_opens_at ?? undefined,
             poppedAt: row.popped_at ?? undefined,
@@ -467,6 +490,7 @@ export class ScrimPostgresRepository {
                     game_mode_id,
                     skill_group_id,
                     submission_id,
+                    test_run_id,
                     timeout_job_id,
                     group_invite_opens_at,
                     popped_at,
@@ -480,7 +504,7 @@ export class ScrimPostgresRepository {
                     settings_lfs,
                     settings_checkin_timeout
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
                 ON CONFLICT (id) DO UPDATE SET
                     updated_at = EXCLUDED.updated_at,
                     status = EXCLUDED.status,
@@ -490,6 +514,7 @@ export class ScrimPostgresRepository {
                     game_mode_id = EXCLUDED.game_mode_id,
                     skill_group_id = EXCLUDED.skill_group_id,
                     submission_id = EXCLUDED.submission_id,
+                    test_run_id = EXCLUDED.test_run_id,
                     timeout_job_id = EXCLUDED.timeout_job_id,
                     group_invite_opens_at = EXCLUDED.group_invite_opens_at,
                     popped_at = EXCLUDED.popped_at,
@@ -514,6 +539,7 @@ export class ScrimPostgresRepository {
                 scrim.gameModeId,
                 scrim.skillGroupId,
                 scrim.submissionId ?? null,
+                scrim.testRunId ?? null,
                 scrim.timeoutJobId ? `${scrim.timeoutJobId}` : null,
                 scrim.groupInviteOpensAt ?? null,
                 scrim.poppedAt ?? null,
@@ -796,6 +822,7 @@ export class ScrimPostgresRepository {
             gameModeId: row.game_mode_id,
             skillGroupId: row.skill_group_id,
             submissionId: row.submission_id ?? undefined,
+            testRunId: row.test_run_id ?? undefined,
             timeoutJobId: row.timeout_job_id ? Number(row.timeout_job_id) : undefined,
             groupInviteOpensAt: row.group_invite_opens_at ?? undefined,
             poppedAt: row.popped_at ?? undefined,

--- a/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim-crud/scrim-crud.service.ts
@@ -58,7 +58,15 @@ export class ScrimCrudService {
         );
     }
 
+    async createTestScrim(options: Omit<CreateScrimOptions, "join"> & {testRunId: string;}): Promise<Scrim> {
+        return this.repository.createTestScrim(options);
+    }
+
     async updateLFSScrim(scrim: Scrim): Promise<void> {
+        await this.repository.saveScrim(scrim);
+    }
+
+    async updateTestScrim(scrim: Scrim): Promise<void> {
         await this.repository.saveScrim(scrim);
     }
 

--- a/microservices/matchmaking-service/src/scrim/scrim.controller.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.controller.ts
@@ -37,6 +37,18 @@ export class ScrimController {
         return this.scrimService.updateLFSScrimPlayers(data);
     }
 
+    @MessagePattern(MatchmakingEndpoint.CreateTestScrim)
+    async createTestScrim(@Payload() payload: unknown): Promise<Scrim> {
+        const data = MatchmakingSchemas.CreateTestScrim.input.parse(payload);
+        return this.scrimService.createTestScrim(data);
+    }
+
+    @MessagePattern(MatchmakingEndpoint.UpdateTestScrimPlayers)
+    async updateTestScrimPlayers(@Payload() payload: unknown): Promise<boolean> {
+        const data = MatchmakingSchemas.UpdateTestScrimPlayers.input.parse(payload);
+        return this.scrimService.updateTestScrimPlayers(data);
+    }
+
     @MessagePattern(MatchmakingEndpoint.GetAllScrims)
     async getAllScrims(@Payload() payload: unknown): Promise<Scrim[]> {
         const data = MatchmakingSchemas.GetAllScrims.input.parse(payload);

--- a/microservices/matchmaking-service/src/scrim/scrim.service.ts
+++ b/microservices/matchmaking-service/src/scrim/scrim.service.ts
@@ -7,6 +7,7 @@ import type {
     Scrim,
     ScrimPlayer,
     UpdateLFSScrimPlayersRequest,
+    UpdateTestScrimPlayersRequest,
 } from "@sprocketbot/common";
 import {
     AnalyticsEndpoint,
@@ -152,6 +153,12 @@ export class ScrimService {
         return scrim;
     }
 
+    async createTestScrim(options: CreateScrimOptions & {testRunId: string;}): Promise<Scrim> {
+        const scrim = await this.scrimCrudService.createTestScrim(options);
+        await this.eventsService.publish(EventTopic.ScrimCreated, scrim, scrim.id);
+        return scrim;
+    }
+
     async updateLFSScrimPlayers({
         scrimId,
         players,
@@ -171,6 +178,18 @@ export class ScrimService {
             scrim.games?.push(game);
         }
         await this.scrimCrudService.updateLFSScrim(scrim);
+        return true;
+    }
+
+    async updateTestScrimPlayers({
+        scrimId, testRunId, players, games,
+    }: UpdateTestScrimPlayersRequest): Promise<boolean> {
+        const rawScrim = await this.scrimCrudService.getScrim(scrimId);
+        if (!rawScrim || rawScrim.testRunId !== testRunId) return false;
+        rawScrim.players = players;
+        rawScrim.games = games;
+        await this.scrimCrudService.updateTestScrim(rawScrim);
+        await this.publishScrimUpdate(scrimId);
         return true;
     }
 

--- a/microservices/submission-service/src/replay-submission/replay-submission.service.ts
+++ b/microservices/submission-service/src/replay-submission/replay-submission.service.ts
@@ -8,9 +8,12 @@ import {
     CeleryService,
     EventsService,
     EventTopic,
+    MatchmakingEndpoint,
+    MatchmakingService,
     ProgressStatus,
     REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID,
     ReplaySubmissionStatus,
+    ResponseStatus,
     Task,
 } from "@sprocketbot/common";
 import {v4} from "uuid";
@@ -34,6 +37,7 @@ export class ReplaySubmissionService {
         private readonly replayValidationService: ReplayValidationService,
         private readonly ratificationService: ReplaySubmissionRatificationService,
         private readonly statsConverterService: StatsConverterService,
+        private readonly matchmakingService: MatchmakingService,
     ) {}
 
     /**
@@ -211,5 +215,18 @@ export class ReplaySubmissionService {
             submissionId: submissionId,
             resultPaths: refreshedSubmission.items.map(item => item.outputPath!),
         });
+
+        if (submission.type === "SCRIM") {
+            const scrimResponse = await this.matchmakingService.send(
+                MatchmakingEndpoint.GetScrimBySubmissionId,
+                submissionId,
+            );
+            if (scrimResponse.status === ResponseStatus.SUCCESS && scrimResponse.data?.testRunId) {
+                await this.ratificationService.ratifyScrim(
+                    REPLAY_SUBMISSION_REJECTION_SYSTEM_PLAYER_ID,
+                    submissionId,
+                );
+            }
+        }
     }
 }

--- a/microservices/submission-service/src/replay-validation/replay-validation.service.ts
+++ b/microservices/submission-service/src/replay-validation/replay-validation.service.ts
@@ -308,7 +308,69 @@ export class ReplayValidationService {
         if (scrimResponse.status === ResponseStatus.ERROR) throw scrimResponse.error;
         if (!scrimResponse.data) throw new Error("Scrim not found");
 
-        const scrim = scrimResponse.data;
+        let scrim = scrimResponse.data;
+
+        if (scrim.testRunId) {
+            if (submission.items.length !== 1) {
+                return {valid: false, errors: [ {error: "Test scrims accept exactly one replay file."} ] };
+            }
+            const parsed = await this.getStats(submission.items[0].outputPath!);
+            const replayPlayers = [parsed.blue, parsed.orange].flatMap(team => team.players.map(player => {
+                const platform = player.id.platform.toUpperCase();
+                const platformAccountId = player.id.id;
+                const {name} = player;
+                return {
+                    platform,
+                    platformAccountId,
+                    name,
+                };
+            }));
+            const provisioned = await this.coreService.send(CoreEndpoint.ProvisionTestReplayPlayers, {
+                testRunId: scrim.testRunId,
+                organizationId: scrim.organizationId,
+                skillGroupId: scrim.skillGroupId,
+                players: replayPlayers,
+            });
+            if (provisioned.status === ResponseStatus.ERROR) throw provisioned.error;
+            const byAccount = new Map(provisioned.data.map(player => [`${player.platform.toUpperCase()}:${player.platformAccountId}`, player]));
+            const now = new Date();
+            const leaveAt = new Date(now.getTime() + (30 * 60 * 1000));
+            const players = provisioned.data.map(player => {
+                const id = player.userId;
+                const {name} = player;
+                const joinedAt = now;
+                const checkedIn = true;
+                return {
+                    id,
+                    name,
+                    joinedAt,
+                    leaveAt,
+                    checkedIn,
+                };
+            });
+            const game = {
+                teams: [parsed.blue, parsed.orange].map(team => ({
+                    players: team.players.map(player => {
+                        const mapped = byAccount.get(`${player.id.platform.toUpperCase()}:${player.id.id}`);
+                        if (!mapped) throw new Error(`Missing provisioned test identity for ${player.id.platform}:${player.id.id}`);
+                        return players.find(candidate => candidate.id === mapped.userId)!;
+                    }),
+                })),
+            };
+            const games = [game];
+            const testScrim = {
+                ...scrim,
+                players,
+                games,
+            };
+            scrim = testScrim;
+            const scrimId = testScrim.id;
+            const testRunId = testScrim.testRunId!;
+            const updated = await this.matchmakingService.send(MatchmakingEndpoint.UpdateTestScrimPlayers, {
+                scrimId, testRunId, players, games,
+            });
+            if (updated.status === ResponseStatus.ERROR || !updated.data) throw updated.status === ResponseStatus.ERROR ? updated.error : new Error("Unable to update test scrim roster");
+        }
 
         // ========================================
         // Validate number of games


### PR DESCRIPTION
## Summary

Maintainers and support operators can now create an isolated end-to-end test scrim from the admin panel and upload exactly one fresh Rocket League replay. The run uses the real upload, parser, validation, ratification, and finalization pipeline.

## What changed

- Added an admin-only `createTestScrim` mutation and admin-panel flow.
- Added persisted test-run metadata to scrims and a migration for it.
- Added one-replay test scrim roster/game reconciliation after parsing.
- Added test-scoped synthetic Sprocket/MLE identities for replay participants that are not already represented in production data.
- Added test identity mapping during Sprocket and legacy MLE finalization.
- Auto-ratifies only submissions associated with a persisted test run.
- Keeps test scrims out of the normal public scrim list.
- Forces test runs to be noncompetitive, preventing eligibility and Elo side effects.
- Added focused repository regression coverage.

## Validation

Passed:

- `npm run build --workspace=common`
- `npm run build --workspace=core`
- `npm run build --workspace=microservices/matchmaking-service`
- `npm run build --workspace=microservices/submission-service`
- `npm run build --workspace=clients/web`
- `npx tsc migrations/*.ts --outDir dist/migrations --module commonjs --esModuleInterop --skipLibCheck` from `core/`
- focused ESLint checks for changed TypeScript paths
- `git diff --check`
- `npm test --workspace=microservices/matchmaking-service -- --runInBand src/scrim/persistence/scrim-postgres.repository.spec.ts`

The hosted production proof has not been run from this checkout because it requires operator-provided production credentials and a fresh replay fixture. That should be the first follow-up check after deployment: create a test scrim, upload one real replay, and verify parser completion, automatic ratification, finalization, and database rows without real-player or competitive side effects.
