### PR TITLE
feat(infra): switch from subdomain to path-based API routing

### DIFF
--- a/infra/LOCAL_ACCESS.md
+++ b/infra/LOCAL_ACCESS.md
@@ -26,14 +26,13 @@ sudo nano /etc/hosts
 
 ```
 127.0.0.1 sprocket.spr.ocket.cloud
-127.0.0.1 api.sprocket.spr.ocket.cloud
 127.0.0.1 image-generation.sprocket.spr.ocket.cloud
 ```
 
 Or run this one-liner:
 
 ```bash
-echo '127.0.0.1 sprocket.spr.ocket.cloud api.sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud' | sudo tee -a /etc/hosts
+echo '127.0.0.1 sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud' | sudo tee -a /etc/hosts
 ```
 
 ### Step 3: Access Your Services
@@ -41,7 +40,7 @@ echo '127.0.0.1 sprocket.spr.ocket.cloud api.sprocket.spr.ocket.cloud image-gene
 Once /etc/hosts is configured:
 
 - **Web UI**: https://sprocket.spr.ocket.cloud
-- **API**: https://api.sprocket.spr.ocket.cloud
+- **API**: https://sprocket.spr.ocket.cloud/graphql (or /login, /authentication/*)
 - **Image Generation**: https://image-generation.sprocket.spr.ocket.cloud
 
 **Note**: Your browser will show a certificate warning because you're using Traefik's default self-signed certificate (Let's Encrypt can't issue certs for localhost). This is normal for local development. Click "Advanced" → "Accept the Risk and Continue" (or similar in your browser).

