### PR TITLE
fix(scrims): resolve user recognition issues causing broken join/create

### DIFF
--- a/clients/web/src/routes/auth/chatwoot.ts
+++ b/clients/web/src/routes/auth/chatwoot.ts
@@ -5,8 +5,24 @@ import {sha256} from "js-sha256";
 export const GET: RequestHandler = async ({locals}) => {
     const {user} = locals;
 
+    // Defensive check: return early if user or userId is missing
+    if (!user?.userId) {
+        return {
+            status: 401,
+            body: {error: "Not authenticated"},
+        };
+    }
+
     const identifier = user.userId.toString();
     const key = config.server.chatwoot.hmacKey;
+
+    // If no HMAC key is configured, return an error instead of failing silently
+    if (!key) {
+        return {
+            status: 500,
+            body: {error: "Chatwoot HMAC key not configured"},
+        };
+    }
 
     const hash = sha256.hmac(key, identifier);
 

--- a/clients/web/src/routes/scrims/index.svelte
+++ b/clients/web/src/routes/scrims/index.svelte
@@ -23,7 +23,16 @@
     $: scrimsAreDisabled = $scrimsDisabled.data?.getScrimsDisabled;
 
     let currentUserFranchises: string[] | undefined;
-    $: currentUserFranchises = $currentUser.data?.me?.members?.flatMap(m => m.players.flatMap(p => p.franchiseName as string) as string[]);
+    $: {
+        const franchises = $currentUser.data?.me?.members?.flatMap(m => m.players.flatMap(p => p.franchiseName as string) as string[]);
+        currentUserFranchises = franchises;
+        // Debug logging for troubleshooting
+        if (typeof window !== "undefined") {
+            console.log("[Scrims] Current User Data:", $currentUser.data);
+            console.log("[Scrims] Franchise Names:", franchises);
+            console.log("[Scrims] Current User Error:", $currentUser.error);
+        }
+    }
 
     let scrimPoints: number | null | undefined;
     $: scrimPoints = $currentUser.data?.me?.members?.[0]?.players?.[0]?.scrimPoints;

--- a/core/src/franchise/player/player.resolver.ts
+++ b/core/src/franchise/player/player.resolver.ts
@@ -101,36 +101,46 @@ export class PlayerResolver {
   }
 
   @ResolveField()
-  async franchiseName(@Root() player: Player): Promise<string> {
-    if (player.franchiseName) return player.franchiseName;
+  async franchiseName(@Root() player: Player): Promise<string | null> {
+    try {
+      if (player.franchiseName) return player.franchiseName;
 
-    if (!player.member)
-      player.member = await this.popService.populateOneOrFail(Player, player, 'member');
-    if (!player.member.user)
-      player.member.user = await this.popService.populateOneOrFail(Member, player.member, 'user');
+      if (!player.member)
+        player.member = await this.popService.populateOneOrFail(Player, player, 'member');
+      if (!player.member.user)
+        player.member.user = await this.popService.populateOneOrFail(Member, player.member, 'user');
 
-    const franchiseResult = await this.franchiseService.getPlayerFranchisesByUserId(
-      player.member.user.id,
-    );
-    // Because we are using MLEDB right now; assume that we only have one
-    return franchiseResult[0].name;
+      const franchiseResult = await this.franchiseService.getPlayerFranchisesByUserId(
+        player.member.user.id,
+      );
+      // Because we are using MLEDB right now; assume that we only have one
+      return franchiseResult[0]?.name ?? null;
+    } catch (error) {
+      this.logger.warn(`Failed to resolve franchiseName for player ${player.id}: ${error}`);
+      return null;
+    }
   }
 
   @ResolveField()
   async franchisePositions(@Root() player: Player): Promise<string[]> {
-    if (player.franchisePositions) return player.franchisePositions;
+    try {
+      if (player.franchisePositions) return player.franchisePositions;
 
-    if (!player.member) {
-      player.member = await this.popService.populateOneOrFail(Player, player, 'member');
+      if (!player.member) {
+        player.member = await this.popService.populateOneOrFail(Player, player, 'member');
+      }
+      if (!player.member.user)
+        player.member.user = await this.popService.populateOneOrFail(Member, player.member, 'user');
+
+      const franchiseResult = await this.franchiseService.getPlayerFranchisesByUserId(
+        player.member.user.id,
+      );
+      // Because we are using MLEDB right now; assume that we only have one
+      return franchiseResult[0]?.staffPositions.map(sp => sp.name) ?? [];
+    } catch (error) {
+      this.logger.warn(`Failed to resolve franchisePositions for player ${player.id}: ${error}`);
+      return [];
     }
-    if (!player.member.user)
-      player.member.user = await this.popService.populateOneOrFail(Member, player.member, 'user');
-
-    const franchiseResult = await this.franchiseService.getPlayerFranchisesByUserId(
-      player.member.user.id,
-    );
-    // Because we are using MLEDB right now; assume that we only have one
-    return franchiseResult[0].staffPositions.map(sp => sp.name);
   }
 
   @ResolveField()


### PR DESCRIPTION
## Summary

Fixes issues where users logged in properly but could not join/create scrims - the buttons were greyed out or form data never loaded.

### Root Cause

The `franchiseName` and `franchisePositions` GraphQL resolvers were throwing errors when they couldn't resolve the franchise, causing the entire `currentUser` query to fail silently. This meant:

1. Frontend never received `franchiseName` data
2. Users saw empty AvailableScrimsView instead of Former Player lock screen
3. mathews175 (Former Player on team "FP") saw empty modal instead of "Former Players Cannot Scrim"

### Changes

1. **`clients/web/src/routes/auth/chatwoot.ts`** - Add defensive checks for missing userId and hmacKey config to prevent TypeError

2. **`core/src/franchise/player/player.resolver.ts`** - Add try/catch to `franchiseName` and `franchisePositions` resolvers:
   - Return `null`/`[]` on error instead of throwing
   - Log warnings for debugging failed resolutions
   - Allow partial query success even when franchise lookup fails

3. **`clients/web/src/routes/scrims/index.svelte`** - Add frontend debug logging to help diagnose user recognition issues in production

### Testing

- Users should now see the Former Player lock screen if their franchise is "FP"
- Active players (ChadGPT, Dynamic, RubberDuck) should be able to join/create scrims
- Check browser console for `[Scrims]` debug logs showing currentUser data and franchise names