--- a/infra/README.md
+++ b/infra/README.md
@@ -108,9 +108,9 @@ Canonical mapping (Pulumi platform stack names, subdomains, and public hostnames
 
 | Pulumi `platform` stack | Config `platform:subdomain` | Example Traefik hosts |
 | --- | --- | --- |
-| `prod` | `main` | `sprocket.mlesports.gg`, `api.sprocket.mlesports.gg`, `rabbitMq.sprocket.mlesports.gg` |
-| `dev` | `dev` | `dev.sprocket.mlesports.gg`, `api.dev.sprocket.mlesports.gg`, … |
-| `staging` | `staging` | `staging.sprocket.mlesports.gg`, `api.staging.sprocket.mlesports.gg`, … |
+| `prod` | `main` | `sprocket.mlesports.gg` (API at /graphql, /login, /authentication/*), `rabbitMq.sprocket.mlesports.gg` |
+| `dev` | `dev` | `dev.sprocket.mlesports.gg` (API at /graphql, /login, /authentication/*), … |
+| `staging` | `staging` | `staging.sprocket.mlesports.gg` (API at /graphql, /login, /authentication/*), … |
 
 Hostnames are derived in `infra/platform` from `platform:hostname` and `platform:subdomain` (`global/helpers/buildHost.ts` and `Platform.ts`). The dev lane now uses dedicated `layer_1/dev`, `layer_2/dev`, and `platform/dev` stacks on the foundation-managed `dev-staging` node.
 ## Lane ↔ Pulumi stack map (hosted)

--- a/infra/platform/Pulumi.dev.template.yaml
+++ b/infra/platform/Pulumi.dev.template.yaml
@@ -5,7 +5,7 @@
 # 2. Merge this file into `Pulumi.dev.yaml` or copy values with `pulumi config set`.
 # 3. Set every **secret** via `pulumi config set --secret <key> <value>` — never commit real secrets.
 # 4. Point `platform:hostname` at the dev web apex so Traefik rules match harness URLs
-#    (e.g. dev.sprocket.mlesports.gg → API at api.dev.sprocket.mlesports.gg per `buildHost`).
+#    (e.g. dev.sprocket.mlesports.gg → API at /graphql, /login, /authentication/* via path-based routing).
 # 5. Image tags: prefer immutable `sha-<full-git-sha>` once CI publishes them (#670); `dev` is a moving alias only.
 #
 # Isolation: dedicated Pulumi stack on the pre-prod Swarm, unique subdomain, DB, Redis prefix, RabbitMQ vhost,

--- a/infra/platform/src/Platform.ts
+++ b/infra/platform/src/Platform.ts
@@ -122,7 +122,8 @@ export class Platform extends pulumi.ComponentResource {
         /////////////////
         // Create Clients / Core
         /////////////////
-        this.apiUrl = buildHost("api", HOSTNAME)
+        // API URL now uses same host as web - routing handled by path prefix in Traefik
+        this.apiUrl = buildHost(HOSTNAME)
         this.webUrl = buildHost(HOSTNAME)
         this.chatwootUrl = buildHost(CHATWOOT_SUBDOMAIN, HOSTNAME)
         this.igUrl = buildHost("image-generation", HOSTNAME)
@@ -136,9 +137,11 @@ export class Platform extends pulumi.ComponentResource {
             .join(" || ")
         const fullIpRule = ipRule ? ` || ${ipRule}` : ""
 
+        // Core service: path-based routing for API endpoints
+        // Matches /graphql, /login, /authentication/*, and other API paths
         const coreLabels = new TraefikLabels(`sprocket-core-${this.environmentSubdomain}`)
             .tls("lets-encrypt-tls")
-            .rule(`Host(\`${this.apiUrl}\`)`)
+            .rule(`PathPrefix(\`/graphql\`) || PathPrefix(\`/login\`) || PathPrefix(\`/authentication\`) || PathPrefix(\`/api\`)`)
             .targetPort(3001)
         const webLabels = new TraefikLabels(`sprocket-web-${this.environmentSubdomain}`)
             .tls("lets-encrypt-tls")

--- a/infra/quick-test.sh
+++ b/infra/quick-test.sh
@@ -42,7 +42,7 @@ if [ "$RESOLVED_IP" = "127.0.0.1" ] || [ "$RESOLVED_IP" = "::1" ]; then
 elif [ -n "$RESOLVED_IP" ]; then
     echo -e "${YELLOW}Resolves to $RESOLVED_IP (NOT localhost)${NC}"
     echo -e "${YELLOW}You need to add to /etc/hosts:${NC}"
-    echo -e "${YELLOW}  127.0.0.1 sprocket.spr.ocket.cloud api.sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud${NC}"
+    echo -e "${YELLOW}  127.0.0.1 sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud${NC}"
 else
     echo -e "${RED}Does not resolve${NC}"
 fi
@@ -76,7 +76,7 @@ if [ "$RESOLVED_IP" != "127.0.0.1" ] && [ "$RESOLVED_IP" != "::1" ]; then
     echo -e "${YELLOW}Action needed:${NC} Add domains to /etc/hosts"
     echo ""
     echo "Run this command:"
-    echo -e "${GREEN}echo '127.0.0.1 sprocket.spr.ocket.cloud api.sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud' | sudo tee -a /etc/hosts${NC}"
+    echo -e "${GREEN}echo '127.0.0.1 sprocket.spr.ocket.cloud image-generation.sprocket.spr.ocket.cloud' | sudo tee -a /etc/hosts${NC}"
     echo ""
     echo "Then test with:"
     echo "  curl -k https://sprocket.spr.ocket.cloud"

--- a/infra/stack-map.yaml
+++ b/infra/stack-map.yaml
@@ -13,7 +13,7 @@ prod:
   platform_subdomain: main
   traefik_hostnames:
     web: sprocket.mlesports.gg
-    api: api.sprocket.mlesports.gg
+    api: sprocket.mlesports.gg  # Path-based: /graphql, /login, /authentication/*, /api/*
     image_generation: image-generation.sprocket.mlesports.gg
     rabbitmq_amqp: rabbitMq.sprocket.mlesports.gg
     rabbitmq_management: management.rabbitMq.sprocket.mlesports.gg
@@ -23,7 +23,7 @@ dev:
   platform_subdomain: dev
   traefik_hostnames:
     web: dev.sprocket.mlesports.gg
-    api: api.dev.sprocket.mlesports.gg
+    api: dev.sprocket.mlesports.gg  # Path-based: /graphql, /login, /authentication/*, /api/*
     image_generation: image-generation.dev.sprocket.mlesports.gg
     rabbitmq_amqp: rabbitMq.dev.sprocket.mlesports.gg
     rabbitmq_management: management.rabbitMq.dev.sprocket.mlesports.gg
@@ -36,7 +36,7 @@ staging:
     - Align DNS in the provider with platform:hostname (staging.sprocket.mlesports.gg below); adjust if your zone uses stg.* instead.
   traefik_hostnames:
     web: staging.sprocket.mlesports.gg
-    api: api.staging.sprocket.mlesports.gg
+    api: staging.sprocket.mlesports.gg  # Path-based: /graphql, /login, /authentication/*, /api/*
     image_generation: image-generation.staging.sprocket.mlesports.gg
     rabbitmq_amqp: rabbitMq.staging.sprocket.mlesports.gg
     rabbitmq_management: management.rabbitMq.staging.sprocket.mlesports.gg


### PR DESCRIPTION
## Summary

Switches API routing from a separate subdomain () to path-based routing on the same origin (). This eliminates CORS issues since browser sees requests to the same origin.

## Changes

- **Platform.ts**: Changed  to use same host as , updated Traefik rule from  to  
- **stack-map.yaml**: Updated API hostname entries
- **LOCAL_ACCESS.md, quick-test.sh**: Removed  from /etc/hosts instructions
- **README.md, Pulumi.dev.template.yaml**: Updated docs

## How it works

| Path | Service | Port |
|------|---------|------|
|  | Web UI | 3000 |
|  | Core API | 3001 |
|  | Core Auth | 3001 |
|  | Core Auth | 3001 |

## Testing

After deployment, verify:
- GraphQL playground accessible at 
- Login flow works at 
- Frontend can make API requests without CORS errors